### PR TITLE
Use 'round_trip'  precision when loading from CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ venv/
 .coverage
 emodb-src/
 emodb.zip
-./coverage.xml
+coverage.xml

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -157,8 +157,7 @@ class Scheme(HeaderBase):
             elif self.dtype == define.DataType.FLOAT:
                 minimum = self.minimum or 0.0
                 maximum = self.maximum or minimum + 1.0
-                x = [round(random.uniform(minimum, maximum), 2)
-                     for _ in range(n)]
+                x = [random.uniform(minimum, maximum) for _ in range(n)]
             elif self.dtype == define.DataType.TIME:
                 x = [pd.to_timedelta(round(random.random(), 2), unit='s')
                      for _ in range(n)]

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -890,6 +890,7 @@ class Table(HeaderBase):
             dtype=dtypes,
             index_col=index_col,
             converters=converters,
+            float_precision='round_trip',
         )
 
         self._df = df

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -150,18 +150,13 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
         num_workers=num_workers,
     )
 
-    assert filecmp.cmp(os.path.join(tmpdir, 'db.yaml'),
-                       os.path.join(tmpdir, 'db-2.yaml'))
+    assert filecmp.cmp(
+        os.path.join(tmpdir, 'db.yaml'),
+        os.path.join(tmpdir, 'db-2.yaml'),
+    )
 
-    ext = f'.{storage_format}'
     for table_id, table in db.tables.items():
-        if storage_format != audformat.define.TableStorageFormat.CSV:
-            # TODO: why is this test failing if compression is turned off?
-            assert db[table_id].df.equals(db_load[table_id].df)
-        else:
-            assert filecmp.cmp(
-                os.path.join(tmpdir, 'db.{}{}'.format(table_id, ext)),
-                os.path.join(tmpdir, 'db-2.{}{}'.format(table_id, ext)))
+        assert db[table_id].df.equals(db_load[table_id].df)
         assert db[table_id].df.dtypes.equals(db_load[table_id].df.dtypes)
         assert db[table_id].files.equals(db_load[table_id].files)
         assert table._id == table_id
@@ -169,7 +164,9 @@ def test_save_and_load(tmpdir, db, storage_format, num_workers):
 
     # Test load_data=False
     db_load = audformat.Database.load(
-        tmpdir, load_data=False, num_workers=num_workers,
+        tmpdir,
+        load_data=False,
+        num_workers=num_workers,
     )
     for table_id, table in db_load.tables.items():
         assert list(db_load.files) == []


### PR DESCRIPTION
Uses `float_precision='round_trip'` in `read_csv()` to avoid rounding errors.

See https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#specifying-method-for-floating-point-conversion

With this change, it is ensured that the following code works:

``` python
db.save('test', storage_format='csv')
db2 = audformat.Database.load('test')
assert db == db2
```

To test the new behavior, floating point values in our test database are no longer rounded.