### PR TITLE
Allow for int, str, float in segmented_index()

### DIFF
--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -26,6 +26,14 @@ def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
     return value
 
 
+def to_timedelta(times):
+    r"""Convert time value to pd.TimeDelta."""
+    try:
+        return pd.to_timedelta(times, unit='s')
+    except ValueError:  # catches values like '1s'
+        return pd.to_timedelta(times)
+
+
 def filewise_index(
         files: Files = None,
 ) -> pd.Index:
@@ -159,14 +167,8 @@ def segmented_index(
             "'starts', and 'ends' differ in size",
         )
 
-    def convert_to_timedelta(times):
-        try:
-            return pd.to_timedelta(times, unit='s')
-        except ValueError:  # catches values like '1s'
-            return pd.to_timedelta(times)
-
     return pd.MultiIndex.from_arrays(
-        [files, convert_to_timedelta(starts), convert_to_timedelta(ends)],
+        [files, to_timedelta(starts), to_timedelta(ends)],
         names=[
             define.IndexField.FILE,
             define.IndexField.START,

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -27,7 +27,7 @@ def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
 
 
 def to_timedelta(times):
-    r"""Convert time value to pd.TimeDelta."""
+    r"""Convert time value to pd.Timedelta."""
     try:
         return pd.to_timedelta(times, unit='s')
     except ValueError:  # catches values like '1s'

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -112,8 +112,10 @@ def segmented_index(
 
     Args:
         files: set confidence values only on a sub-set of files
-        starts: segment start positions
-        ends: segment end positions
+        starts: segment start positions.
+            Time values given as float or integers are treated as seconds
+        ends: segment end positions.
+            Time values given as float or integers are treated as seconds
 
     Returns:
         segmented index

--- a/audformat/core/typing.py
+++ b/audformat/core/typing.py
@@ -9,8 +9,12 @@ Files = typing.Union[
     str, typing.Sequence[str], pd.Index, pd.Series,
 ]
 Timestamps = typing.Union[
-    pd.Timedelta, typing.Sequence[typing.Union[str, pd.Timedelta]],
-    pd.Index, pd.Series,
+    float,
+    int,
+    pd.Timedelta,
+    typing.Sequence[typing.Union[float, int, str, pd.Timedelta]],
+    pd.Index,
+    pd.Series,
 ]
 Values = typing.Union[
     int, float, str, pd.Timedelta,

--- a/audformat/core/typing.py
+++ b/audformat/core/typing.py
@@ -11,6 +11,7 @@ Files = typing.Union[
 Timestamps = typing.Union[
     float,
     int,
+    str,
     pd.Timedelta,
     typing.Sequence[typing.Union[float, int, str, pd.Timedelta]],
     pd.Index,


### PR DESCRIPTION
Closes #12.

This adds `float`, `int`, `str` to the allowed types in `audformat.segmented_index()`:

![image](https://user-images.githubusercontent.com/173624/103896616-89d9eb80-50f2-11eb-857f-e183905f1ed5.png)


Looks a little bit messy, but we are quite flexible with seems to me a good thing for this function.

Both are now interpreted as seconds which you expect as the default behavior anyway.