### PR TITLE
DOC: add examples for index related functions

### DIFF
--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -66,6 +66,12 @@ def index_type(
         ValueError: if not conform to
             :ref:`table specifications <data-tables:Tables>`
 
+    Example:
+        >>> index_type(filewise_index())
+        'filewise'
+        >>> index_type(segmented_index())
+        'segmented'
+
     """
     if isinstance(obj, (pd.Series, pd.DataFrame)):
         obj = obj.index

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -39,6 +39,10 @@ def filewise_index(
     Returns:
         filewise index
 
+    Example:
+        >>> filewise_index(['a.wav', 'b.wav'])
+        Index(['a.wav', 'b.wav'], dtype='object', name='file')
+
     """
     if files is None:
         files = []

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -113,6 +113,27 @@ def segmented_index(
     Raises:
         ValueError: if ``files``, ``start`` and ``ends`` differ in size
 
+    Example:
+        >>> segmented_index('a.wav', '0s', '1s')
+        MultiIndex([('a.wav', '0 days', '0 days 00:00:01')],
+                   names=['file', 'start', 'end'])
+        >>> segmented_index(['a.wav', 'b.wav'])
+        MultiIndex([('a.wav', '0 days', NaT),
+                    ('b.wav', '0 days', NaT)],
+                   names=['file', 'start', 'end'])
+        >>> segmented_index(['a.wav', 'b.wav'], [None, '1s'], ['1s', None])
+        MultiIndex([('a.wav',               NaT, '0 days 00:00:01'),
+                    ('b.wav', '0 days 00:00:01',               NaT)],
+                   names=['file', 'start', 'end'])
+        >>> segmented_index(
+        ...     files=['a.wav', 'a.wav'],
+        ...     starts=[f'{t}s' for t in (0, 1)],
+        ...     ends=pd.to_timedelta([1, 2], unit='s'),
+        ... )
+        MultiIndex([('a.wav', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('a.wav', '0 days 00:00:01', '0 days 00:00:02')],
+                   names=['file', 'start', 'end'])
+
     """
     files = to_array(files)
     starts = to_array(starts)


### PR DESCRIPTION
This adds the following examples to the docstring of index related functions:

### filewise_index

![image](https://user-images.githubusercontent.com/173624/103763107-a6562500-5019-11eb-93ce-ca8a0287a512.png)

### segmented_index

![image](https://user-images.githubusercontent.com/173624/103889764-3f06a680-50e7-11eb-9d5d-9dd3dc1749dc.png)


### index_type

![image](https://user-images.githubusercontent.com/173624/103763302-e6b5a300-5019-11eb-8159-f3810a629d98.png)
