### PR TITLE
Reimplement utils.concat() and Table.__add__()

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -740,7 +740,7 @@ class Table(HeaderBase):
     def __add__(self, other: 'Table') -> 'Table':
         r"""Create new table by combining two tables.
 
-        The new the table contains index and columns of both tables.
+        The new table contains index and columns of both tables.
         Missing values will be set to ``NaN``.
         If at least one table is segmented, the output has a segmented index.
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -740,20 +740,19 @@ class Table(HeaderBase):
     def __add__(self, other: 'Table') -> 'Table':
         r"""Create new table by combining two tables.
 
-        If the tables are of the same type, the created tables contain index
-        and columns of both tables.
-        If the tables are not of the same type and one of the tables is a
-        file-wise table, the created table has the index of segmented table
-        and columns of both tables.
+        The new the table contains index and columns of both tables.
         Missing values will be set to ``NaN``.
+        If at least one table is segmented, the output has a segmented index.
+
+        Columns with the same identifier are combined to a single column.
+        This requires that:
+
+        1. both columns have the same dtype
+        2. in places where the indices overlap the values of both columns
+           match or one column contains ``NaN``
+
         References to schemes and raters are always preserved.
         Media and split information only when they match.
-
-        .. warning::
-            Columns with the same identifier are combined to a single column.
-            This requires that either the indices of the tables do not
-            overlap or at least one table contains a ``NaN`` in places where
-            the indices overlap.
 
         Args:
             other: the other table

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import os
 import typing as typing
 
