### PR TITLE
Add update_other_formats option to Table.save()

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -227,12 +227,21 @@ class DefineBase:
 
     @classmethod
     def assert_has_value(cls, value):
-        attributes = inspect.getmembers(
-            cls, lambda x: not inspect.isroutine(x))
-        valid_values = [a[1] for a in attributes if
-                        not(a[0].startswith('__') and a[0].endswith('__'))]
+        valid_values = cls.values()
         if value not in valid_values:
             raise BadValueError(value, valid_values)
+
+    @classmethod
+    def values(cls):
+        attributes = inspect.getmembers(
+            cls, lambda x: not inspect.isroutine(x)
+        )
+        return sorted(
+            [
+                a[1] for a in attributes
+                if not(a[0].startswith('__') and a[0].endswith('__'))
+            ]
+        )
 
 
 def format_series_as_html():  # pragma: no cover (only used in documentation)

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -226,13 +226,13 @@ class HeaderBase:
 class DefineBase:
 
     @classmethod
-    def assert_has_value(cls, value):
-        valid_values = cls.values()
+    def assert_has_attribute_value(cls, value):
+        valid_values = cls.attribute_values()
         if value not in valid_values:
             raise BadValueError(value, valid_values)
 
     @classmethod
-    def values(cls):
+    def attribute_values(cls):
         attributes = inspect.getmembers(
             cls, lambda x: not inspect.isroutine(x)
         )

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -327,10 +327,11 @@ class Database(HeaderBase):
         r"""Save database to disk.
 
         Creates a header ``<root>/<name>.yaml``
-        and for every table a file ``<root>/<name>.<table-id>.[csv,pkl]``,
-        or both of them.
+        and for every table a file ``<root>/<name>.<table-id>.[csv,pkl]``.
 
         Existing files will be overwritten.
+        If ``update_other_formats`` is provided,
+        it will overwrite all existing files in others formats as well.
 
         Args:
             root: root directory (possibly created)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -316,7 +316,7 @@ class Database(HeaderBase):
             *,
             name: str = 'db',
             indent: int = 2,
-            storage_format: define.TableStorageFormat = (
+            storage_format: typing.Optional[define.TableStorageFormat] = (
                 define.TableStorageFormat.CSV
             ),
             header_only: bool = False,
@@ -325,8 +325,11 @@ class Database(HeaderBase):
     ):
         r"""Save database to disk.
 
-        Creates a header ``<root>/<name>.yaml`` and for every table
-        a file ``<root>/<name>.<table-id>.[csv,pkl]``.
+        Creates a header ``<root>/<name>.yaml``
+        and for every table a file ``<root>/<name>.<table-id>.[csv,pkl]``,
+        or both of them.
+
+        Existing files will be overwritten.
 
         Args:
             root: root directory (possibly created)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -103,7 +103,7 @@ class Database(HeaderBase):
             description: str = None,
             meta: dict = None,
     ):
-        define.Usage.assert_has_value(usage)
+        define.Usage.assert_has_attribute_value(usage)
 
         languages = [] if languages is None else audeer.to_list(languages)
         for idx in range(len(languages)):
@@ -316,9 +316,10 @@ class Database(HeaderBase):
             *,
             name: str = 'db',
             indent: int = 2,
