### PR TITLE
Add Table.update()

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -1,3 +1,5 @@
+import typing
+
 import numpy as np
 import pandas as pd
 
@@ -8,6 +10,7 @@ from audformat.core.index import (
     is_scalar,
     to_array,
 )
+from audformat.core.rater import Rater
 from audformat.core.scheme import Scheme
 from audformat.core.typing import Values
 
@@ -80,6 +83,38 @@ class Column(HeaderBase):
         r"""Rater identifier"""
         self._table = None
         self._id = None
+
+    @property
+    def rater(self) -> typing.Optional[Rater]:
+        r"""Rater object.
+
+        Returns:
+            rater object or ``None`` if not assigned yet
+
+        """
+        if self.rater_id is not None and self.table and self.table.db:
+            return self.table.db.raters[self.rater_id]
+
+    @property
+    def scheme(self) -> typing.Optional[Scheme]:
+        r"""Scheme object.
+
+        Returns:
+            scheme object or ``None`` if not assigned yet
+
+        """
+        if self.scheme_id is not None and self.table and self.table.db:
+            return self.table.db.schemes[self.scheme_id]
+
+    @property
+    def table(self):
+        r"""Table object.
+
+        Returns:
+            table object or ``None`` if not assigned yet
+
+        """
+        return self._table
 
     def get(
             self,

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -89,7 +89,7 @@ class Column(HeaderBase):
         r"""Rater object.
 
         Returns:
-            rater object or ``None`` if not assigned yet
+            rater object or ``None`` if not available
 
         """
         if self.rater_id is not None and self.table and self.table.db:
@@ -100,7 +100,7 @@ class Column(HeaderBase):
         r"""Scheme object.
 
         Returns:
-            scheme object or ``None`` if not assigned yet
+            scheme object or ``None`` if not available
 
         """
         if self.scheme_id is not None and self.table and self.table.db:

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -92,7 +92,13 @@ class Column(HeaderBase):
             rater object or ``None`` if not available
 
         """
-        if self.rater_id is not None and self.table and self.table.db:
+        if (
+                self.rater_id is not None
+        ) and (
+                self.table is not None
+        ) and (
+                self.table.db is not None
+        ):
             return self.table.db.raters[self.rater_id]
 
     @property
@@ -103,7 +109,13 @@ class Column(HeaderBase):
             scheme object or ``None`` if not available
 
         """
-        if self.scheme_id is not None and self.table and self.table.db:
+        if (
+                self.scheme_id is not None
+        ) and (
+                self.table is not None
+        ) and (
+                self.table.db is not None
+        ):
             return self.table.db.schemes[self.scheme_id]
 
     @property

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -581,8 +581,6 @@ class Table(HeaderBase):
                     os.path.exists(csv_file)
                     and os.path.getmtime(csv_file) > os.path.getmtime(pkl_file)
             ):
