### PR TITLE
WIP: Combine database objects

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -37,6 +37,13 @@ class Database(HeaderBase):
         expires: expiry date
         languages: list of languages
         description: database description
+        license: database license.
+            You can use a custom license
+            or pick one from :attr:`audformat.define.License`.
+            In the later case,
+            ``license_url`` will be automatically set
+            if it is not given
+        license_url: URL of database license
         meta: additional meta fields
 
     Raises:
@@ -102,9 +109,16 @@ class Database(HeaderBase):
             expires: datetime.date = None,
             languages: typing.Union[str, typing.Sequence[str]] = None,
             description: str = None,
+            license: typing.Union[str, define.License] = None,
+            license_url: str = None,
             meta: dict = None,
     ):
         define.Usage.assert_has_attribute_value(usage)
+        if (
+                license_url is None
+                and license in define.License.attribute_values()
+        ):
+            license_url = define.LICENSE_URLS[license]
 
         languages = [] if languages is None else audeer.to_list(languages)
         for idx in range(len(languages)):
@@ -121,6 +135,10 @@ class Database(HeaderBase):
         r"""Expiry date"""
         self.languages = languages
         r"""List of included languages"""
+        self.license = license
+        r"""License of database"""
+        self.license_url = license_url
+        r"""URL of database license"""
         self.media = HeaderDict(value_type=Media)
         r"""Dictionary of media information"""
         self.raters = HeaderDict(value_type=Rater)

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -48,6 +48,25 @@ class MediaType(DefineBase):
     VIDEO = 'video'
 
 
+class License(DefineBase):
+    r"""Common public licenses recommended to use with your data."""
+    CC0_1_0 = 'CC0-1.0'
+    CC_BY_4_0 = 'CC-BY-4.0'
+    CC_BY_NC_4_0 = 'CC-BY-NC-4.0'
+    CC_BY_NC_SA_4_0 = 'CC-BY-NC-SA-4.0'
+    CC_BY_SA_4_0 = 'CC-BY-SA-4.0'
+
+
+LICENSE_URLS = {
+    License.CC0_1_0: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    License.CC_BY_4_0: 'https://creativecommons.org/licenses/by/4.0/',
+    License.CC_BY_NC_4_0: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    License.CC_BY_NC_SA_4_0:
+        'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+    License.CC_BY_SA_4_0: 'https://creativecommons.org/licenses/by-sa/4.0/',
+}
+
+
 class RaterType(DefineBase):
     r"""Rater type of column."""
     HUMAN = 'human'

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -540,11 +540,19 @@ class Table(HeaderBase):
     ):
         r"""Load table data from disk.
 
+        Tables can be stored as PKL and/or CSV files to disk.
+        If both files are present
+        it will load the PKL file
+        as long as its modification date is newer,
+        otherwise it will raise an error
+        and ask to delete one of the files.
+
         Args:
             path: file path without extension
 
         Raises:
             RuntimeError: if table file(s) are missing
+            RuntimeError: if CSV file is newer than PKL file
 
         """
         path = audeer.safe_path(path)
@@ -556,7 +564,27 @@ class Table(HeaderBase):
                 f"No file found for table with path '{path}.{{pkl|csv}}'"
             )
 
-        pickled = os.path.exists(pkl_file)
+        # Load from PKL if file exists and is newer then CSV file.
+        # If both are written by Database.save() this is the case
+        # as it stores first the PKL file
+        pickled = False
+        if os.path.exists(pkl_file):
+            if (
+                    os.path.exists(csv_file)
+                    and os.path.getmtime(csv_file) > os.path.getmtime(pkl_file)
+            ):
+                print('CSV time:', os.path.getmtime(csv_file))
+                print('PKL time:', os.path.getmtime(pkl_file))
+                raise RuntimeError(
+                    f"The table CSV file '{csv_file}' is newer "
+                    f"than the table PKL file '{pkl_file}'. "
+                    "If you want to load from the CSV file, "
+                    "please delete the PKL file. "
+                    "If you want to load from the PKL file, "
+                    "please delete the CSV file."
+                )
+            pickled = True
+
         if pickled:
             self._load_pickled(pkl_file)
         else:
@@ -691,10 +719,12 @@ class Table(HeaderBase):
         pickle_file = path + f'.{define.TableStorageFormat.PICKLE}'
         csv_file = path + f'.{define.TableStorageFormat.CSV}'
 
+        # Make sure the CSV file is always written first
+        # as it is expected to be older by load()
         if storage_format == define.TableStorageFormat.PICKLE:
-            self._save_pickled(pickle_file)
             if update_other_formats and os.path.exists(csv_file):
                 self._save_csv(csv_file)
+            self._save_pickled(pickle_file)
 
         if storage_format == define.TableStorageFormat.CSV:
             self._save_csv(csv_file)

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -217,6 +217,7 @@ def create_db(minimal: bool = False) -> Database:
         return db
 
     db.description = 'A database for unit testing.'
+    db.license = define.License.CC0_1_0,
     db.meta['audformat'] = 'https://github.com/audeering/audformat'
 
     #########

