### PR TITLE
Parallel processing for Database methods drop_, map_, pick_files() and save()

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,18 +9,30 @@ import audformat.testing
 
 
 @pytest.mark.parametrize(
-    'files',
+    'files, num_workers',
     [
-        pytest.DB.files,
-        pytest.DB.files[:2],
-        pytest.DB.files[0],
-        lambda x: '1' in x,
+        (
+            pytest.DB.files,
+            1,
+        ),
+        (
+            pytest.DB.files[:2],
+            1,
+        ),
+        (
+            pytest.DB.files[0],
+            4,
+        ),
+        (
+            lambda x: '1' in x,
+            None,
+        ),
     ]
 )
-def test_drop_files(files):
+def test_drop_files(files, num_workers):
 
     db = audformat.testing.create_db()
-    db.drop_files(files)
+    db.drop_files(files, num_workers=num_workers)
     if callable(files):
         files = db.files.to_series().apply(files)
     else:
@@ -30,18 +42,30 @@ def test_drop_files(files):
 
 
 @pytest.mark.parametrize(
-    'files',
+    'files, num_workers',
     [
-        pytest.DB.files,
-        pytest.DB.files[:2],
-        pytest.DB.files[0],
-        lambda x: '1' in x,
+        (
+            pytest.DB.files,
+            1,
+        ),
+        (
+            pytest.DB.files[:2],
+            1,
+        ),
+        (
+            pytest.DB.files[0],
+            4,
+        ),
+        (
+            lambda x: '1' in x,
+            None,
+        ),
     ]
 )
-def test_pick_files(files):
+def test_pick_files(files, num_workers):
 
     db = audformat.testing.create_db()
-    db.pick_files(files)
+    db.pick_files(files, num_workers=num_workers)
     if callable(files):
         files = db.files[db.files.to_series().apply(files)]
     else:
@@ -68,12 +92,20 @@ def test_drop_and_pick_tables():
     assert 'segments' not in db
 
 
-def test_map_files():
+@pytest.mark.parametrize(
+    'num_workers',
+    [
+        1,
+        4,
+        None,
+    ]
+)
+def test_map_files(num_workers):
 
     db = audformat.testing.create_db()
 
     files = sorted(db.files)
-    db.map_files(lambda x: x.upper())
+    db.map_files(lambda x: x.upper(), num_workers=num_workers)
     assert [x.upper() for x in files] == sorted(db.files)
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -110,32 +110,45 @@ def test_map_files(num_workers):
 
 
 @pytest.mark.parametrize(
-    'db, storage_format',
+    'db, storage_format, num_workers',
     [
         (
             audformat.testing.create_db(minimal=True),
             audformat.define.TableStorageFormat.CSV,
+            1,
         ),
         (
             audformat.testing.create_db(minimal=True),
             audformat.define.TableStorageFormat.PICKLE,
+            1,
         ),
         (
             audformat.testing.create_db(),
             audformat.define.TableStorageFormat.CSV,
+            4,
         ),
         (
             audformat.testing.create_db(),
             audformat.define.TableStorageFormat.PICKLE,
+            None,
         ),
     ],
 )
-def test_save_and_load(tmpdir, db, storage_format):
+def test_save_and_load(tmpdir, db, storage_format, num_workers):
 
-    db.save(tmpdir, storage_format=storage_format)
+    db.save(
+        tmpdir,
+        storage_format=storage_format,
+        num_workers=num_workers,
+    )
 
     db_load = audformat.Database.load(tmpdir)
-    db_load.save(tmpdir, name='db-2', storage_format=storage_format)
+    db_load.save(
+        tmpdir,
+        name='db-2',
+        storage_format=storage_format,
+        num_workers=num_workers,
+    )
 
     assert filecmp.cmp(os.path.join(tmpdir, 'db.yaml'),
                        os.path.join(tmpdir, 'db-2.yaml'))


### PR DESCRIPTION
Closes #11.

This uses `audeer.run_tasks()` for `Database.drop_files()`, `Database.map_files()`, `Database.pick_files()`.

Haven't tested yet if you really see a progress bar, but I don't see a reason why it shouldn't work.