### PR TITLE
Forbid duplicates

### DIFF
--- a/audformat/__init__.py
+++ b/audformat/__init__.py
@@ -3,6 +3,7 @@ from audformat import errors
 from audformat import utils
 from audformat.core.database import Database
 from audformat.core.index import (
+    assert_index,
     filewise_index,
     segmented_index,
     index_type,

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -52,15 +52,19 @@ def assert_index(
         obj = obj.index
 
     if obj.has_duplicates:
-        duplicates = '\n'.join(
+        max_display = 10
+        duplicates = obj[obj.duplicated()]
+        msg_tail = '\n...' if len(duplicates) > max_display else ''
+        msg_duplicates = '\n'.join(
             [
-                str(duplicate) for duplicate in obj[obj.duplicated()].tolist()
+                str(duplicate) for duplicate
+                in duplicates[:max_display].tolist()
             ]
         )
         raise ValueError(
             'Index not conform to audformat. '
             'Found duplicates:\n'
-            f'{duplicates}'
+            f'{msg_duplicates}{msg_tail}'
         )
 
     num = len(obj.names)

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -119,6 +119,9 @@ def filewise_index(
     Returns:
         filewise index
 
+    Raises:
+        ValueError: if created index contains duplicates
+
     Example:
         >>> filewise_index(['a.wav', 'b.wav'])
         Index(['a.wav', 'b.wav'], dtype='object', name='file')
@@ -126,8 +129,12 @@ def filewise_index(
     """
     if files is None:
         files = []
+
     files = to_array(files)
-    return pd.Index(files, name=define.IndexField.FILE)
+    index = pd.Index(files, name=define.IndexField.FILE)
+    assert_index(index)
+
+    return index
 
 
 def index_type(
@@ -189,6 +196,9 @@ def segmented_index(
         segmented index
 
     Raises:
+        ValueError: if created index contains duplicates
+
+    Raises:
         ValueError: if ``files``, ``start`` and ``ends`` differ in size
 
     Example:
@@ -237,10 +247,13 @@ def segmented_index(
             "'starts', and 'ends' differ in size",
         )
 
-    return pd.MultiIndex.from_arrays(
+    index = pd.MultiIndex.from_arrays(
         [files, to_timedelta(starts), to_timedelta(ends)],
         names=[
             define.IndexField.FILE,
             define.IndexField.START,
             define.IndexField.END,
         ])
+    assert_index(index)
+
+    return index

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -70,7 +70,7 @@ def assert_index(
             'Index not conform to audformat. '
             f'Found '
             f'{num} '
-            f'levels, but expected 1 or 3.'
+            f'levels, but expected 1 or 3 levels.'
         )
 
     if num == 1 and not (
@@ -78,9 +78,9 @@ def assert_index(
     ):
         raise ValueError(
             'Index not conform to audformat. '
-            'Found one level with name '
-            f'{obj.names[0]} '
-            f', but expected '
+            'Found single level with name '
+            f'{obj.names[0]}, '
+            f'but expected name '
             f"'{define.IndexField.FILE}'."
         )
     elif num == 3 and not (
@@ -96,8 +96,8 @@ def assert_index(
         raise ValueError(
             'Index not conform to audformat. '
             'Found three levels with names '
-            f'{obj.names} '
-            f', but expected '
+            f'{obj.names}, '
+            f'but expected names '
             f'{expected_names}.'
         )
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,12 @@ audformat
 
 .. automodule:: audformat
 
+
+assert_index
+------------
+
+.. autofunction:: assert_index
+
 Column
 ------
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -24,25 +24,8 @@ def to_array(value):
         pd.DataFrame(
             index=audformat.filewise_index(['f1', 'f2']),
         ),
-        pytest.param(  # duplicates
-            audformat.filewise_index(['f1', 'f2', 'f2']),
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
         audformat.segmented_index(),
         audformat.segmented_index(['f1', 'f2']),
-        pytest.param(  # duplicates
-            audformat.segmented_index(['f1', 'f2', 'f2']),
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-        audformat.segmented_index(['f1', 'f1'], [0, 0], [1, 2]),
-        pytest.param(  # duplicates
-            audformat.segmented_index(['f1', 'f1'], [0, 0], [1, 1]),
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-        pytest.param(  # duplicates
-            audformat.segmented_index(['f1', 'f1'], [0, 0]),
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
         pytest.param(  # missing names
             pd.Index(['f1', 'f2']),
             marks=pytest.mark.xfail(raises=ValueError),
@@ -91,6 +74,10 @@ def test_assert_index(obj):
         '1.wav',
         ['1.wav', '2.wav'],
         pytest.DB['files'].files,
+        pytest.param(  # duplicates
+            ['f1', 'f2', 'f2'],
+            marks=pytest.mark.xfail(raises=ValueError),
+        )
     ]
 )
 def test_create_filewise_index(files):
@@ -174,10 +161,28 @@ def test_create_filewise_index(files):
             pytest.DB['segments'].starts,
             pytest.DB['segments'].ends,
         ),
-        pytest.param(
+        pytest.param(  # len files != len starts/ends
             ['1.wav'],
             [pd.Timedelta('0s'), pd.Timedelta('1s')],
             [pd.Timedelta('1s'), pd.Timedelta('2s')],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # duplicates
+            ['f1', 'f1'],
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # duplicates
+            ['f1', 'f1'],
+            [0, 0],
+            [1, 1],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # duplicates
+            ['f1', 'f1'],
+            [0, 0],
+            None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
     ]

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -14,6 +14,76 @@ def to_array(value):
 
 
 @pytest.mark.parametrize(
+    'obj',
+    [
+        audformat.filewise_index(),
+        audformat.filewise_index(['f1', 'f2']),
+        pd.Series(
+            index=audformat.filewise_index(['f1', 'f2']),
+        ),
+        pd.DataFrame(
+            index=audformat.filewise_index(['f1', 'f2']),
+        ),
+        pytest.param(  # duplicates
+            audformat.filewise_index(['f1', 'f2', 'f2']),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        audformat.segmented_index(),
+        audformat.segmented_index(['f1', 'f2']),
+        pytest.param(  # duplicates
+            audformat.segmented_index(['f1', 'f2', 'f2']),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        audformat.segmented_index(['f1', 'f1'], [0, 0], [1, 2]),
+        pytest.param(  # duplicates
+            audformat.segmented_index(['f1', 'f1'], [0, 0], [1, 1]),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # duplicates
+            audformat.segmented_index(['f1', 'f1'], [0, 0]),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # missing names
+            pd.Index(['f1', 'f2']),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # missing names
+            pd.MultiIndex.from_arrays(
+                [
+                    ['f1', 'f2'],
+                    [0, 0],
+                    [0, 0],
+                ]
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid level number
+            pd.MultiIndex.from_arrays(
+                [
+                    ['f1', 'f2'],
+                    [0, 0],
+                ]
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid level number
+            pd.MultiIndex.from_arrays(
+                [
+                    ['f1', 'f2'],
+                    [0, 0],
+                    [0, 0],
+                    [0, 0],
+                ]
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_assert_index(obj):
+    audformat.assert_index(obj)
+
+
+@pytest.mark.parametrize(
     'files',
     [
         None,

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -220,6 +220,9 @@ def test_pick_files(files, table):
     table = table.pick_files(files, inplace=False)
     if callable(files):
         files = table.files[table.files.to_series().apply(files)]
+        seen = set()
+        seen_add = seen.add
+        files = [x for x in files if not (x in seen or seen_add(x))]
     elif isinstance(files, str):
         files = [files]
     pd.testing.assert_index_equal(


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/32

In https://github.com/audeering/audformat/issues/32 we decided that an index conform to `audformat` must not contain duplicates.

This is now checked by `audformat.assert_index()` which is called by `audformat.index_type()`.

### Examples:

```python
index = audformat.segmented_index(['f1', 'f2'])
audformat.assert_index(index)

try:
    audformat.segmented_index(['f1', 'f1', 'f2', 'f2'])
except Exception as ex:
    print(ex)

try:
    audformat.assert_index(pd.Index(['f1']))
except Exception as ex:
    print(ex)

try:
    audformat.assert_index(pd.MultiIndex.from_arrays(
        [
            ['f1'], [0],
        ]
    ))
except Exception as ex:
    print(ex)

try:
    audformat.assert_index(
        pd.MultiIndex.from_arrays(
            [
                ['f1'], [0], [1]
            ], names=['File', 'Start', 'End']
        )
    )
except Exception as ex:
    print(ex)
```
```
Index not conform to audformat. Found duplicates:
('f1', Timedelta('0 days 00:00:00'), NaT)
('f2', Timedelta('0 days 00:00:00'), NaT)
Index not conform to audformat. Found single level with name None, but expected name 'file'.
Index not conform to audformat. Found 2 levels, but expected 1 or 3 levels.
Index not conform to audformat. Found three levels with names ['File', 'Start', 'End'], but expected names ['file', 'start', 'end'].
```
