### PR TITLE
Add overwrite argument to utils.concat()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -174,7 +174,8 @@ def concat(
                             if len(overlap) > max_display \
                             else ''
                         raise ValueError(
-                            'Found overlapping data:\n'
+                            "Found overlapping data in column "
+                            f"'{column.name}':\n"
                             f"{msg_overlap}{msg_tail}"
                         )
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -81,14 +81,14 @@ def concat(
         ...         'float': [np.nan, 2.],
         ...         'string': ['a', 'b'],
         ...     },
-        ...     index=segmented_index(['f2', 'f3']),
+        ...     index=filewise_index(['f2', 'f3']),
         ... )
         >>> concat([obj1, obj2])
-                         float string
-        file start  end
-        f1   0 days NaT    0.0    NaN
-        f2   0 days NaT    1.0      a
-        f3   0 days NaT    2.0      b
+              float string
+        file
+        f1      0.0    NaN
+        f2      1.0      a
+        f3      2.0      b
         >>> obj1 = pd.Series(
         ...     [0., 0.],
         ...     index=filewise_index(['f1', 'f2']),

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -32,9 +32,11 @@ def concat(
 
     Columns with the same identifier are combined to a single column.
     This requires that both columns have the same dtype
-    and unless ``overwrite`` is set to ``True``,
+    and if ``overwrite`` is set to ``False``,
     values in places where the indices overlap have to match
     or one column contains ``NaN``.
+    If ``overwrite`` is set to ``True``,
+    the value of the last object in the list is kept.
 
     Args:
         objs: objects conform to
@@ -70,13 +72,13 @@ def concat(
         f2   0 days NaT    1.0      a
         f3   0 days NaT    2.0      b
         >>> obj1 = pd.Series(
-        ...     [0., np.nan],
+        ...     [0., 1.],
         ...     index=filewise_index(['f1', 'f2']),
         ...     name='float',
         ... )
         >>> obj2 = pd.DataFrame(
         ...     {
-        ...         'float': [1., 2.],
+        ...         'float': [np.nan, 2.],
         ...         'string': ['a', 'b'],
         ...     },
         ...     index=segmented_index(['f2', 'f3']),

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -18,6 +18,8 @@ from audformat.core.index import (
 
 def concat(
         objs: typing.Sequence[typing.Union[pd.Series, pd.DataFrame]],
+        *,
+        overwrite: bool = False,
 ) -> typing.Union[pd.Series, pd.DataFrame]:
     r"""Concatenate objects.
 
@@ -29,15 +31,15 @@ def concat(
     If at least one object is segmented, the output has a segmented index.
 
     Columns with the same identifier are combined to a single column.
-    This requires that:
-
-    1. both columns have the same dtype
-    2. in places where the indices overlap the values of both columns
-       match or one column contains ``NaN``
+    This requires that both columns have the same dtype
+    and unless ``overwrite`` is set to ``True``,
+    values in places where the indices overlap have to match
+    or one column contains ``NaN``.
 
     Args:
         objs: objects conform to
             :ref:`table specifications <data-tables:Tables>`
+        overwrite: overwrite values where indices overlap
 
     Returns:
         concatenated objects
@@ -62,6 +64,42 @@ def concat(
         ...     index=segmented_index(['f2', 'f3']),
         ... )
         >>> concat([obj1, obj2])
+                         float string
+        file start  end
+        f1   0 days NaT    0.0    NaN
+        f2   0 days NaT    1.0      a
+        f3   0 days NaT    2.0      b
+        >>> obj1 = pd.Series(
+        ...     [0., np.nan],
+        ...     index=filewise_index(['f1', 'f2']),
+        ...     name='float',
+        ... )
+        >>> obj2 = pd.DataFrame(
+        ...     {
+        ...         'float': [1., 2.],
+        ...         'string': ['a', 'b'],
+        ...     },
+        ...     index=segmented_index(['f2', 'f3']),
+        ... )
+        >>> concat([obj1, obj2])
+                         float string
+        file start  end
+        f1   0 days NaT    0.0    NaN
+        f2   0 days NaT    1.0      a
+        f3   0 days NaT    2.0      b
+        >>> obj1 = pd.Series(
+        ...     [0., 0.],
+        ...     index=filewise_index(['f1', 'f2']),
+        ...     name='float',
+        ... )
+        >>> obj2 = pd.DataFrame(
+        ...     {
+        ...         'float': [1., 2.],
+        ...         'string': ['a', 'b'],
+        ...     },
+        ...     index=segmented_index(['f2', 'f3']),
+        ... )
+        >>> concat([obj1, obj2], overwrite=True)
                          float string
         file start  end
         f1   0 days NaT    0.0    NaN
@@ -110,30 +148,33 @@ def concat(
                 )
 
             # overlapping values must match or have to be nan in one column
-            intersection = intersect(
-                [
-                    columns_reindex[column.name].index,
-                    column.index,
-                ]
-            )
-            if not intersection.empty:
-                combine = pd.DataFrame(
-                    {
-                        'left': columns_reindex[column.name][intersection],
-                        'right': column[intersection]
-                    }
+            if not overwrite:
+                intersection = intersect(
+                    [
+                        columns_reindex[column.name].index,
+                        column.index,
+                    ]
                 )
-                combine.dropna(inplace=True)
-                differ = combine['left'] != combine['right']
-                if np.any(differ):
-                    max_display = 10
-                    overlap = combine[differ]
-                    msg_overlap = str(overlap[:max_display])
-                    msg_tail = '\n...' if len(overlap) > max_display else ''
-                    raise ValueError(
-                        'Found overlapping data:\n'
-                        f"{msg_overlap}{msg_tail}"
+                if not intersection.empty:
+                    combine = pd.DataFrame(
+                        {
+                            'left': columns_reindex[column.name][intersection],
+                            'right': column[intersection]
+                        }
                     )
+                    combine.dropna(inplace=True)
+                    differ = combine['left'] != combine['right']
+                    if np.any(differ):
+                        max_display = 10
+                        overlap = combine[differ]
+                        msg_overlap = str(overlap[:max_display])
+                        msg_tail = '\n...' \
+                            if len(overlap) > max_display \
+                            else ''
+                        raise ValueError(
+                            'Found overlapping data:\n'
+                            f"{msg_overlap}{msg_tail}"
+                        )
 
             # drop NaN to avoid overwriting values from other column
             column = column.dropna()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -304,10 +304,15 @@ from audformat import define
                     audformat.filewise_index(['f1', 'f2']),
                     name='c1',
                 ),
+                pd.Series(
+                    ['a', np.nan, 'd'],
+                    audformat.filewise_index(['f1', 'f2', 'f4']),
+                    name='c2',
+                ),
                 pd.DataFrame(
                     {
                         'c1': [np.nan, 3.],
-                        'c2': ['a', 'b'],
+                        'c2': ['b', 'c'],
                     },
                     audformat.segmented_index(['f2', 'f3']),
                 ),
@@ -315,10 +320,10 @@ from audformat import define
             False,
             pd.DataFrame(
                 {
-                    'c1': [1., 2., 3.],
-                    'c2': [np.nan, 'a', 'b']
+                    'c1': [1., 2., 3., np.nan],
+                    'c2': ['a', 'b', 'c', 'd']
                 },
-                audformat.segmented_index(['f1', 'f2', 'f3']),
+                audformat.segmented_index(['f1', 'f2', 'f3', 'f4']),
             ),
         ),
         # error: dtypes do not match

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,19 +13,22 @@ from audformat import define
 
 
 @pytest.mark.parametrize(
-    'objs, expected',
+    'objs, overwrite, expected',
     [
         # empty
         (
             [],
+            False,
             pd.Series([], audformat.filewise_index(), dtype='object'),
         ),
         (
             [pd.Series([], audformat.filewise_index(), dtype='object')],
+            False,
             pd.Series([], audformat.filewise_index(), dtype='object')
         ),
         (
             [pd.Series([], audformat.segmented_index(), dtype='object')],
+            False,
             pd.Series([], audformat.segmented_index(), dtype='object')
         ),
         # combine series with same name
@@ -34,6 +37,7 @@ from audformat import define
                 pd.Series([], audformat.filewise_index(), dtype=float),
                 pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
             ],
+            False,
             pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
         ),
         (
@@ -41,6 +45,7 @@ from audformat import define
                 pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
                 pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
             ],
+            False,
             pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
         ),
         (
@@ -48,6 +53,7 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([2.], audformat.filewise_index('f2')),
             ],
+            False,
             pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
         ),
         (
@@ -55,6 +61,7 @@ from audformat import define
                 pd.Series([1.], audformat.segmented_index('f1')),
                 pd.Series([2.], audformat.segmented_index('f2')),
             ],
+            False,
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
         ),
         (
@@ -62,6 +69,7 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([2.], audformat.segmented_index('f2')),
             ],
+            False,
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
         ),
         # combine values in same location
@@ -70,6 +78,7 @@ from audformat import define
                 pd.Series([np.nan], audformat.filewise_index('f1')),
                 pd.Series([np.nan], audformat.filewise_index('f1')),
             ],
+            False,
             pd.Series([np.nan], audformat.filewise_index('f1')),
         ),
         (
@@ -77,6 +86,7 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([np.nan], audformat.filewise_index('f1')),
             ],
+            False,
             pd.Series([1.], audformat.filewise_index('f1')),
         ),
         (
@@ -84,7 +94,25 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([1.], audformat.filewise_index('f1')),
             ],
+            False,
             pd.Series([1.], audformat.filewise_index('f1')),
+        ),
+        # combine series and overwrite values
+        (
+            [
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([np.nan], audformat.filewise_index('f1')),
+            ],
+            True,
+            pd.Series([1.], audformat.filewise_index('f1')),
+        ),
+        (
+            [
+                pd.Series([1.], audformat.filewise_index('f1')),
+                pd.Series([2.], audformat.filewise_index('f1')),
+            ],
+            True,
+            pd.Series([2.], audformat.filewise_index('f1')),
         ),
         # combine values with matching dtype
         (
@@ -92,6 +120,7 @@ from audformat import define
                 pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
                 pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
             ],
+            False,
             pd.Series([1, 2], audformat.filewise_index(['f1', 'f2'])),
         ),
         (
@@ -107,6 +136,7 @@ from audformat import define
                     dtype='Int64',
                 ),
             ],
+            False,
             pd.Series(
                 [1, 2],
                 audformat.filewise_index(['f1', 'f2']),
@@ -126,6 +156,7 @@ from audformat import define
                     dtype='float64',
                 ),
             ],
+            False,
             pd.Series(
                 [1., 2.],
                 audformat.filewise_index(['f1', 'f2']),
@@ -145,6 +176,7 @@ from audformat import define
                     dtype='float64',
                 ),
             ],
+            False,
             pd.Series(
                 [1., 2.],
                 audformat.filewise_index(['f1', 'f2']),
@@ -162,6 +194,7 @@ from audformat import define
                     index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 ),
             ],
+            False,
             pd.Series(
                 ['a', 'b', 'a'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
@@ -180,6 +213,7 @@ from audformat import define
                     dtype='category',
                 ),
             ],
+            False,
             pd.Series(
                 ['a', 'b', 'a'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
@@ -192,6 +226,7 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1'), name='c1'),
                 pd.Series([2.], audformat.filewise_index('f1'), name='c2'),
             ],
+            False,
             pd.DataFrame(
                 {
                     'c1': [1.],
@@ -205,6 +240,7 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1'), name='c1'),
                 pd.Series([2.], audformat.filewise_index('f2'), name='c2'),
             ],
+            False,
             pd.DataFrame(
                 {
                     'c1': [1., np.nan],
@@ -226,6 +262,7 @@ from audformat import define
                     name='c2',
                 ),
             ],
+            False,
             pd.DataFrame(
                 {
                     'c1': [1., 2.],
@@ -246,6 +283,7 @@ from audformat import define
                     name='c2',
                 ),
             ],
+            False,
             pd.DataFrame(
                 {
                     'c1': [1., np.nan],
@@ -274,6 +312,7 @@ from audformat import define
                     audformat.segmented_index(['f2', 'f3']),
                 ),
             ],
+            False,
             pd.DataFrame(
                 {
                     'c1': [1., 2., 3.],
@@ -288,6 +327,7 @@ from audformat import define
                 pd.Series([1], audformat.filewise_index('f1')),
                 pd.Series([1.], audformat.filewise_index('f1')),
             ],
+            False,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
@@ -303,6 +343,7 @@ from audformat import define
                     dtype='category',
                 ),
             ],
+            False,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
@@ -318,6 +359,7 @@ from audformat import define
                     dtype='category',
                 ),
             ],
+            False,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
@@ -334,6 +376,7 @@ from audformat import define
                     dtype='category',
                 ),
             ],
+            False,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
@@ -343,13 +386,14 @@ from audformat import define
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([2.], audformat.filewise_index('f1')),
             ],
+            False,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
     ],
 )
-def test_concat(objs, expected):
-    obj = utils.concat(objs)
+def test_concat(objs, overwrite, expected):
+    obj = utils.concat(objs, overwrite=overwrite)
     if isinstance(obj, pd.Series):
         pd.testing.assert_series_equal(obj, expected)
     else:


### PR DESCRIPTION
Relates to #48 

### Example:

```python
obj1 = pd.Series(
    [0., 0.],                 # assigns 0. to 'f2'
    index=audformat.filewise_index(['f1', 'f2']),
    name='float',
)
obj2 = pd.DataFrame(
    {
        'float': [1., 2.],    # assigns 1. to 'f2'
        'string': ['a', 'b'],
    },
    index=audformat.segmented_index(['f2', 'f3']),
)
```

Usually the following would raise an error:

```python
try:
    audformat.utils.concat([obj1, obj2])
except Exception as ex:
    print(ex)
```
```
Found overlapping data:
                 left  right
file start  end             
f2   0 days NaT   0.0    1.0
```

But with `overwrite=True` it gives:

```python
audformat.utils.concat([obj1, obj2], overwrite=True)
```
```
                 float string
file start  end              
f1   0 days NaT    0.0    NaN
f2   0 days NaT    1.0      a
f3   0 days NaT    2.0      b
```



