### PR TITLE
DOC: cache emodb on Github

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,12 @@ jobs:
       with:
         fetch-depth: 2
 
+    - name: Cache emodb
+      uses: actions/cache@v2
+      with:
+        path: emodb-src
+        key: emodb-ubuntu
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,22 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 2
+
+    - name: Cache emodb
+      uses: actions/cache@v2
+      with: emodb-src
+      key: emodb
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     # PyPI package
     - name: Build and publish
       env:
@@ -28,23 +36,28 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         python -m twine upload dist/*
+
     # Docuemntation
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes graphviz libsndfile1 sox
+
     - name: Install doc dependencies
       run: |
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
+
     - name: Build documentation
       run: |
         python -m sphinx docs/ docs/_build/ -b html
+
     - name: Deploy documentation to Github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build
+
     # Github release
     - name: Read CHANGELOG
       id: changelog
@@ -58,6 +71,7 @@ jobs:
         CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
         echo "::set-output name=body::$CHANGELOG"
+
     - name: Create release on Github
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,6 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Cache emodb
-      uses: actions/cache@v2
-      with:
-        path: emodb-src
-        key: emodb
-
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,9 @@ jobs:
 
     - name: Cache emodb
       uses: actions/cache@v2
-      with: emodb-src
-      key: emodb
+      with:
+        path: emodb-src
+        key: emodb
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,9 @@ jobs:
 
     - name: Cache emodb
       uses: actions/cache@v2
-      with: emodb-src
-      key: emodb
+      with:
+        path: emodb-src
+        key: emodb
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: emodb-src
-        key: emodb-ubuntu-18.04
+        key: emodb-ubuntu
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: emodb-src
-        key: emodb
+        key: emodb-ubuntu-18.04
+      if: matrix.os == 'ubuntu-18.04'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,21 +22,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Cache emodb
+      uses: actions/cache@v2
+      with: emodb-src
+      key: emodb
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes graphviz libsndfile1 sox
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+
     - name: Prepare Windows
       run: choco install sox.portable
       if: matrix.os == 'windows-latest'
+
     - name: Prepare OSX
       run: brew install sox
       if: matrix.os == 'macOS-latest'
+
     - name: Install dependencies
       run: |
         python -V
@@ -44,15 +54,18 @@ jobs:
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
+
     - name: Test with pytest
       run: |
         python -m pytest
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
       if: matrix.os == 'ubuntu-18.04'
+
     - name: Test building documentation
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W


### PR DESCRIPTION
Closes #6.

Caches the extracted emodb database to avoid downloading it every time the documentation is build.

It is stored under the cache key `emodb-ubuntu` and is used in the test and publish workflows.
We don't need to cache for Windows or Mac as the docuemntation is only build on `ubuntu-18.04` in the test workflow and `ubuntu-latest` in the publish workflow.

Note: it will [only cache for 7 days](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), but that's still better as nothing as we will trigger the pipeline with every commit we add to an existing pull request.