--- a/audformat/define/__init__.py
+++ b/audformat/define/__init__.py
@@ -1,6 +1,7 @@
 from audformat.core.define import (
     DataType,
     Gender,
+    License,
     MediaType,
     RaterType,
     SplitType,

--- a/docs/api-define.rst
+++ b/docs/api-define.rst
@@ -32,6 +32,13 @@ IndexType
     :members:
     :undoc-members:
 
+License
+-------
+
+.. autoclass:: License
+    :members:
+    :undoc-members:
+
 MediaType
 ---------
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,6 +93,45 @@ def test_drop_and_pick_tables():
 
 
 @pytest.mark.parametrize(
+    'license, license_url, expected_license, expected_url',
+    [
+        (
+            audformat.define.License.CC0_1_0,
+            None,
+            'CC0-1.0',
+            'https://creativecommons.org/publicdomain/zero/1.0/',
+        ),
+        (
+            audformat.define.License.CC0_1_0,
+            'https://custom.org',
+            'CC0-1.0',
+            'https://custom.org',
+        ),
+        (
+            'custom',
+            None,
+            'custom',
+            None,
+        ),
+        (
+            'custom',
+            'https://custom.org',
+            'custom',
+            'https://custom.org',
+        ),
+    ]
+)
+def test_license(license, license_url, expected_license, expected_url):
+    db = audformat.Database(
+        'test',
+        license=license,
+        license_url=license_url,
+    )
+    assert db.license == expected_license
+    assert db.license_url == expected_url
+
+
+@pytest.mark.parametrize(
     'num_workers',
     [
         1,


### PR DESCRIPTION
Implements `Database.__add__()` that creates a new object from two databases.

### Example:

Create a simple database with one table:

```python
db = audformat.testing.create_db(minimal=True)
db.description = 'Some test database.'
db.schemes['str'] = audformat.Scheme()
db.expires = datetime.date(2023, 1, 1)
db.meta = {'foo': 'bar'}
audformat.testing.add_table(db, 'table', audformat.define.IndexType.FILEWISE)
db
```
```
name: unittest
description: Some test database.
source: internal
usage: unrestricted
expires: 2023-01-01
languages: [deu, eng]
schemes:
  str: {dtype: str}
tables:
  table:
    type: filewise
    columns:
      str: {scheme_id: str}
foo: bar
```

Now combine with `emodb` database:

```python
emodb = audformat.Database.load(...)
db + emodb
```
```
name: unittest+emodb
description: Some test database. Berlin Database of Emotional Speech. A German database of emotional
  utterances spoken by actors recorded as a part of the DFG funded research project
  SE462/3-1 in 1997 and 1999. Recordings took place in the anechoic chamber of the
  Technical University Berlin, department of Technical Acoustics. It contains about
  500 utterances from ten different actors expressing basic six emotions and neutral.
source: internal,http://emodb.bilderbar.info/download/download.zip
usage: unrestricted
expires: 2023-01-01
languages: [eng, deu]
media:
  microphone: {type: other, format: wav, channels: 1, sampling_rate: 16000}
raters:
  gold: {type: human}
schemes:
  confidence: {description: Confidence of emotion ratings., dtype: float, minimum: 0,
    maximum: 1}
  duration: {dtype: time}
  emotion:
    description: Six basic emotions and neutral.
    dtype: str
    labels: [anger, boredom, disgust, fear, happiness, sadness, neutral]
  speaker:
    description: The actors could produce each sentence as often as they liked and
      were asked to remember a real situation from their past when they had felt this
      emotion.
    dtype: int
    labels:
      3: {gender: male, age: 31, language: deu}
      8: {gender: female, age: 34, language: deu}
      9: {gender: male, age: 21, language: deu}
      10: {gender: female, age: 32, language: deu}
      11: {gender: male, age: 26, language: deu}
      12: {gender: female, age: 30, language: deu}
      13: {gender: male, age: 32, language: deu}
      14: {gender: female, age: 35, language: deu}
      15: {gender: male, age: 25, language: deu}
      16: {gender: female, age: 31, language: deu}
  str: {dtype: str}
  transcription:
    description: Sentence produced by actor.
    dtype: str
    labels: {a01: Der Lappen liegt auf dem Eisschrank., a02: Das will sie am Mittwoch
        abgeben., a04: Heute abend könnte ich es ihm sagen., a05: Das schwarze Stück
        Papier befindet sich da oben neben dem Holzstück., a07: In sieben Stunden
        wird es soweit sein., b01: 'Was sind denn das für Tüten, die da unter dem
        Tisch stehen.', b02: Sie haben es gerade hochgetragen und jetzt gehen sie
        wieder runter., b03: An den Wochenenden bin ich jetzt immer nach Hause gefahren
        und habe Agnes besucht., b09: Ich will das eben wegbringen und dann mit Karl
        was trinken gehen., b10: 'Die wird auf dem Platz sein, wo wir sie immer hinlegen.'}
tables:
  emotion:
    type: filewise
    columns:
      emotion: {scheme_id: emotion, rater_id: gold}
      emotion.confidence: {scheme_id: confidence, rater_id: gold}
  files:
    type: filewise
    columns:
      duration: {scheme_id: duration}
      speaker: {scheme_id: speaker}
      transcription: {scheme_id: transcription}
  table:
    type: filewise
    columns:
      str: {scheme_id: str}
audb:
  root: /media/jwagner/Data/audb2/data-public-local/emodb/5030d22e-33a9-2386-1e03-693d20589cce/1.1.0
  version: 1.1.0
  flavor: {only_metadata: false, bit_depth: null, channels: null, format: null, mixdown: false,
    sampling_rate: null, tables: null, exclude: null, include: null}
foo: bar
pdf: http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
```

### Discussion

Turns out it's not so obvious what we should with some of the header fields if they do not match. Here's a list of fields that are up to discussion:

| field | result |
| - | - |
| name | 'name1+name2' |
| description | 'description1 description2' |
| source | 'source1,source2' |
| usage | error |
| expires | min(expires1, expires2) |
| languages | set([languages1, languages2]) |
| meta | meta1.update(meta2) |

For complex fields like `schemes` or `raters` an error is raised if contain different objects with the same ID.


