### PR TITLE
Table.__add__ does not assign result to Database

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -762,36 +762,13 @@ class Table(HeaderBase):
             ValueError: if values in the same position do not match
 
         """
-        if self == other:
-            return self
-
-        # concatenate table data
         df = utils.concat([self._df, other._df])
         if isinstance(df, pd.Series):
             df = df.to_frame()
 
-        # create table
-        media_id = self.media_id if self.media_id == other.media_id else None
-        split_id = self.split_id if self.split_id == other.split_id else None
-        table = Table(df.index, media_id=media_id, split_id=split_id)
-        table._db = self._db
-
-        # add columns
-        scheme_ids = {}
-        rater_ids = {}
-        for column_id, column in self.columns.items():
-            scheme_ids[column_id] = column.scheme_id
-            rater_ids[column_id] = column.rater_id
-        for column_id, column in other.columns.items():
-            scheme_ids[column_id] = column.scheme_id
-            rater_ids[column_id] = column.rater_id
+        table = Table(df.index)
         for column_id in df:
-            table[column_id] = Column(
-                scheme_id=scheme_ids[column_id],
-                rater_id=rater_ids[column_id],
-            )
-
-        # set table data
+            table[column_id] = Column()
         table._df = df
 
         return table

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -489,8 +489,6 @@ def to_segmented_index(
     """
     if index_type(obj) == define.IndexType.SEGMENTED:
         return obj
-    elif obj.empty:
-        return segmented_index()
 
     if isinstance(obj, (pd.Series, pd.DataFrame)):
         index = obj.index

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -34,6 +34,24 @@ def test_with_data(tmpdir):
     assert db['files'] == db3['files']
     assert db['files']['string'] == db3['files']['string']
 
+    # compare with db that has different table values
+
+    db.save(tmpdir)
+    db4 = audformat.Database.load(tmpdir)
+    db4['files'].df['string'][0] = 'Believe me, I am special!'
+
+    assert db != db4
+    assert db['files'] != db4['files']
+
+    # compare with db that has different table meta
+
+    db.save(tmpdir)
+    db5 = audformat.Database.load(tmpdir)
+    db5['files'].description = 'Believe me, I am special!'
+
+    assert db != db5
+    assert db['files'] != db5['files']
+
     # compare with column that has no data
 
     c_no_data = audformat.Column(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -67,7 +67,7 @@ def test_access():
                 )
             ),
         ),
-        # empty + content
+        # content + empty
         (
             [
                 create_table(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -90,6 +90,7 @@ def test_access():
                 )
             ),
         ),