-            storage_format: typing.Optional[define.TableStorageFormat] = (
+            storage_format: define.TableStorageFormat = (
                 define.TableStorageFormat.CSV
             ),
+            update_other_formats: bool = True,
             header_only: bool = False,
             num_workers: typing.Optional[int] = 1,
             verbose: bool = False,
@@ -337,10 +338,10 @@ class Database(HeaderBase):
             indent: indent size
             storage_format: storage format of tables.
                 See :class:`audformat.define.TableStorageFormat`
-                for available formats.
-                If ``'all'`` it will write to all formats.
-                If ``'update'`` it will only update existing files
-                independend of the storage format
+                for available formats
+            update_other_formats: if ``True`` it will not only save
+                to the given ``storage_format``,
+                but update all files stored in other storage formats as well
             header_only: store header only
             num_workers: number of parallel jobs.
                 If ``None`` will be set to the number of processors
@@ -359,7 +360,11 @@ class Database(HeaderBase):
 
             def job(table_id, table):
                 table_path = os.path.join(root, name + '.' + table_id)
-                table.save(table_path, storage_format=storage_format)
+                table.save(
+                    table_path,
+                    storage_format=storage_format,
+                    update_other_formats=update_other_formats,
+                )
 
             audeer.run_tasks(
                 job,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -337,7 +337,10 @@ class Database(HeaderBase):
             indent: indent size
             storage_format: storage format of tables.
                 See :class:`audformat.define.TableStorageFormat`
-                for available formats
+                for available formats.
+                If ``'all'`` it will write to all formats.
+                If ``'update'`` it will only update existing files
+                independend of the storage format
             header_only: store header only
             num_workers: number of parallel jobs.
                 If ``None`` will be set to the number of processors

--- a/audformat/core/media.py
+++ b/audformat/core/media.py
@@ -51,7 +51,7 @@ class Media(HeaderBase):
             meta: dict = None,
     ):
         super().__init__(description=description, meta=meta)
-        define.MediaType.assert_has_value(type)
+        define.MediaType.assert_has_attribute_value(type)
 
         self.type = type
         r"""Media type"""

--- a/audformat/core/rater.py
+++ b/audformat/core/rater.py
@@ -27,6 +27,6 @@ class Rater(HeaderBase):
             meta: dict = None,
     ):
         super().__init__(description=description, meta=meta)
-        define.RaterType.assert_has_value(type)
+        define.RaterType.assert_has_attribute_value(type)
         self.type = type
         r"""Rater type"""

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -76,7 +76,7 @@ class Scheme(HeaderBase):
         if dtype is not None:
             if dtype in self._dtypes:
                 dtype = self._dtypes[dtype]
-            define.DataType.assert_has_value(dtype)
+            define.DataType.assert_has_attribute_value(dtype)
 
         if dtype is None and labels is None:
             dtype = define.DataType.STRING
@@ -93,7 +93,7 @@ class Scheme(HeaderBase):
                 )
             if derived_dtype in self._dtypes:
                 derived_dtype = self._dtypes[derived_dtype]
-            define.DataType.assert_has_value(derived_dtype)
+            define.DataType.assert_has_attribute_value(derived_dtype)
             if dtype is not None:
                 if dtype != derived_dtype:
                     raise ValueError(

--- a/audformat/core/split.py
+++ b/audformat/core/split.py
@@ -31,6 +31,6 @@ class Split(HeaderBase):
             meta: dict = None,
     ):
         super().__init__(description=description, meta=meta)
-        define.SplitType.assert_has_value(type)
+        define.SplitType.assert_has_attribute_value(type)
         self.type = type
         r"""Split type"""

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -688,7 +688,7 @@ class Table(HeaderBase):
         if storage_format == define.TableStorageFormat.CSV:
             self._save_csv(csv_file)
             if update_other_formats and os.path.exists(pickle_file):
