### PR TITLE
Add license and license_url to Database

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -36,6 +36,8 @@ class Database(HeaderBase):
         expires: expiry date
         languages: list of languages
         description: database description
+        license: database license
+        license_url: URL of database license
         meta: additional meta fields
 
     Raises:
@@ -101,6 +103,8 @@ class Database(HeaderBase):
             expires: datetime.date = None,
             languages: typing.Union[str, typing.Sequence[str]] = None,
             description: str = None,
+            license: str = None,
+            license_url: str = None,
             meta: dict = None,
     ):
         define.Usage.assert_has_attribute_value(usage)
@@ -120,6 +124,10 @@ class Database(HeaderBase):
         r"""Expiry date"""
         self.languages = languages
         r"""List of included languages"""
+        self.license = license
+        r"""License of database"""
+        self.license_url = license_url
+        r"""URL of database license"""
         self.media = HeaderDict(value_type=Media)
         r"""Dictionary of media information"""
         self.raters = HeaderDict(value_type=Rater)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -12,6 +12,7 @@ from audformat.core import utils
 from audformat.core.index import segmented_index
 from audformat.core.column import Column
 from audformat.core.common import HeaderBase, HeaderDict
+from audformat.core.define import LICENSE_URLS
 from audformat.core.errors import BadIdError
 from audformat.core.media import Media
 from audformat.core.rater import Rater
@@ -36,7 +37,12 @@ class Database(HeaderBase):
         expires: expiry date
         languages: list of languages
         description: database description
-        license: database license
+        license: database license.
+            You can use a custom license
+            or pick one from :attr:`audformat.define.License`.
+            In the later case,
+            ``license_url`` will be automatically set
+            if it is not given
         license_url: URL of database license
         meta: additional meta fields
 
@@ -103,11 +109,16 @@ class Database(HeaderBase):
             expires: datetime.date = None,
             languages: typing.Union[str, typing.Sequence[str]] = None,
             description: str = None,
-            license: str = None,
+            license: typing.Union[str, define.License] = None,
             license_url: str = None,
             meta: dict = None,
     ):
         define.Usage.assert_has_attribute_value(usage)
+        if (
+                license_url is None
+                and license in define.License.attribute_values()
+        ):
+            license_url = LICENSE_URLS[license]
 
         languages = [] if languages is None else audeer.to_list(languages)
         for idx in range(len(languages)):

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -12,7 +12,6 @@ from audformat.core import utils
 from audformat.core.index import segmented_index
 from audformat.core.column import Column
 from audformat.core.common import HeaderBase, HeaderDict
-from audformat.core.define import LICENSE_URLS
 from audformat.core.errors import BadIdError
 from audformat.core.media import Media
 from audformat.core.rater import Rater
@@ -118,7 +117,7 @@ class Database(HeaderBase):
                 license_url is None
                 and license in define.License.attribute_values()
         ):
-            license_url = LICENSE_URLS[license]
+            license_url = define.LICENSE_URLS[license]
 
         languages = [] if languages is None else audeer.to_list(languages)
         for idx in range(len(languages)):

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -48,6 +48,25 @@ class MediaType(DefineBase):
     VIDEO = 'video'
 
 
+class License(DefineBase):
+    r"""Common public licenses recommended to use with your data."""
+    CC0_1_0 = 'CC0-1.0'
+    CC_BY_4_0 = 'CC-BY-4.0'
+    CC_BY_NC_4_0 = 'CC-BY-NC-4.0'
+    CC_BY_NC_SA_4_0 = 'CC-BY-NC-SA-4.0'
+    CC_BY_SA_4_0 = 'CC-BY-SA-4.0'
+
+
+LICENSE_URLS = {
+    License.CC0_1_0: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    License.CC_BY_4_0: 'https://creativecommons.org/licenses/by/4.0/',
+    License.CC_BY_NC_4_0: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    License.CC_BY_NC_SA_4_0:
+        'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+    License.CC_BY_SA_4_0: 'https://creativecommons.org/licenses/by-sa/4.0/',
+}
+
+
 class RaterType(DefineBase):
     r"""Rater type of column."""
     HUMAN = 'human'

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -217,10 +217,7 @@ def create_db(minimal: bool = False) -> Database:
         return db
 
     db.description = 'A database for unit testing.'
-    db.license = 'CC0'
-    db.license_url = (
-        'https://creativecommons.org/share-your-work/public-domain/cc0/'
-    )
+    db.license = define.License.CC0_1_0,
     db.meta['audformat'] = 'https://github.com/audeering/audformat'
 
     #########

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -217,6 +217,10 @@ def create_db(minimal: bool = False) -> Database:
         return db
 
     db.description = 'A database for unit testing.'
+    db.license = 'CC0'
+    db.license_url = (
+        'https://creativecommons.org/share-your-work/public-domain/cc0/'
+    )
     db.meta['audformat'] = 'https://github.com/audeering/audformat'
 
     #########

--- a/audformat/define/__init__.py
+++ b/audformat/define/__init__.py
@@ -1,6 +1,7 @@
 from audformat.core.define import (
     DataType,
     Gender,
+    License,
     MediaType,
     RaterType,
     SplitType,

--- a/docs/api-define.rst
+++ b/docs/api-define.rst
@@ -32,6 +32,13 @@ IndexType
     :members:
     :undoc-members:
 
+License
+-------
+
+.. autoclass:: License
+    :members:
+    :undoc-members:
+
 MediaType
 ---------
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,6 +93,45 @@ def test_drop_and_pick_tables():
 
 
 @pytest.mark.parametrize(
+    'license, license_url, expected_license, expected_url',
+    [
+        (
+            audformat.define.License.CC0_1_0,
+            None,
+            'CC0-1.0',
+            'https://creativecommons.org/publicdomain/zero/1.0/',
+        ),
+        (
+            audformat.define.License.CC0_1_0,
+            'https://custom.org',
+            'CC0-1.0',
+            'https://custom.org',
+        ),
+        (
+            'custom',
+            None,
+            'custom',
+            None,
+        ),
+        (
+            'custom',
+            'https://custom.org',
+            'custom',
+            'https://custom.org',
+        ),
+    ]
+)
+def test_license(license, license_url, expected_license, expected_url):
+    db = audformat.Database(
+        'test',
+        license=license,
+        license_url=license_url,
+    )
+    assert db.license == expected_license
+    assert db.license_url == expected_url
+
+
+@pytest.mark.parametrize(
     'num_workers',
     [
         1,


### PR DESCRIPTION
This covers the license part discussed in #27.

It add the following two arguments/attributes to `audformat.Database():
* `license`
* `license_url` 