### PR TITLE
Union of index objects

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -499,7 +499,6 @@ def union(
                     ('f4', '0 days 00:00:00', '0 days 00:00:01')],
                    names=['file', 'start', 'end'])
 
-
     """
     if not objs:
         return filewise_index()

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -517,6 +517,9 @@ def union(
         if index.empty:
             index = segmented_index()
         elif index.levels[2].empty:
+            # If all end values are NaT, pandas stores an empty array and
+            # since pd.Index.union() in that case sets the type to
+            # DatetimeArray, we need to set it back to 'timedelta64[ns]'.
             index.set_levels(
                 [pd.to_timedelta([])],
                 level=[2],

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -444,7 +444,7 @@ def to_segmented_index(
 
 
 def union(
-    objs: typing.Sequence[typing.Union[pd.Index]],
+    objs: typing.Sequence[pd.Index],
 ) -> pd.Index:
     r"""Create union of index objects.
 

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -5,4 +5,5 @@ from audformat.core.utils import (
     read_csv,
     to_filewise_index,
     to_segmented_index,
+    union,
 )

--- a/docs/api-errors.rst
+++ b/docs/api-errors.rst
@@ -7,17 +7,17 @@ audformat.errors
 BadIdError
 ----------
 
-.. autoclass:: audformat.errors.BadIdError
+.. autoclass:: BadIdError
     :members:
 
 BadTypeError
 ------------
 
-.. autoclass:: audformat.errors.BadTypeError
+.. autoclass:: BadTypeError
     :members:
 
 BadValueError
 -------------
 
-.. autoclass:: audformat.errors.BadValueError
+.. autoclass:: BadValueError
     :members:

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -35,3 +35,8 @@ to_segmented_index
 ------------------
 
 .. autofunction:: to_segmented_index
+
+union
+-----
+
+.. autofunction:: union

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,56 +6,56 @@ audformat
 Column
 ------
 
-.. autoclass:: audformat.Column
+.. autoclass:: Column
     :members:
 
 filewise_index
 --------------
 
-.. autofunction:: audformat.filewise_index
+.. autofunction:: filewise_index
 
 segmented_index
 ---------------
 
-.. autofunction:: audformat.segmented_index
+.. autofunction:: segmented_index
 
 Database
 --------
 
-.. autoclass:: audformat.Database
+.. autoclass:: Database
     :members:
     :special-members:
 
 index_type
 ----------
 
-.. autofunction:: audformat.index_type
+.. autofunction:: index_type
 
 Media
 ---------
 
-.. autoclass:: audformat.Media
+.. autoclass:: Media
     :members:
 
 Rater
 -----
 
-.. autoclass:: audformat.Rater
+.. autoclass:: Rater
     :members:
 
 Scheme
 ------
 
-.. autoclass:: audformat.Scheme
+.. autoclass:: Scheme
     :members:
 
 Split
 -----
 
 Tables can be classified by splits.
-Usually one of :class:`audformat.define.SplitType`.
+Usually one of :class:`define.SplitType`.
 
-.. autoclass:: audformat.Split
+.. autoclass:: Split
     :members:
 
 Table
@@ -68,13 +68,8 @@ or numerical values to the files.
 
 There are two types of tables:
 
-* :class:`audformat.define.TableType.FILEWISE` tables annotate whole files
-* :class:`audformat.define.TableType.SEGMENTED` tables annotate file segments
+* :class:`define.TableType.FILEWISE` tables annotate whole files
+* :class:`define.TableType.SEGMENTED` tables annotate file segments
 
-.. autoclass:: audformat.Table
+.. autoclass:: Table
     :members:
-
-union
----------------
-
-.. autofunction:: audformat.union

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -73,3 +73,8 @@ There are two types of tables:
 
 .. autoclass:: audformat.Table
     :members:
+
+union
+---------------
+
+.. autofunction:: audformat.union

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -482,3 +482,163 @@ def test_to_filewise(tmpdir, output_folder, table_id, expected_file_names):
                     define.IndexField.FILE):
                 if os.path.exists(f):
                     os.remove(f)
+
+
+@pytest.mark.parametrize(
+    'objs, expected',
+    [
+        (
+            [],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+            ],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.filewise_index(),
+            ],
+            audformat.filewise_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f2', 'f3']),
+            ],
+            audformat.filewise_index(['f1', 'f2', 'f3']),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index('f3'),
+            ],
+            audformat.filewise_index(['f1', 'f2', 'f3']),
+        ),
+        (
+            [
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2']),
+                audformat.segmented_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2']),
+                audformat.segmented_index(['f3', 'f4']),
+            ],
+            audformat.segmented_index(['f1', 'f2', 'f3', 'f4']),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f2', 'f3'],
+                [0, 0, 0],
+                [1, 1, 1],
+            ),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [1, 1], [2, 2]),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f2', 'f2', 'f3'],
+                [0, 0, 1, 1],
+                [1, 1, 2, 2],
+            ),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.segmented_index(),
+            ],
+            audformat.segmented_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.filewise_index(),
+                audformat.segmented_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(['f1', 'f2']),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f1', 'f2', 'f2', 'f3'],
+                [0, 0, 0, 0, 0],
+                [1, pd.NaT, 1, pd.NaT, 1],
+            ),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+                audformat.filewise_index('f1'),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f1', 'f2', 'f3'],
+                [0, 0, 0, 0],
+                [1, pd.NaT, 1, 1],
+            ),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f2', 'f3']),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f1', 'f2', 'f2', 'f3'],
+                [0, 0, 0, 0, 0],
+                [1, pd.NaT, 1, pd.NaT, pd.NaT],
+            ),
+        ),
+    ]
+)
+def test_union(objs, expected):
+    pd.testing.assert_index_equal(
+        audformat.utils.union(objs),
+        expected,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -381,7 +381,17 @@ def test_read_csv(csv, result):
     'table_id',
     ['files', 'segments']
 )
-def test_to_segmented(table_id):
+def test_to_segmented_index(table_id):
+
+    # empty case
+    for index in [audformat.filewise_index(), audformat.segmented_index()]:
+        assert audformat.index_type(
+            audformat.utils.to_segmented_index(
+                index
+            )
+        ) == audformat.define.IndexType.SEGMENTED
+
+    # non-empty case
     for column_id, column in pytest.DB[table_id].get().items():
         series = utils.to_segmented_index(column)
         pd.testing.assert_series_equal(series.reset_index(drop=True),


### PR DESCRIPTION
Adds `utils.union()` to create the union of a list of index objects.

### Example:

```python
objs = [
    audformat.segmented_index(['f1', 'f2'], [0, 0], [2, 2]),
    audformat.segmented_index(['f1', 'f2', 'f3'], [1, 0, 0], [2, 2, 2]),
    audformat.filewise_index(['f1', 'f1', 'f2', 'f3']),
]
audformat.utils.union(objs)
```
```
MultiIndex([('f1', '0 days 00:00:00', '0 days 00:00:02'),
            ('f1', '0 days 00:00:00',               NaT),
            ('f1', '0 days 00:00:01', '0 days 00:00:02'),
            ('f2', '0 days 00:00:00', '0 days 00:00:02'),
            ('f2', '0 days 00:00:00',               NaT),
            ('f3', '0 days 00:00:00', '0 days 00:00:02'),
            ('f3', '0 days 00:00:00',               NaT)],
           names=['file', 'start', 'end'])
```