@@ -87,7 +86,7 @@ def concat(
                 columns.append(obj[column])
 
     # reindex all columns to the new index
-    columns_reindex = OrderedDict()
+    columns_reindex = {}
     for column in columns:
 
         if as_segmented:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -24,7 +24,7 @@ def concat(
     Objects must be conform to
     :ref:`table specifications <data-tables:Tables>`.
 
-    The new the object contains index and columns of both objects.
+    The new object contains index and columns of both objects.
     Missing values will be set to ``NaN``.
     If at least one object is segmented, the output has a segmented index.
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -20,17 +20,15 @@ from audformat.core.index import (
 def compare_dtype(d1, d2) -> bool:
     r"""Helper function to compare pandas dtype."""
     if d1.name.lower().startswith('int') and d2.name.lower().startswith('int'):
-        # match various int types, e.g. int64 and Int64
+        # match different int types, e.g. int64 and Int64
         return True
     if d1.name.startswith('float') and d2.name.startswith('float'):
-        # match various float types, e.g. float32 and float64
+        # match different float types, e.g. float32 and float64
         return True
-    if d1.name == d2.name:
-        if d1.name == 'category':
-            # check if categories match
-            return d1 == d2
-        return True
-    return False
+    if d1.name == 'category' and d2.name == 'category':
+        # match only if categories are the same
+        return d1 == d2
+    return d1.name == d2.name
 
 
 def concat(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -137,9 +137,12 @@ def concat(
 
             # drop NaN to avoid overwriting values from other column
             column = column.dropna()
-            columns_reindex[column.name][column.index] = column
         else:
-            columns_reindex[column.name] = column.reindex(index)
+            columns_reindex[column.name] = pd.Series(
+                index=index,
+                dtype=column.dtype,
+            )
+        columns_reindex[column.name][column.index] = column
 
     df = pd.DataFrame(columns_reindex, index=index)
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -82,7 +82,7 @@ def concat(
 
     # convert dtype int to nullable Int64
     for idx in range(len(columns)):
-        if columns[idx].dtype == int:
+        if columns[idx].dtype.name == 'int64':
             columns[idx] = columns[idx].astype('Int64')
 
     # reindex all columns to the new index
@@ -101,9 +101,9 @@ def concat(
                     'Found two columns with name '
                     f"'{column.name}' "
                     'buf different dtypes '
-                    f"'{columns_reindex[column.name].dtype}' "
+                    f"'{columns_reindex[column.name].dtype.name}' "
                     'and '
-                    f"'{column.dtype}'."
+                    f"'{column.dtype.name}'."
                 )
 
             # overlapping values must match or have to be nan in one column

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -25,10 +25,16 @@ def concat(
     Objects must be conform to
     :ref:`table specifications <data-tables:Tables>`.
 
-    Columns with same name must have the same dtype and values in the
-    same position must match or NaN in all but one column.
-
+    The new the object contains index and columns of both objects.
+    Missing values will be set to ``NaN``.
     If at least one object is segmented, the output has a segmented index.
+
+    Columns with the same identifier are combined to a single column.
+    This requires that:
+
+    1. both columns have the same dtype
+    2. in places where the indices overlap the values of both columns
+       match or one column contains ``NaN``
 
     Args:
         objs: objects conform to

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -17,20 +17,6 @@ from audformat.core.index import (
 )
 
 
-def compare_dtype(d1, d2) -> bool:
-    r"""Helper function to compare pandas dtype."""
-    if d1.name.lower().startswith('int') and d2.name.lower().startswith('int'):
-        # match different int types, e.g. int64 and Int64
-        return True
-    if d1.name.startswith('float') and d2.name.startswith('float'):
-        # match different float types, e.g. float32 and float64
-        return True
-    if d1.name == 'category' and d2.name == 'category':
-        # match only if categories are the same
-        return d1 == d2
-    return d1.name == d2.name
-
-
 def concat(
         objs: typing.Sequence[typing.Union[pd.Series, pd.DataFrame]],
 ) -> typing.Union[pd.Series, pd.DataFrame]:
@@ -111,7 +97,7 @@ def concat(
         if column.name in columns_reindex:
 
             # assert same dtype
-            if not compare_dtype(
+            if not same_dtype(
                     columns_reindex[column.name].dtype, column.dtype
             ):
                 # use repr() to print category names
@@ -367,6 +353,20 @@ def read_csv(
         return frame[frame.columns[0]]
     else:
         return frame
+
+
+def same_dtype(d1, d2) -> bool:
+    r"""Helper function to compare pandas dtype."""
+    if d1.name.lower().startswith('int') and d2.name.lower().startswith('int'):
+        # match different int types, e.g. int64 and Int64
+        return True
+    if d1.name.startswith('float') and d2.name.startswith('float'):
+        # match different float types, e.g. float32 and float64
+        return True
+    if d1.name == 'category' and d2.name == 'category':
+        # match only if categories are the same
+        return d1 == d2
+    return d1.name == d2.name
 
 
 def to_filewise_index(

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,3 +79,4 @@ There are two types of tables:
 
 .. autoclass:: Table
     :members:
+    :special-members:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -32,9 +32,10 @@ def test_add():
         p_none=0.25, num_files=[1, 6, 7, 8, 9], media_id='media',
     )
     db['table'] = db['table1'] + db['table2']
-    pd.testing.assert_index_equal(db['table'].files,
-                                  db['table1'].files.union(
-                                      db['table2'].files))
+    pd.testing.assert_index_equal(
+        db['table'].files,
+        db['table1'].files.union(db['table2'].files)
+    )
     assert db['table'].media_id == 'media'
     assert db['table'].split_id is None
 
@@ -49,39 +50,56 @@ def test_add():
 
     # tables of same type without overlap
 
-    for table_type in (audformat.define.IndexType.FILEWISE,
-                       audformat.define.IndexType.SEGMENTED):
+    for table_type in [
+        audformat.define.IndexType.FILEWISE,
+        audformat.define.IndexType.SEGMENTED
+    ]:
         db.drop_tables(list(db.tables))
         audformat.testing.add_table(
-            db, 'table1', table_type,
-            num_files=5, columns=['scheme1'],
+            db,
+            'table1',
+            table_type,
+            num_files=5,
+            columns=['scheme1'],
         )
         audformat.testing.add_table(
-            db, 'table2', table_type,
-            num_files=(6, 7, 8, 9, 10), columns='scheme1',
+            db,
+            'table2',
+            table_type,
+            num_files=(6, 7, 8, 9, 10),
+            columns='scheme1',
         )
         db['table'] = db['table1'] + db['table2']
-        pd.testing.assert_frame_equal(db['table'].get(),
-                                      pd.concat([db['table1'].get(),
-                                                 db['table2'].get()]))
+        pd.testing.assert_frame_equal(
+            db['table'].get(),
+            pd.concat([db['table1'].get(), db['table2'].get()])
+        )
 
     # tables of same type with overlap
 
     db.drop_tables(list(db.tables))
     audformat.testing.add_table(
-        db, 'table1', audformat.define.IndexType.FILEWISE,
-        num_files=(1, 2), columns='scheme1',
+        db,
+        'table1',
+        audformat.define.IndexType.FILEWISE,
+        num_files=(1, 2),
+        columns='scheme1',
     )
     audformat.testing.add_table(
-        db, 'table2', audformat.define.IndexType.FILEWISE,
-        num_files=(1,), columns='scheme1',
+        db,
+        'table2',
+        audformat.define.IndexType.FILEWISE,
+        num_files=(1,),
+        columns='scheme1',
     )
-    db['table2'].df.iloc[0] = np.nan
+    db['table2'].df.iloc[0] = np.nan  # ok if other value is nan
     db['table'] = db['table1'] + db['table2']
-    pd.testing.assert_series_equal(db['table']['scheme1'].get(),
-                                   db['table1']['scheme1'].get())
+    pd.testing.assert_series_equal(
+        db['table']['scheme1'].get(),
+        db['table1']['scheme1'].get()
+    )
     with pytest.raises(ValueError):
-        db['table2'].df.iloc[0] = db['table1'].df.iloc[0]
+        db['table2'].df.iloc[0] = 'do not match'  # values do not match
         db['table'] = db['table1'] + db['table2']
 
     # filewise with segmented table
@@ -93,12 +111,18 @@ def test_add():
     ):
         db.drop_tables(list(db.tables))
         audformat.testing.add_table(
-            db, 'table1', audformat.define.IndexType.FILEWISE,
-            columns='scheme1', num_files=num_files_1,
+            db,
+            'table1',
+            audformat.define.IndexType.FILEWISE,
+            columns='scheme1',
+            num_files=num_files_1,
         )
         audformat.testing.add_table(
-            db, 'table2', audformat.define.IndexType.SEGMENTED,
-            columns='scheme2', num_files=num_files_2,
+            db,
+            'table2',
+            audformat.define.IndexType.SEGMENTED,
+            columns='scheme2',
+            num_files=num_files_2,
         )
         db['table'] = db['table1'] + db['table2']
         assert db['table'].type == audformat.define.IndexType.SEGMENTED
@@ -118,12 +142,18 @@ def test_add():
     ):
         db.drop_tables(list(db.tables))
         audformat.testing.add_table(
-            db, 'table1', audformat.define.IndexType.SEGMENTED,
-            columns='scheme1', num_files=num_files_1,
+            db,
+            'table1',
+            audformat.define.IndexType.SEGMENTED,
+            columns='scheme1',
+            num_files=num_files_1,
         )
         audformat.testing.add_table(
-            db, 'table2', audformat.define.IndexType.FILEWISE,
-            columns='scheme2', num_files=num_files_2,
+            db,
+            'table2',
+            audformat.define.IndexType.FILEWISE,
+            columns='scheme2',
+            num_files=num_files_2,
         )
         db['table'] = db['table1'] + db['table2']
         assert db['table'].type == audformat.define.IndexType.SEGMENTED

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -153,6 +153,30 @@ from audformat import define
                 audformat.filewise_index(['f1', 'f2']),
             ),
         ),
+        # combine series and data frame
+        (
+            [
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    name='c1',
+                ),
+                pd.DataFrame(
+                    {
+                        'c1': [np.nan, 3.],
+                        'c2': ['a', 'b'],
+                    },
+                    audformat.segmented_index(['f2', 'f3']),
+                ),
+            ],
+            pd.DataFrame(
+                {
+                    'c1': [1., 2., 3.],
+                    'c2': [np.nan, 'a', 'b']
+                },
+                audformat.segmented_index(['f1', 'f2', 'f3']),
+            ),
+        ),
         # dtype does not match
         pytest.param(
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,46 +45,46 @@ from audformat import define
         ),
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1'])),
-                pd.Series([2.], audformat.filewise_index(['f2'])),
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([2.], audformat.filewise_index('f2')),
             ],
             pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
         ),
         (
             [
-                pd.Series([1.], audformat.segmented_index(['f1'])),
-                pd.Series([2.], audformat.segmented_index(['f2'])),
+                pd.Series([1.], audformat.segmented_index('f1')),
+                pd.Series([2.], audformat.segmented_index('f2')),
             ],
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
         ),
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1'])),
-                pd.Series([2.], audformat.segmented_index(['f2'])),
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([2.], audformat.segmented_index('f2')),
             ],
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
         ),
         # combine values in same location
         (
             [
-                pd.Series([np.nan], audformat.filewise_index(['f1'])),
-                pd.Series([np.nan], audformat.filewise_index(['f1'])),
+                pd.Series([np.nan], audformat.filewise_index('f1')),
+                pd.Series([np.nan], audformat.filewise_index('f1')),
             ],
-            pd.Series([np.nan], audformat.filewise_index(['f1'])),
+            pd.Series([np.nan], audformat.filewise_index('f1')),
         ),
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1'])),
-                pd.Series([np.nan], audformat.filewise_index(['f1'])),
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([np.nan], audformat.filewise_index('f1')),
             ],