+        # empty + content
         (
             [
                 create_table(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -59,6 +59,23 @@ def test_access():
                         dtype=float,
                     )
                 ),
+            ] * 3,
+            create_table(
+                pd.Series(
+                    index=audformat.filewise_index(),
+                    dtype=float,
+                )
+            ),
+        ),
+        # empty + content
+        (
+            [
+                create_table(
+                    pd.Series(
+                        [1.],
+                        index=audformat.filewise_index('f1'),
+                    )
+                ),
                 create_table(
                     pd.Series(
                         index=audformat.filewise_index(),
@@ -68,8 +85,30 @@ def test_access():
             ],
             create_table(
                 pd.Series(
-                    index=audformat.filewise_index(),
-                    dtype=float,
+                    [1.],
+                    index=audformat.filewise_index('f1'),
+                )
+            ),
+        ),
+        (
+            [
+                create_table(
+                    pd.Series(
+                        index=audformat.filewise_index(),
+                        dtype=float,
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [1.],
+                        index=audformat.filewise_index('f1'),
+                    )
+                ),
+            ],
+            create_table(
+                pd.Series(
+                    [1.],
+                    index=audformat.filewise_index('f1'),
                 )
             ),
         ),
@@ -113,14 +152,20 @@ def test_access():
             [
                 create_table(
                     pd.Series(
-                        [1., 2., np.nan],
-                        index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                        [1., np.nan],
+                        index=audformat.filewise_index(['f1', 'f2']),
                     )
                 ),
                 create_table(
                     pd.Series(
-                        [2., 3., 4.],
-                        index=audformat.filewise_index(['f2', 'f3', 'f4']),
+                        [2., 3.],
+                        index=audformat.filewise_index(['f2', 'f3']),
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [3., 4.],
+                        index=audformat.filewise_index(['f3', 'f4']),
                     )
                 ),
             ],

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -8,6 +10,20 @@ import audformat
 import audformat.testing
 
 
+def create_table(
+        obj: typing.Union[pd.Series, pd.DataFrame],
+) -> audformat.Table:
+    r"""Helper function to create Table."""
+    table = audformat.Table(obj.index)
+    if isinstance(obj, pd.Series):
+        obj = obj.to_frame()
+    for name in obj:
+        table[name] = audformat.Column()
+        table[name].set(obj[name].values)
+    table._df = table.df.astype(obj.dtypes)
+    return table
+
+
 def test_access():
     db = audformat.testing.create_db()
     for table_id in db.tables.keys():
@@ -15,7 +31,203 @@ def test_access():
         assert str(db.tables[table_id]) == str(db[table_id])
 
 
-def test_add():
+@pytest.mark.parametrize(
+    'tables, expected',
+    [
+        # empty
+        (
+            [
+                create_table(
+                    pd.Series(
+                        index=audformat.filewise_index(),
+                        dtype=float,
+                    )
+                ),
+            ],
+            create_table(
+                pd.Series(
+                    index=audformat.filewise_index(),
+                    dtype=float,
+                )
+            ),
+        ),
+        (
+            [
+                create_table(
+                    pd.Series(
+                        index=audformat.filewise_index(),
+                        dtype=float,
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        index=audformat.filewise_index(),
+                        dtype=float,
+                    )
+                ),
+            ],
+            create_table(
+                pd.Series(
+                    index=audformat.filewise_index(),
+                    dtype=float,
+                )
+            ),
+        ),
+        # filewise + segmented
+        (
+            [
+                create_table(
+                    pd.Series(
+                        index=audformat.filewise_index(),
+                        dtype=float,
+                        name='c1',
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        index=audformat.segmented_index(),
+                        dtype=float,
+                        name='c2',
+                    )
+                ),
+            ],
+            create_table(
+                pd.DataFrame(
+                    {
+                        'c1': pd.Series(
+                            index=audformat.segmented_index(),
+                            dtype=float,
+                            name='c1',
+                        ),
+                        'c2': pd.Series(
+                            index=audformat.segmented_index(),
+                            dtype=float,
+                            name='c2',
+                        )
+                    },
+                )
+            ),
+        ),
+        # same column
+        (
+            [
+                create_table(
+                    pd.Series(
+                        [1., 2., np.nan],
+                        index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [2., 3., 4.],
+                        index=audformat.filewise_index(['f2', 'f3', 'f4']),
+                    )
+                ),
+            ],
+            create_table(
+                pd.Series(
+                    [1., 2., 3., 4.],
+                    index=audformat.filewise_index(['f1', 'f2', 'f3', 'f4']),
+                )
+            ),
+        ),
+        pytest.param(  # value mismatch
+            [
+                create_table(
+                    pd.Series(
+                        [1.],
+                        index=audformat.filewise_index('f1'),
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [-1.],
+                        index=audformat.filewise_index('f1'),
+                    )
+                ),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        # different columns
+        (
+            [
+                create_table(
+                    pd.Series(
+                        [1., 2.],
+                        index=audformat.filewise_index(['f1', 'f2']),
+                        name='c1',
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [2., 3.],
+                        index=audformat.filewise_index(['f2', 'f3']),
+                        name='c2',
+                    )
+                ),
+            ],
+            create_table(
+                pd.DataFrame(
+                    {
+                        'c1': [1., 2., np.nan],
+                        'c2': [np.nan, 2., 3.],
+                    },
+                    index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                )
+            ),
+        ),
+        # filewise + segmented
+        (
+            [
+                create_table(
+                    pd.Series(
+                        [1.],
+                        index=audformat.filewise_index('f1'),
+                    )
+                ),
+                create_table(
+                    pd.Series(
+                        [1.],
+                        index=audformat.segmented_index('f1', 0, 1),
+                    )
+                ),
+            ],
+            create_table(
+                pd.Series(
+                    [1., 1.],
+                    index=audformat.segmented_index(
+                        ['f1', 'f1'],
+                        [0, 0],
+                        [None, 1],
+                    ),
+                )
+            ),
+        ),
+        (
+            [
+                pytest.DB['files'],
+                pytest.DB['segments'],
+            ],
+            create_table(
+                audformat.utils.concat(
+                    [
+                        pytest.DB['files'].df,
+                        pytest.DB['segments'].df,
+                    ]
+                )
+            )
+        )
+    ]
+)
+def test_add(tables, expected):
+    table = tables[0]
+    for other in tables[1:]:
+        table += other
+    assert table == expected
+
+
+def test_add_2():  # TODO: turn into test_update()
 
     db = audformat.testing.create_db(minimal=True)
     db.media['media'] = audformat.Media()
@@ -36,17 +248,17 @@ def test_add():
         db['table'].files,
         db['table1'].files.union(db['table2'].files)
     )
-    for column in db['table'].columns:
-        assert column.rater_id is None
-        assert column.scheme_id is None
     assert db['table'].media_id is None
     assert db['table'].split_id is None
+    for column in db['table'].columns:
+        assert column.scheme_id is None
+        assert column.rater_id is None
 
     # add table to itself
 
     pd.testing.assert_frame_equal(
-        (db['table1'] + db['table1']).get(),
-        db['table1'].get(),
+        (db['table1'] + db['table1']).df,
+        db['table1'].df,
     )
 
     # add two schemes

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -8,7 +8,7 @@ import audformat
 import audformat.testing
 
 
-def test_table_access():
+def test_access():
     db = audformat.testing.create_db()
     for table_id in db.tables.keys():
         assert db.tables[table_id] == db[table_id]
@@ -36,12 +36,18 @@ def test_add():
         db['table'].files,
         db['table1'].files.union(db['table2'].files)
     )
-    assert db['table'].media_id == 'media'
+    for column in db['table'].columns:
+        assert column.rater_id is None
+        assert column.scheme_id is None
+    assert db['table'].media_id is None
     assert db['table'].split_id is None
 
     # add table to itself
 
-    assert db['table1'] + db['table1'] == db['table1']
+    pd.testing.assert_frame_equal(
+        (db['table1'] + db['table1']).get(),
+        db['table1'].get(),
+    )
 
     # add two schemes
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -661,12 +661,18 @@ def test_read_csv(csv, result):
 def test_to_segmented_index(table_id):
 
     # empty case
-    for index in [audformat.filewise_index(), audformat.segmented_index()]:
-        assert audformat.index_type(
-            audformat.utils.to_segmented_index(
-                index
-            )
-        ) == audformat.define.IndexType.SEGMENTED
+    for obj in [
+        audformat.filewise_index(),
+        audformat.segmented_index(),
+        pd.Series(
+            index=audformat.filewise_index(),
+            dtype=float,
+        )
+    ]:
+        obj_segmented = audformat.utils.to_segmented_index(obj)
+        assert isinstance(obj_segmented, type(obj))
+        assert audformat.index_type(obj_segmented)\
+               == audformat.define.IndexType.SEGMENTED
 
     # non-empty case
     for column_id, column in pytest.DB[table_id].get().items():


### PR DESCRIPTION
Relates to #48 

Since the result of `+` is not assigned to a `Database` object, the following now works:

```python
db1 = audformat.testing.create_db(minimal=True)
db1.schemes['int'] = audformat.Scheme(int)
audformat.testing.add_table(db1, 'table', 'filewise')

db2 = audformat.testing.create_db(minimal=True)
db2.schemes['str'] = audformat.Scheme(str)
audformat.testing.add_table(db2, 'table', 'filewise')

(db1['table'] + db2['table']).get()
```
```
               int         str
file                          
audio/001.wav   22  5rIopnlMaW
audio/002.wav   66  O5UXXBIQmL
audio/003.wav   56  LDEXtoA1Yo
audio/004.wav   10  VyaeKKbuuX
audio/005.wav   83  SJpIxbNsIm
```

Also fixes a bug in `utils.to_segmented_index()` if an empty `pd.Series` or `pd.DataFrame` is passed - before the result was a `pd.Index` in that case. An according test to cover this case is added to `test_utils`.
