### PR TITLE
DOC: fix copy button for bash prompt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
 
 # Do not copy prompot output
-copybutton_prompt_text = r'>>> |\.\.\. '
+copybutton_prompt_text = r'>>> |\.\.\. |$ '
 copybutton_prompt_is_regexp = True
 
 # Mapping to external documentation


### PR DESCRIPTION
In the [installation documentation](https://audeering.github.io/audformat/install.html) we use the `$` sign to highlight bash commands. This shouldn't be copied if you click on the button.