-            pd.Series([1.], audformat.filewise_index(['f1'])),
+            pd.Series([1.], audformat.filewise_index('f1')),
         ),
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1'])),
-                pd.Series([1.], audformat.filewise_index(['f1'])),
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([1.], audformat.filewise_index('f1')),
             ],
-            pd.Series([1.], audformat.filewise_index(['f1'])),
+            pd.Series([1.], audformat.filewise_index('f1')),
         ),
         # combine values with matching dtype
         (
@@ -189,21 +189,21 @@ from audformat import define
         # combine series with different names
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1']), name='c1'),
-                pd.Series([2.], audformat.filewise_index(['f1']), name='c2'),
+                pd.Series([1.], audformat.filewise_index('f1'), name='c1'),
+                pd.Series([2.], audformat.filewise_index('f1'), name='c2'),
             ],
             pd.DataFrame(
                 {
                     'c1': [1.],
                     'c2': [2.],
                 },
-                audformat.filewise_index(['f1']),
+                audformat.filewise_index('f1'),
             ),
         ),
         (
             [
-                pd.Series([1.], audformat.filewise_index(['f1']), name='c1'),
-                pd.Series([2.], audformat.filewise_index(['f2']), name='c2'),
+                pd.Series([1.], audformat.filewise_index('f1'), name='c1'),
+                pd.Series([2.], audformat.filewise_index('f2'), name='c2'),
             ],
             pd.DataFrame(
                 {
@@ -222,7 +222,7 @@ from audformat import define
                 ),
                 pd.Series(
                     [2.],
-                    audformat.filewise_index(['f2']),
+                    audformat.filewise_index('f2'),
                     name='c2',
                 ),
             ],
@@ -232,6 +232,30 @@ from audformat import define
                     'c2': [np.nan, 2.],
                 },
                 audformat.filewise_index(['f1', 'f2']),