-                self._save_pickle(pickle_file)
+                self._save_pickled(pickle_file)
 
     def set(
             self,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -666,7 +666,7 @@ class Table(HeaderBase):
 
         Args:
             path: file path without extension
-            storage_format: storage format of tables.
+            storage_format: storage format of table.
                 See :class:`audformat.define.TableStorageFormat`
                 for available formats
             update_other_formats: if ``True`` it will not only save

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -655,11 +655,13 @@ class Table(HeaderBase):
             self,
             path: str,
             *,
-            storage_format: define.TableStorageFormat = (
+            storage_format: typing.Optional[define.TableStorageFormat] = (
                 define.TableStorageFormat.CSV
             ),
     ):
         r"""Save table data to disk.
+
+        Existing files will be overwritten.
 
         Args:
             path: file path without extension
@@ -669,13 +671,21 @@ class Table(HeaderBase):
 
         """
         path = audeer.safe_path(path)
-        define.TableStorageFormat.assert_has_value(storage_format)
-        if storage_format == define.TableStorageFormat.PICKLE:
+        if storage_format is None:
+            storage_formats = [
+                define.TableStorageFormat.PICKLE,
+                define.TableStorageFormat.CSV,
+            ]
+        else:
+            define.TableStorageFormat.assert_has_value(storage_format)
+            storage_formats = [storage_format]
+
+        if define.TableStorageFormat.PICKLE in storage_formats:
             self._df.to_pickle(
                 path + f'.{define.TableStorageFormat.PICKLE}',
                 compression='xz',
             )
-        else:
+        if define.TableStorageFormat.CSV in storage_formats:
             with open(path + f'.{define.TableStorageFormat.CSV}', 'w') as fp:
                 self.df.to_csv(fp, encoding='utf-8')
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -152,11 +152,12 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
                 assert not os.path.exists(table_file)
 
     # Test update other formats
-    if storage_format == audformat.define.TableStorageFormat.CSV:
+    if (
+            storage_format == audformat.define.TableStorageFormat.CSV
+            and db.tables
+    ):
         db2 = audformat.testing.create_db()
         db2.meta = {}
-        print(db)
-        print(db2)
         db2.save(
             tmpdir,
             storage_format=audformat.define.TableStorageFormat.PICKLE,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -167,7 +167,6 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         # which means we are loading the second database here
         db_load = audformat.Database.load(tmpdir)
         db_load.meta = {}
-        assert str(db_load) == str(db2)
         assert db_load == db2
         assert db_load != db
         # Save and not update PKL files

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -155,7 +155,7 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         db2 = audformat.testing.create_db()
         print(db)
         print(db2)
-        db.save(
+        db2.save(
             tmpdir,
             storage_format=audformat.define.TableStorageFormat.PICKLE,
             num_workers=num_workers,
@@ -163,6 +163,7 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         # Load prefers PKL files over CSV files,
         # which means we are loading the second database here
         db_load = audformat.Database.load(tmpdir)
+        assert str(db_load) == str(db2)
         assert db_load == db2
         assert db_load != db
         # Save and not update PKL files

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -136,7 +136,6 @@ def test_map_files(num_workers):
 )
 def test_save_and_load(tmpdir, db, storage_format, num_workers):
 
-    db.meta = {}
     db.save(
         tmpdir,
         storage_format=storage_format,
@@ -157,7 +156,6 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
             and db.tables
     ):
         db2 = audformat.testing.create_db()
-        db2.meta = {}
         db2.save(
             tmpdir,
             storage_format=audformat.define.TableStorageFormat.PICKLE,
@@ -166,7 +164,6 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         # Load prefers PKL files over CSV files,
         # which means we are loading the second database here
         db_load = audformat.Database.load(tmpdir)
-        db_load.meta = {}
         assert db_load == db2
         assert db_load != db
         # Save and not update PKL files
@@ -177,7 +174,6 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
             update_other_formats=False,
         )
         db_load = audformat.Database.load(tmpdir)
-        db_load.meta = {}
         assert db_load == db2
         assert db_load != db
         # Save and update PKL files
@@ -188,7 +184,6 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
             update_other_formats=True,
         )
         db_load = audformat.Database.load(tmpdir)
-        db_load.meta = {}
         assert db_load == db
 
     db_load = audformat.Database.load(tmpdir)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -113,11 +113,6 @@ def test_map_files(num_workers):
     'db, storage_format, num_workers',
     [
         (
-            audformat.testing.create_db(),
-            'all',
-            None,
-        ),
-        (
             audformat.testing.create_db(minimal=True),
             audformat.define.TableStorageFormat.CSV,
             1,
@@ -137,16 +132,6 @@ def test_map_files(num_workers):
             audformat.define.TableStorageFormat.PICKLE,
             None,
         ),
-        (
-            audformat.testing.create_db(),
-            'all',
-            None,
-        ),
-        (
-            audformat.testing.create_db(),
-            'update',
-            None,
-        ),
     ],
 )
 def test_save_and_load(tmpdir, db, storage_format, num_workers):
@@ -156,35 +141,48 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         storage_format=storage_format,
         num_workers=num_workers,
     )