-                print('CSV time:', os.path.getmtime(csv_file))
-                print('PKL time:', os.path.getmtime(pkl_file))
                 raise RuntimeError(
                     f"The table CSV file '{csv_file}' is newer "
                     f"than the table PKL file '{pkl_file}'. "

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -792,14 +792,41 @@ class Table(HeaderBase):
         #       https://github.com/audeering/audformat/pull/51
         df = utils.concat([self._df, other._df])
 
-        # assert that schemes and raters match for overlapping columns and
-        # look for missing schemes and raters in new columns,
-        # raise an error if a different scheme or rater with same ID exists
+        # assert media matches
+        mismatch = False
+        if self.media and other.media:
+            mismatch = self.media == other.media
+        elif self.media or other.media:
+            mismatch = True
+        if mismatch:
+            raise ValueError(
+                    "Cannot update table, "
+                    "media does not match:\n"
+                    f"{self.media}\n"
+                    "!=\n"
+                    f"{other.media}."
+                )
+
+        # assert split matches
+        mismatch = False
+        if self.split and other.split:
+            mismatch = self.split == other.split
+        elif self.split or other.split:
+            mismatch = True
+        if mismatch:
+            raise ValueError(
+                    "Cannot update table, "
+                    "split does not match:\n"
+                    f"{self.split}\n"
+                    "!=\n"
+                    f"{other.split}."
+                )
+
+        # assert schemes match for overlapping columns and
+        # look for missing schemes in new columns,
+        # raise an error if a different scheme with same ID exists
         missing_schemes = {}
-        missing_raters = {}
-        
         for column_id, column in other.columns.items():
-            
             if column_id in self.columns:
                 mismatch = False           
                 scheme = self.columns[column_id].scheme                
@@ -833,6 +860,11 @@ class Table(HeaderBase):
                     else:
                         missing_schemes[column.scheme_id] = column.scheme
 
+        # assert raters match for overlapping columns and
+        # look for missing raters in new columns,
+        # raise an error if a different rater with same ID exists
+        missing_raters = {}
+        for column_id, column in other.columns.items():
             if column_id in self.columns:
                 mismatch = False           
                 rater = self.columns[column_id].rater                

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -793,12 +793,12 @@ class Table(HeaderBase):
             mismatch = True
         if mismatch:
             raise ValueError(
-                    "Cannot update table, "
-                    "media does not match:\n"
-                    f"{self.media}\n"
-                    "!=\n"
-                    f"{other.media}."
-                )
+                "Cannot update table, "
+                "media does not match:\n"
+                f"{self.media}\n"
+                "!=\n"
+                f"{other.media}."
+            )
 
         # assert split matches
         mismatch = False
@@ -808,12 +808,12 @@ class Table(HeaderBase):
             mismatch = True
         if mismatch:
             raise ValueError(
-                    "Cannot update table, "
-                    "split does not match:\n"
-                    f"{self.split}\n"
-                    "!=\n"
-                    f"{other.split}."
-                )
+                "Cannot update table, "
+                "split does not match:\n"
+                f"{self.split}\n"
+                "!=\n"
+                f"{other.split}."
+            )
 
         # assert schemes match for overlapping columns and
         # look for missing schemes in new columns,
@@ -821,17 +821,17 @@ class Table(HeaderBase):
         missing_schemes = {}
         for column_id, column in other.columns.items():
             if column_id in self.columns:
-                mismatch = False           
-                scheme = self.columns[column_id].scheme                
-                if column.scheme and scheme:                    
+                mismatch = False
+                scheme = self.columns[column_id].scheme
+                if column.scheme and scheme:
                     mismatch = column.scheme != scheme
                 elif column.scheme or scheme:
