### PR TITLE
DOC: improve summary and fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,19 +6,20 @@ audformat
 
 Specification and reference implementation of **audformat**.
 
-audformat is intended to store media data,
+audformat stores media data,
 such as audio or video,
 together with corresponding annotations
 in a pre-defined way.
-An audformat database is a folder that contains
-media files together with a header YAML file
-and one or several files storing the annotations.
+This makes it easy to combine or replace databases
+in machine learning projects.
 
-An audformat database is represented as a
-``audformat.Database`` object and can be loaded with
-``audformat.Database.load()``
-or written to disk with
-``audformat.Database.save()``.
+An audformat database is a folder
+that contains media files
+together with a header YAML file
+and one or several files storing the annotations.
+The database is represented as an ``audformat.Database`` object
+and can be loaded with ``audformat.Database.load()``
+or written to disk with ``audformat.Database.save()``.
 
 Have a look at the installation_ and usage_ instructions
 and the `format specifications`_ as a starting point.

--- a/docs/data-introduction.rst
+++ b/docs/data-introduction.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-The :ref:`audformat <data-format:Database>` was created
+:ref:`audformat <data-format:Database>` was created
 to handle all databases inside audEERING
 in an unified way to make them easily accessible.
 


### PR DESCRIPTION
This improves the summary text in the README and fixes a typo in the introduction to the format specification chapter.