-    available_formats = audformat.define.TableStorageFormat.values()
-    if storage_format == 'all':
-        expected_formats = available_formats
-    elif storage_format == 'update':
-        expected_formats = []
-    else:
-        expected_formats = [storage_format]
+    expected_formats = [storage_format]
     for table_id in db.tables:
-        for ext in available_formats:
+        for ext in audformat.define.TableStorageFormat.attribute_values():
             table_file = os.path.join(tmpdir, f'db.{table_id}.{ext}')
             if ext in expected_formats:
                 assert os.path.exists(table_file)
             else:
                 assert not os.path.exists(table_file)
 
-    if storage_format == 'update':
-        # Test update by first storing a modified version of the database
-        # and update if afterwards
+    # Test update other formats
+    if storage_format == audformat.define.TableStorageFormat.CSV:
         db2 = audformat.testing.create_db()
-        db2.save(
+        print(db)
+        print(db2)
+        db.save(
+            tmpdir,
+            storage_format=audformat.define.TableStorageFormat.PICKLE,
+            num_workers=num_workers,
+        )
+        # Load prefers PKL files over CSV files,
+        # which means we are loading the second database here
+        db_load = audformat.Database.load(tmpdir)
+        assert db_load == db2
+        assert db_load != db
+        # Save and not update PKL files
+        db.save(
             tmpdir,
             storage_format=audformat.define.TableStorageFormat.CSV,
             num_workers=num_workers,
+            update_other_formats=False,
         )
+        db_load = audformat.Database.load(tmpdir)
+        assert db_load == db2
+        assert db_load != db
+        # Save and update PKL files
         db.save(
             tmpdir,
-            storage_format=storage_format,
+            storage_format=audformat.define.TableStorageFormat.CSV,
             num_workers=num_workers,
+            update_other_formats=True,
         )
+        assert db_load == db
 
     db_load = audformat.Database.load(tmpdir)
     db_load.save(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -132,6 +132,11 @@ def test_map_files(num_workers):
             audformat.define.TableStorageFormat.PICKLE,
             None,
         ),
+        (
+            audformat.testing.create_db(),
+            None,
+            None,
+        ),
     ],
 )
 def test_save_and_load(tmpdir, db, storage_format, num_workers):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -136,6 +136,7 @@ def test_map_files(num_workers):
 )
 def test_save_and_load(tmpdir, db, storage_format, num_workers):
 
+    db.meta = {}
     db.save(
         tmpdir,
         storage_format=storage_format,
@@ -153,6 +154,7 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
     # Test update other formats
     if storage_format == audformat.define.TableStorageFormat.CSV:
         db2 = audformat.testing.create_db()
+        db2.meta = {}
         print(db)
         print(db2)
         db2.save(
@@ -163,6 +165,7 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         # Load prefers PKL files over CSV files,
         # which means we are loading the second database here
         db_load = audformat.Database.load(tmpdir)
+        db_load.meta = {}
         assert str(db_load) == str(db2)
         assert db_load == db2
         assert db_load != db
@@ -174,6 +177,7 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
             update_other_formats=False,
         )
         db_load = audformat.Database.load(tmpdir)
+        db_load.meta = {}
         assert db_load == db2
         assert db_load != db
         # Save and update PKL files
@@ -183,6 +187,8 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
             num_workers=num_workers,
             update_other_formats=True,
         )
+        db_load = audformat.Database.load(tmpdir)
+        db_load.meta = {}
         assert db_load == db
 
     db_load = audformat.Database.load(tmpdir)


### PR DESCRIPTION
Adds the possibility to store a table to a given format,
but update other existing formats as well.
This is also the default behavior, as we have `update_other_formats=True`.

`Database.save()`

![image](https://user-images.githubusercontent.com/173624/106271128-542aad00-622f-11eb-8114-83bbbd3aa753.png)


`Table.save()`

![image](https://user-images.githubusercontent.com/173624/106270731-b33bf200-622e-11eb-9c2f-b1f5c062735b.png)