-                    mismatch = True 
+                    mismatch = True
                 if mismatch:
                     raise ValueError(
                         "Cannot update table, "
                         "schemes do not match for column "
-                        f"'{column_id}':\n"                        
+                        f"'{column_id}':\n"
                         f"{scheme}\n"
                         "!=\n"
                         f"{column.scheme}."
@@ -859,17 +859,17 @@ class Table(HeaderBase):
         missing_raters = {}
         for column_id, column in other.columns.items():
             if column_id in self.columns:
-                mismatch = False           
-                rater = self.columns[column_id].rater                
-                if column.rater and rater:                    
+                mismatch = False
+                rater = self.columns[column_id].rater
+                if column.rater and rater:
                     mismatch = column.rater != rater
                 elif column.rater or rater:
-                    mismatch = True 
+                    mismatch = True
                 if mismatch:
                     raise ValueError(
                         "Cannot update table, "
                         "raters do not match for column "
-                        f"'{column_id}':\n"                        
+                        f"'{column_id}':\n"
                         f"{rater}\n"
                         "!=\n"
                         f"{column.rater}"
@@ -905,7 +905,7 @@ class Table(HeaderBase):
         # insert new columns
         for column_id, column in other.columns.items():
             if column_id not in self.columns:
-                self.columns[column_id] = copy.copy(column)                
+                self.columns[column_id] = copy.copy(column)
 
         # update table data
         self._df = df

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1,8 +1,7 @@
-from collections.abc import Iterable
+import copy
 import os
 import typing
 
-import numpy as np
 import pandas as pd
 
 import audeer
@@ -737,6 +736,79 @@ class Table(HeaderBase):
         for idx, data in values.items():
             self.columns[idx].set(data, index=index)
 
+    def update(
+            self,
+            other: typing.Union['Table', typing.Sequence['Table']],
+    ):  # pragma: no cover
+        # TODO: add tests
+
+        if not isinstance(other, Table):
+            for o in other:
+                self.update(o)
+            return
+
+        # concatenate table data
+        # TODO: set overwrite=True or at least add option for it
+        #       https://github.com/audeering/audformat/pull/51
+        df = utils.concat([self._df, other._df])
+
+        # find missing schemes and raters,
+        # raise error for different objects with same ID
+        missing_schemes = {}
+        missing_raters = {}
+        if self._db is not None:
+            for column_id, column in other.columns.items():
+                if column_id not in self.columns:
+                    if column.scheme_id is not None:
+                        other_scheme = other._db.schemes[column.scheme_id]
+                        if column.scheme_id in self._db.schemes:
+                            self_scheme = self._db.schemes[column.scheme_id]
+                            if other_scheme != self_scheme:
+                                raise ValueError(
+                                    "Cannot update table, "
+                                    "found different schemes with same ID "
+                                    f"'{column.scheme_id}':"
+                                    f"{self_scheme}\n"
+                                    "!=\n"
+                                    f"{other_scheme}."
+                                )
+                        else:
+                            missing_schemes[column.scheme_id] = other_scheme
+                    if column.rater_id is not None:
+                        other_rater = other._db.raters[column.rater_id]
+                        if column.rater_id in self._db.raters:
+                            self_rater = self._db.raters[column.rater_id]
+                            if other_rater != self_rater:
+                                raise ValueError(
+                                    "Cannot update table, "
+                                    "found different raters with same ID "
+                                    f"'{column.rater_id}':\n"
+                                    f"{self_rater}\n"
+                                    "!=\n"
+                                    f"{other_rater}."
+                                )
+                        else:
+                            missing_raters[column.rater_id] = other_rater
+
+        # insert missing schemes and raters
+        for scheme_id, scheme in missing_schemes.items():
+            self._db.schemes[scheme_id] = copy.copy(scheme)
+        for rater_id, rater in missing_raters.items():
+            self._db.raters[rater_id] = copy.copy(rater)
+
+        # insert new columns
+        for column_id, column in other.columns.items():
+            if column_id not in self.columns:
+                self.columns[column_id] = copy.copy(column)
+                if self._db is None:
+                    # if table is not assigned to a database,
+                    # set scheme_id and rater_id to None
+                    self.columns[column_id].scheme_id = None
+                    self.columns[column_id].rater_id = None
+
+        # update table data
+        self._df = df
+
     def __add__(self, other: 'Table') -> 'Table':
         r"""Create new table by combining two tables.
 
@@ -751,8 +823,11 @@ class Table(HeaderBase):
         2. in places where the indices overlap the values of both columns
            match or one column contains ``NaN``
 
-        References to schemes and raters are always preserved.
-        Media and split information only when they match.
+        Media and split information,
+        as well as,
+        references to schemes and raters are discarded.
+        If you would like to keep them,
+        use :meth:`audformat.Table.update` instead.
 
         Args:
             other: the other table

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -18,9 +18,10 @@ from audformat.core.errors import (
 )
 from audformat.core.index import (
     filewise_index,
-    segmented_index,
     index_type,
 )
+from audformat.core.media import Media
+from audformat.core.split import Split
 from audformat.core.typing import (
     Values,
 )
@@ -153,6 +154,16 @@ class Table(HeaderBase):
         self._id = None
 
     @property
+    def db(self):
+        r"""Database object.
+
+        Returns:
+            database object or ``None`` if not assigned yet
+
+        """
+        return self._db
+
+    @property
     def df(self) -> pd.DataFrame:
         r"""Table data.
 
@@ -223,6 +234,18 @@ class Table(HeaderBase):
 
         """
         return self.type == define.IndexType.SEGMENTED
+
+    @property
+    def media(self) -> typing.Optional[Media]:
+        r"""Media object."""
+        if self.media_id is not None and self._db:
+            return self._db.media[self.media_id]
+
+    @property
+    def split(self) -> typing.Optional[Split]:
+        r"""Split object."""
+        if self.split_id is not None and self._db:
+            return self._db.splits[self.split_id]
 
     @property
     def starts(self) -> pd.Index:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -817,6 +817,16 @@ class Table(HeaderBase):
         if isinstance(others, Table):
             others = [others]
 
+        for other in others:
+            if self.type != other.type:
+                raise ValueError(
+                    'Cannot update a '
+                    f'{self.type} '
+                    'table with a '
+                    f'{other.type} '
+                    'table.'
+                )
+
         def raise_error(
                 msg,
                 left: typing.Optional[HeaderDict],
@@ -922,11 +932,6 @@ class Table(HeaderBase):
         )
         if isinstance(df, pd.Series):
             df = df.to_frame()
-
-        if self.type != index_type(df):
-            raise ValueError(
-                'Index type of the table must not change.'
-            )
 
         # insert missing schemes and raters
         for scheme_id, scheme in missing_schemes.items():

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -791,6 +791,8 @@ class Table(HeaderBase):
         # TODO: set overwrite=True or at least add option for it
         #       https://github.com/audeering/audformat/pull/51
         df = utils.concat([self._df, other._df])
+        if isinstance(df, pd.Series):
+            df = df.to_frame()
 
         # assert media matches
         mismatch = False

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -880,7 +880,7 @@ class Table(HeaderBase):
                         if column.scheme_id in self.db.schemes:
                             assert_equal(
                                 "Cannot copy scheme of column "
-                                f"'{other._id}.{column_id}' "                         
+                                f"'{other._id}.{column_id}' "
                                 "as a different scheme with ID "
                                 f"'{column.scheme_id}' "
                                 "exists",
@@ -897,7 +897,7 @@ class Table(HeaderBase):
                 if column_id in self.columns:
                     assert_equal(
                         f"self['{self._id}']['{column_id}'].rater "
-                        "does not match "                    
+                        "does not match "
                         f"other['{other._id}']['{column_id}'].rater",
                         self.columns[column_id].rater,
                         column.rater,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -775,11 +775,11 @@ class Table(HeaderBase):
         r"""Update table with other table(s).
 
         Table which calls ``update()`` must be assigned to a database.
+        For all tables media and split must match.
 
         Columns that are not yet part of the table will be added and
         referenced schemes or raters are copied.
         For overlapping columns, schemes and raters must match.
-        This also holds if table is assigned to a media or split.
 
         Columns with the same identifier are combined to a single column.
         This requires that both columns have the same dtype

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -139,14 +139,19 @@ def concat(
             if not same_dtype(
                     columns_reindex[column.name].dtype, column.dtype
             ):
-                # use repr() to print category names
+                dtype_1 = columns_reindex[column.name].dtype
+                if dtype_1.name == 'category':
+                    dtype_1 = repr(dtype_1)
+                dtype_2 = column.dtype
+                if dtype_2.name == 'category':
+                    dtype_2 = repr(dtype_2)
                 raise ValueError(
-                    'Found two columns with name '
+                    "Found two columns with name "
                     f"'{column.name}' "
-                    'buf different dtypes '
-                    f"'{repr(columns_reindex[column.name].dtype)}' "
-                    'and '
-                    f"'{repr(column.dtype)}'."
+                    "buf different dtypes:\n"
+                    f"{dtype_1} "
+                    "!= "
+                    f"{dtype_2}."
                 )
 
             # overlapping values must match or have to be nan in one column

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -84,3 +84,47 @@ Which results in the following :class:`pandas.DataFrame`:
 .. jupyter-execute::
 
     df_age
+
+So far we have combined tables using the ``+`` operator.
+The result is a table that is no longer attached to a database.
+That means that meta information about the media
+or referenced schemes is discarded.
+If you want to keep this information,
+you can use :meth:`audformat.Table.update`,
+which also works across database,
+as we will to demonstrate with the following example.
+
+First we create a second database
+and add a gender scheme:
+
+.. jupyter-execute::
+
+    db2 = audformat.testing.create_db(minimal=True)
+    db2.schemes['gender'] = audformat.Scheme(
+        labels=['female', 'male'],
+    )
+    db2.schemes
+
+Next, we add a table and fill in some gender information:
+
+.. jupyter-execute::
+
+    audformat.testing.add_table(
+        db2,
+        table_id='gender_and_age',
+        index_type=audformat.define.IndexType.FILEWISE,
+        columns='gender',
+        num_files=[2, 3, 4],
+    ).get()
+
+Now, we update the table with age values from the other database.
+
+.. jupyter-execute::
+
+    db2['gender_and_age'].update(db['age']).get()
+
+And also copies the according scheme to the database:
+
+.. jupyter-execute::
+
+    db2.schemes

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -91,7 +91,7 @@ That means that meta information about the media
 or referenced schemes is discarded.
 If you want to keep this information,
 you can use :meth:`audformat.Table.update`,
-which also works across database,
+which also works across databases,
 as we will demonstrate with the following example.
 
 First we create a second database

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -92,7 +92,7 @@ or referenced schemes is discarded.
 If you want to keep this information,
 you can use :meth:`audformat.Table.update`,
 which also works across database,
-as we will to demonstrate with the following example.
+as we will demonstrate with the following example.
 
 First we create a second database
 and add a gender scheme:

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -9,9 +9,17 @@ import audformat.testing
 def test_access():
     db = audformat.testing.create_db()
     for table in db.tables.values():
-        for column_id in table.columns.keys():
+        for column_id, column in table.columns.items():
             assert table.columns[column_id] == table[column_id]
             assert str(table.columns[column_id]) == str(table[column_id])
+            if column.scheme_id is not None:
+                assert column.scheme == db.schemes[column.scheme_id]
+            else:
+                assert column.scheme is None
+            if column.rater_id is not None:
+                assert column.rater == db.raters[column.rater_id]
+            else:
+                assert column.rater is None
 
 
 def test_exceptions():

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -38,7 +38,7 @@ def test_with_data(tmpdir):
 
     db.save(tmpdir)
     db4 = audformat.Database.load(tmpdir)
-    db4['files'].df['string'][0] = 'Believe me, I am special!'
+    db4['files'].df.at['string', 0] = 'Believe me, I am special!'
 
     assert db != db4
     assert db['files'] != db4['files']

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -20,6 +20,7 @@ def to_array(value):
         audformat.filewise_index(['f1', 'f2']),
         pd.Series(
             index=audformat.filewise_index(['f1', 'f2']),
+            dtype=float,
         ),
         pd.DataFrame(
             index=audformat.filewise_index(['f1', 'f2']),

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -26,9 +26,17 @@ def create_table(
 
 def test_access():
     db = audformat.testing.create_db()
-    for table_id in db.tables.keys():
+    for table_id, table in db.tables.items():
         assert db.tables[table_id] == db[table_id]
         assert str(db.tables[table_id]) == str(db[table_id])
+        if table.media_id is not None:
+            assert table.media == db.media[table.media_id]
+        else:
+            assert table.media is None
+        if table.split_id is not None:
+            assert table.split == db.splits[table.split_id]
+        else:
+            assert table.split is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -905,3 +905,22 @@ def test_type():
         )
     )
     pd.testing.assert_index_equal(db['files'].index, db['files'].index)
+
+
+@pytest.mark.parametrize(
+    'table, others',
+    [
+        (
+            audformat.testing.create_db(
+                data={
+                    'table': pd.Series(index=audformat.filewise_index())
+                }
+            )['table'],
+            [],
+        ),
+    ]
+)
+def test_update(table, others):
+    df = pd.concat([table.df] + [other.df for other in others])
+    table.update(others)
+    pd.testing.assert_frame_equal(table.df, df)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1237,12 +1237,29 @@ def test_type():
             ),
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        # not assigned to db
+        # error: not assigned to db
         pytest.param(
             audformat.Table(),
             False,
             [],
             marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        # error: index type must not change
+        pytest.param(
+            create_db_table(
+                pd.Series(
+                    [1., 2.],
+                    index=audformat.filewise_index(['f1', 'f2']),
+                )
+            ),
+            False,
+            create_db_table(
+                pd.Series(
+                    [2., 3.],
+                    index=audformat.segmented_index(['f2', 'f3']),
+                )
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ]
 )
@@ -1255,6 +1272,7 @@ def test_update(table, overwrite, others):
         [df] + [other.df for other in others],
         overwrite=overwrite,
     )
+    assert table.type == audformat.index_type(df)
     if isinstance(df, pd.Series):
         df = df.to_frame()
     pd.testing.assert_frame_equal(table.df, df)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -314,10 +314,15 @@ def test_add(tables, expected):
     table = tables[0]
     for other in tables[1:]:
         table += other
+    assert table.media_id is None
+    assert table.split_id is None
+    for column in table.columns.values():
+        assert column.scheme_id is None
+        assert column.rater_id is None
     assert table == expected
 
 
-def test_add_2():  # TODO: turn into test_update()
+def test_add_2():
 
     db = audformat.testing.create_db(minimal=True)
     db.media['media'] = audformat.Media()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1244,7 +1244,7 @@ def test_type():
             [],
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
-        # error: index type must not change
+        # error: different index type
         pytest.param(
             create_db_table(
                 pd.Series(
@@ -1257,6 +1257,22 @@ def test_type():
                 pd.Series(
                     [2., 3.],
                     index=audformat.segmented_index(['f2', 'f3']),
+                )
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            create_db_table(
+                pd.Series(
+                    [1., 2.],
+                    index=audformat.segmented_index(['f1', 'f2']),
+                )
+            ),
+            False,
+            create_db_table(
+                pd.Series(
+                    [2., 3.],
+                    index=audformat.filewise_index(['f2', 'f3']),
                 )
             ),
             marks=pytest.mark.xfail(raises=ValueError),


### PR DESCRIPTION
Closes #48 

### Example

Create database with single table and a column 'int':

```python
db1 = audformat.testing.create_db(minimal=True)
db1.raters['rater'] = audformat.Rater()
db1.schemes['int'] = audformat.Scheme(int)
audformat.testing.add_table(
    db1,
    'table',
    'filewise',
    num_files=[0, 1],
    columns={'int': ('int', 'rater')},
)
db1
```
```
name: unittest
source: internal
usage: unrestricted
languages: [deu, eng]
raters:
  rater: {type: human}
schemes:
  int: {dtype: int}
tables:
  table:
    type: filewise
    columns:
      int: {scheme_id: int, rater_id: rater}
```
```python
db1['table'].get()
```
```
               int
file              
audio/000.wav   71
audio/001.wav    8
```

Create `db2` with single table and two columns `int` and `float`:

```python
db2 = audformat.testing.create_db(minimal=True)
db2.raters['rater'] = audformat.Rater()
db2.raters['rater2'] = audformat.Rater()
db2.schemes['int'] = audformat.Scheme(int)
db2.schemes['float'] = audformat.Scheme(float)
audformat.testing.add_table(
    db2,
    'table',
    'filewise',
    num_files=[2, 3],
    columns={'int': ('int', 'rater'), 'float': ('float', 'rater2')},
)
db2['table'].get()
```
```
               int     float
file                        
audio/002.wav   29  0.580805
audio/003.wav   41  0.206261
```

Create `db3` with single table and a column 'str':

```python
db3 = audformat.testing.create_db(minimal=True)
db3.raters['rater3'] = audformat.Rater(description='db3')
db3.schemes['str'] = audformat.Scheme(str, description='db3')
audformat.testing.add_table(
    db3,
    'table',
    'filewise',
    num_files=[0, 1, 2, 3],
    columns={'str': ('str', 'rater3')},
)
db3['table'].get()
```
```
                      str
file                     
audio/000.wav  yaoZEabQX1
audio/001.wav  NOaw2g1N8A
audio/002.wav  PifD7JZNkW
audio/003.wav  hplepGXxJS
```

Now update table of `db1` with the tables from `db2` and `db3`:

```python
db1['table'].update([db2['table'], db2['table'], db3['table']])
db1
```
```
               int     float         str
file                                    
audio/000.wav   74       NaN  yaoZEabQX1
audio/001.wav   60       NaN  NOaw2g1N8A
audio/002.wav   29  0.580805  PifD7JZNkW
audio/003.wav   41  0.206261  hplepGXxJS
```

Schemes and raters from table columns that were not in `db1` before, have been added:

```python
db1
```
```
name: unittest
source: internal
usage: unrestricted
languages: [deu, eng]
raters:
  rater: {type: human}
  rater2: {description: from db2, type: human}
  rater3: {description: from db3, type: human}
schemes:
  float: {description: from db2, dtype: float}
  int: {dtype: int}
  str: {description: from db3, dtype: str}
tables:
  table:
    type: filewise
    columns:
      int: {scheme_id: int, rater_id: rater}
      float: {scheme_id: float, rater_id: rater2}
      str: {scheme_id: str, rater_id: rater3}
```

### Constraints

When updating a table, the media / split information must not change:

```python
db1 = audformat.testing.create_db(minimal=True)
db1.media['media'] = audformat.Media('audio')
db1['table'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2']),
    media_id='media',
)

db2 = audformat.testing.create_db(minimal=True)
db2.media['media'] = audformat.Media('video')
db2['other'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2']),
    media_id='media',
)

try:
    db1['table'].update([db2['other']])
except ValueError as ex:
    print(ex)
```
```
Media of table 'other' does not match:
{type: audio}
!=
{type: video}
```

Columns can only be combined if scheme and rater objects match:

```python
db1 = audformat.testing.create_db(minimal=True)
db1.schemes['scheme'] = audformat.Scheme(str)
db1['table'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2'])
)
db1['table']['c'] = audformat.Column(scheme_id='scheme')
db1['table']['c'].set(['a', 'b'])
audformat.testing.add_table(db1, 'table2', 'filewise')

db2 = audformat.testing.create_db(minimal=True)
db2.schemes['scheme'] = audformat.Scheme(int)
db2['other'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2'])
)
db2['other']['c'] = audformat.Column(scheme_id='scheme')
db2['other']['c'].set([0, 1])

try:
    db1['table'].update([db2['other']])
except ValueError as ex:
    print(ex)
```
```
Scheme of common column 'other.c' does not match:
{dtype: str}
!=
{dtype: int}
```

A new scheme/rater can only be added if not a different object with the same ID exists:

```python
db1 = audformat.testing.create_db(minimal=True)
db1.schemes['scheme'] = audformat.Scheme(str)
db1['table'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2'])
)
db1['table']['c1'] = audformat.Column(scheme_id='scheme')
db1['table']['c1'].set(['a', 'b'])
audformat.testing.add_table(db1, 'table2', 'filewise')

db2 = audformat.testing.create_db(minimal=True)
db2.schemes['scheme'] = audformat.Scheme(int)
db2['other'] = audformat.Table(
    audformat.filewise_index(['f1', 'f2'])
)
db2['other']['c2'] = audformat.Column(scheme_id='scheme')
db2['other']['c2'].set([0, 1])

try:
    db1['table'].update([db2['other']])
except ValueError as ex:
    print(ex)
```
```
Cannot copy scheme of column 'other.c2' as a different scheme with ID 'scheme' exists:
{dtype: str}
!=
{dtype: int}
```

Finally, the table must be part of a database and the index type of the table must not change.