+            ),
+        ),
+        (
+            [
+                pd.Series(
+                    [1.],
+                    audformat.filewise_index('f1'),
+                    name='c1'),
+                pd.Series(
+                    [2.],
+                    audformat.segmented_index('f1', 0, 1),
+                    name='c2',
+                ),
+            ],
+            pd.DataFrame(
+                {
+                    'c1': [1., np.nan],
+                    'c2': [np.nan, 2.],
+                },
+                audformat.segmented_index(
+                    ['f1', 'f1'],
+                    [0, 0],
+                    [None, 1],
+                ),
             ),
         ),
         # combine series and data frame
@@ -261,8 +285,8 @@ from audformat import define
         # error: dtypes do not match
         pytest.param(
             [
-                pd.Series([1], audformat.filewise_index(['f1'])),
-                pd.Series([1.], audformat.filewise_index(['f1'])),
+                pd.Series([1], audformat.filewise_index('f1')),
+                pd.Series([1.], audformat.filewise_index('f1')),
             ],
             None,
             marks=pytest.mark.xfail(raises=ValueError),
@@ -316,8 +340,8 @@ from audformat import define
         # error: values do not match
         pytest.param(
             [
-                pd.Series([1.], audformat.filewise_index(['f1'])),
-                pd.Series([2.], audformat.filewise_index(['f1'])),
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([2.], audformat.filewise_index('f1')),
             ],
             None,
             marks=pytest.mark.xfail(raises=ValueError),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,15 +18,15 @@ from audformat import define
         # empty
         (
             [],
-            pd.Series([], audformat.filewise_index()),
+            pd.Series([], audformat.filewise_index(), dtype='object'),
         ),
         (
-            [pd.Series([], audformat.filewise_index())],
-            pd.Series([], audformat.filewise_index())
+            [pd.Series([], audformat.filewise_index(), dtype='object')],
+            pd.Series([], audformat.filewise_index(), dtype='object')
         ),
         (
-            [pd.Series([], audformat.segmented_index())],
-            pd.Series([], audformat.segmented_index())
+            [pd.Series([], audformat.segmented_index(), dtype='object')],
+            pd.Series([], audformat.segmented_index(), dtype='object')
         ),
         # combine series with same name
         (
@@ -52,25 +52,6 @@ from audformat import define
         ),
         (
             [
-                pd.Series(
-                    [1, 2],
-                    audformat.filewise_index(['f1', 'f2']),
-                    dtype='int64',  # will be converted to Int64
-                ),
-                pd.Series(
-                    [1, 2],
-                    audformat.filewise_index(['f1', 'f2']),
-                    dtype='Int64',
-                ),
-            ],
-            pd.Series(
-                [1, 2],
-                audformat.filewise_index(['f1', 'f2']),
-                dtype='Int64',
-            ),
-        ),
-        (
-            [
                 pd.Series([1.], audformat.segmented_index(['f1'])),
                 pd.Series([2.], audformat.segmented_index(['f2'])),
             ],
@@ -83,7 +64,7 @@ from audformat import define
             ],
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
         ),
-        # combine same location
+        # combine values in same location
         (
             [
                 pd.Series([np.nan], audformat.filewise_index(['f1'])),
@@ -104,6 +85,106 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index(['f1'])),
             ],
             pd.Series([1.], audformat.filewise_index(['f1'])),
+        ),
+        # combine values with matching dtype
+        (
+            [
+                pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
+                pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
+            ],
+            pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
+        ),
+        (
+            [
+                pd.Series(
+                    [1, 2],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='int64',
+                ),
+                pd.Series(
+                    [1, 2],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='Int64',
+                ),
+            ],
+            pd.Series(
+                [1, 2],
+                audformat.filewise_index(['f1', 'f2']),
+                dtype='Int64',
+            ),
+        ),
+        (
+            [
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='float32',
+                ),
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='float64',
+                ),
+            ],
+            pd.Series(
+                [1., 2.],
+                audformat.filewise_index(['f1', 'f2']),
+                dtype='float64',
+            ),
+        ),
+        (
+            [
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='float32',
+                ),
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    dtype='float64',
+                ),
+            ],
+            pd.Series(
+                [1., 2.],
+                audformat.filewise_index(['f1', 'f2']),
+                dtype='float64',
+            ),
+        ),
+        (
+            [
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                ),
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                ),
+            ],
+            pd.Series(
+                ['a', 'b', 'a'],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+            )
+        ),
+        (
+            [
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+            ],
+            pd.Series(
+                ['a', 'b', 'a'],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                dtype='category',
+            )
         ),
         # combine series with different names
         (
@@ -177,7 +258,7 @@ from audformat import define
                 audformat.segmented_index(['f1', 'f2', 'f3']),
             ),
         ),
