### PR TITLE
intersect index objects

### DIFF
--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -1,5 +1,6 @@
 from audformat.core.utils import (
     concat,
+    intersect,
     map_language,
     read_csv,
     to_filewise_index,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -10,6 +10,12 @@ concat
 .. autofunction:: concat
 
 
+intersect
+---------
+
+.. autofunction:: intersect
+
+
 map_language
 ------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,7 +87,16 @@ def test_concat(objects, axis):
             audformat.filewise_index(),
         ),
         (
-            [audformat.filewise_index()],
+            [
+                audformat.filewise_index(),
+            ],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.filewise_index(),
+            ],
             audformat.filewise_index(),
         ),
         (
@@ -112,6 +121,19 @@ def test_concat(objects, axis):
                 audformat.filewise_index('f3'),
             ],
             audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,6 +80,124 @@ def test_concat(objects, axis):
 
 
 @pytest.mark.parametrize(
+    'objs, expected',
+    [
+        (
+            [],
+            audformat.filewise_index(),
+        ),
+        (
+            [audformat.filewise_index()],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f2', 'f3']),
+            ],
+            audformat.filewise_index('f2'),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index('f3'),
+            ],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2']),
+                audformat.segmented_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2']),
+                audformat.segmented_index(['f3', 'f4']),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+            ],
+            audformat.segmented_index('f2', 0, 1),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [1, 1], [2, 2]),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.segmented_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index('f2', 0, 1),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+                audformat.filewise_index('f1'),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f2', 'f3']),
+            ],
+            audformat.segmented_index('f2', 0, 1),
+        ),
+    ]
+)
+def test_intersect(objs, expected):
+    pd.testing.assert_index_equal(
+        audformat.utils.intersect(objs),
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
     'language, expected',
     [
         ('en', 'eng'),


### PR DESCRIPTION
Adds `utils.intersect()` that returns the intersection of a list of index objects.

### Example:

```python
objs = [
    audformat.segmented_index(['f1', 'f2'], [0, 0], [2, 2]),
    audformat.segmented_index(['f1', 'f2', 'f3'], [1, 0, 0], [2, 2, 2]),
    audformat.filewise_index(['f1', 'f2', 'f3']),
]
audformat.utils.intersect(objs))
```
```
MultiIndex([('f2', '0 days', '0 days 00:00:02')],
           names=['file', 'start', 'end'])
```