### PR TITLE
Add audformat.Database.author

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -36,6 +36,7 @@ class Database(HeaderBase):
         expires: expiry date
         languages: list of languages
         description: database description
+        author: database author(s)
         license: database license.
             You can use a custom license
             or pick one from :attr:`audformat.define.License`.
@@ -108,6 +109,7 @@ class Database(HeaderBase):
             expires: datetime.date = None,
             languages: typing.Union[str, typing.Sequence[str]] = None,
             description: str = None,
+            author: str = None,
             license: typing.Union[str, define.License] = None,
             license_url: str = None,
             meta: dict = None,
@@ -134,6 +136,8 @@ class Database(HeaderBase):
         r"""Expiry date"""
         self.languages = languages
         r"""List of included languages"""
+        self.author = author
+        r"""Author(s) of database"""
         self.license = license
         r"""License of database"""
         self.license_url = license_url

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -217,7 +217,7 @@ def create_db(minimal: bool = False) -> Database:
         return db
 
     db.description = 'A database for unit testing.'
-    db.author = 'audEERING GmbH'
+    db.author = 'J. Wagner, H. Wierstorf'
     db.license = define.License.CC0_1_0,
     db.meta['audformat'] = 'https://github.com/audeering/audformat'
 

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -217,6 +217,7 @@ def create_db(minimal: bool = False) -> Database:
         return db
 
     db.description = 'A database for unit testing.'
+    db.author = 'audEERING GmbH'
     db.license = define.License.CC0_1_0,
     db.meta['audformat'] = 'https://github.com/audeering/audformat'
 


### PR DESCRIPTION
This adds the `author` attribute to `audformat.Database`.

I'm not completely sure if it is always possible to differentiate it from `source`, but I think in most cases it should be obvious to the user.