-        # dtype does not match
+        # error: dtypes do not match
         pytest.param(
             [
                 pd.Series([1], audformat.filewise_index(['f1'])),
@@ -186,7 +267,53 @@ from audformat import define
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        # values do not match
+        pytest.param(
+            [
+                pd.Series(
+                    [1, 2, 3],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                ),
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                ),
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [
+                pd.Series(
+                    ['a', 'b', 'a'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+                pd.Series(
+                    ['a', 'b', 'c'],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    dtype='category',
+                ),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        # error: values do not match
         pytest.param(
             [
                 pd.Series([1.], audformat.filewise_index(['f1'])),


### PR DESCRIPTION
Closes #46 

The implementation of `Table.__add__()` is now much simpler as it relies mainly on  `utils.concat()`. And `utils.concat()` got simpler as it now uses `utils.union()` to create the combined index and  `utils.intersect()` to test for overlapping data.

Note, that `utils.concat()` now behaves like `Table.__add__()`, i.e. it is will raise an error if two columns with the same name have different values in the same position unless one of the values is `NaN`. In the old implementation it would also raise an error for matching values, i.e. always one value had to be `NaN`. I think the new implementation makes more sense as it allows to update table with another table that has new, but also some old data.

### Examples

```python
obj1 = pd.Series(
    [1., 2., 3.],
    index=audformat.filewise_index(['f1', 'f2', 'f3']),
    name='float',
)
print(obj1)

obj2 = pd.DataFrame(
    {
        'float': [2., np.nan, 4.],
        'string': ['b', 'c', 'd'],
    },
    index=audformat.segmented_index(['f2', 'f3', 'f4']),
)
print(obj2)

obj3 = audformat.utils.concat([obj1, obj2])
print(obj3)
```
```
file
f1    1.0
f2    2.0
f3    3.0
Name: float, dtype: float64
                 float string
file start  end              
f2   0 days NaT    2.0      b
f3   0 days NaT    NaN      c
f4   0 days NaT    4.0      d
                 float string
file start  end              
f1   0 days NaT    1.0    NaN   # missing values in second column are filled with NaN
f2   0 days NaT    2.0      b   # ok, since obj1 and obj2 match in first column
f3   0 days NaT    3.0      c   # ok, since obj2 has NaN in first column
f4   0 days NaT    4.0      d
```

Value mismatch:

```python
obj2 = pd.DataFrame(
    {
        'float': [2., -1., 4.],
        'string': ['b', 'c', 'd'],
    },
    index=audformat.segmented_index(['f2', 'f3', 'f4']),
)

try:
    audformat.utils.concat([obj1, obj2])
except ValueError as ex:
    print(ex)
```
```
Found overlapping data:
                 left  right
file start  end             
f3   0 days NaT   3.0   -1.0
```

Type mismatch:

```python
obj2 = pd.DataFrame(
    {
        'float': ['b', 'c', 'd'],
    },
    index=audformat.segmented_index(['f2', 'f3', 'f4']),
)

try:
    audformat.utils.concat([obj1, obj2])
except ValueError as ex:
    print(ex)
```
```
Found two columns with name 'float' buf different dtypes 'float64' and 'object'.
```