### PR TITLE
Implement __eq__

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -222,3 +222,13 @@ class Column(HeaderBase):
                     'Cannot set values of a filewise column '
                     'using a segmented index.'
                 )
+
+    def __eq__(
+            self,
+            other: 'Column',
+    ) -> bool:
+        if self.dump() != other.dump():
+            return False
+        if self._table is not None and other._table is not None:
+            return self.get().equals(other.get())
+        return self._table is None and other._table is None

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -230,5 +230,5 @@ class Column(HeaderBase):
         if self.dump() != other.dump():
             return False
         if self._table is not None and other._table is not None:
-            return self.get().equals(other.get())
+            return self._table.df[self._id].equals(other._table.df[other._id])
         return self._table is None and other._table is None

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -212,6 +212,9 @@ class HeaderBase:
     ) -> bool:
         return self.dump() == other.dump()
 
+    def __hash__(self) -> int:
+        return hash(self.dump())
+
     def __repr__(self):
         s = self.dump()
         return s[:-1] if s.endswith('\n') else s

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -206,6 +206,12 @@ class HeaderBase:
             indent=indent, allow_unicode=True,
         )
 
+    def __eq__(
+            self,
+            other: 'HeaderBase',
+    ) -> bool:
+        return self.dump() == other.dump()
+
     def __repr__(self):
         s = self.dump()
         return s[:-1] if s.endswith('\n') else s
@@ -214,7 +220,7 @@ class HeaderBase:
         return repr(self)
 
 
-class DefineBase(object):
+class DefineBase:
 
     @classmethod
     def assert_has_value(cls, value):

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -390,6 +390,17 @@ class Database(HeaderBase):
         """
         return self.tables[table_id]
 
+    def __eq__(
+            self,
+            other: 'Database',
+    ) -> bool:
+        if self.dump() != other.dump():
+            return False
+        for table_id in self.tables:
+            if self[table_id] != other[table_id]:
+                return False
+        return True
+
     def __setitem__(
             self,
             table_id: str,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -818,6 +818,14 @@ class Table(HeaderBase):
         """
         return self.columns[column_id]
 
+    def __eq__(
+            self,
+            other: 'Table',
+    ) -> bool:
+        if self.dump() != other.dump():
+            return False
+        return self.df.equals(other.df)
+
     def __len__(self) -> int:
         return len(self._df)
 

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -1,0 +1,75 @@
+import audformat
+import audformat.testing
+
+
+def test_with_data(tmpdir):
+
+    db = audformat.testing.create_db(minimal=False)
+
+    # compare with self
+
+    assert db == db
+    assert db['files'] == db['files']
+    assert db['files']['string'] == db['files']['string']
+    assert db['files']['string'] != db['files']['int']  # different columns
+
+    # compare with db that has different data
+
+    db2 = audformat.testing.create_db(minimal=False)
+
+    assert db != db2
+    assert str(db) == str(db2)  # same header
+    assert db['files'] != db2['files']
+    assert db['files']['string'] != db2['files']['string']
+    assert db.schemes['string'] == db2.schemes['string']  # same schemes
+
+    # compare with db that has same data
+
+    db.save(tmpdir)
+    db3 = audformat.Database.load(tmpdir)
+
+    assert db == db3
+    assert db['files'] == db3['files']
+    assert db['files']['string'] == db3['files']['string']
+
+    # compare with column that has no data
+
+    c_no_data = audformat.Column(
+        scheme_id=db['files']['string'].scheme_id,
+        rater_id=db['files']['string'].rater_id,
+        description=db['files']['string'].description,
+        meta=db['files']['string'].meta.copy()
+    )
+
+    assert str(db['files']['string']) == str(c_no_data)
+    assert db['files']['string'] != c_no_data
+
+
+def test_without_data(tmpdir):
+
+    db = audformat.testing.create_db(minimal=True)
+
+    # compare with self
+
+    assert db == db
+
+    # compare with db that has different header
+
+    db2 = audformat.testing.create_db(minimal=True)
+    db.meta['new'] = 'key'
+
+    assert db != db2
+
+    # compare with db that has same header
+
+    db.save(tmpdir)
+    db3 = audformat.Database.load(tmpdir)
+
+    assert db == db3
+
+    # compare two columns without data
+
+    c1 = audformat.Column(description='c1')
+    c2 = audformat.Column(description='c2')
+
+    assert c1 != c2

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -1,3 +1,5 @@
+import pytest
+
 import audformat
 import audformat.testing
 
@@ -73,3 +75,20 @@ def test_without_data(tmpdir):
     c2 = audformat.Column(description='c2')
 
     assert c1 != c2
+
+
+def test_hash():
+
+    db = audformat.testing.create_db(minimal=False)
+    db2 = audformat.testing.create_db(minimal=False)
+
+    assert hash(db.schemes['string']) == hash(db2.schemes['string'])
+
+    with pytest.raises(TypeError):
+        hash(db)
+
+    with pytest.raises(TypeError):
+        hash(db['files'])
+
+    with pytest.raises(TypeError):
+        hash(db['files']['string'])


### PR DESCRIPTION
Closes #26 

### Example

```python
import audformat


db = audformat.testing.create_db()
db2 = audformat.testing.create_db()

assert db != db2

db.save('test')
db3 = audformat.Database.load('test')

assert db == db3
```

### Note

In Python 3 a class that overrides `__eq__` does not have a `__hash__` method by default:

https://docs.python.org/3/reference/datamodel.html#object.__hash__

The implementation I propose here, implements `__hash__` except for `Database`, `Table` and `Column` as their state usually depends on one or more `pd.DataFrame` objects, which are mutable (actually there are ways to get the hash for a `pd.DataFrame`, but I decided to stay with the default behavior of `pandas`, which does not implement `__hash__`). This means, we cannot use  `Database`, `Table` and `Column` in a `set()` or as key in a `dict`.
