### PR TITLE
Add audformat.utils.duration()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -214,7 +214,7 @@ def concat(
 
 def duration(
         obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
-) -> float:
+) -> pd.Timedelta:
     r"""Duration of all segments present in a segmented object.
 
     Args:
@@ -236,7 +236,7 @@ def duration(
         ...     ends=[1, 2, 4],
         ... )
         >>> duration(idx)
-        3.0
+        Timedelta('0 days 00:00:03')
 
     """
     if index_type(obj) != define.IndexType.SEGMENTED:
@@ -246,14 +246,11 @@ def duration(
         obj = obj.index
 
     if obj.empty:
-        return 0
+        return pd.Timedelta(0, unit='s')
 
-    starts = list(obj.get_level_values(define.IndexField.START))
-    ends = list(obj.get_level_values(define.IndexField.END))
-    duration = [end - start for start, end in zip(starts, ends)]
-    duration = np.sum(duration)
-    duration = duration.total_seconds()
-    return duration
+    starts = obj.get_level_values(define.IndexField.START)
+    ends = obj.get_level_values(define.IndexField.END)
+    return (ends - starts).sum()
 
 
 def intersect(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -214,19 +214,31 @@ def concat(
 
 def duration(
         obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+        *,
+        num_workers: int = 1,
 ) -> pd.Timedelta:
-    r"""Duration of all segments present in a segmented object.
+    r"""Duration of all entries present in the object.
+
+    The object might contain a segmented or a filewise index.
+    For a segmented index the duration is calculated
+    from its start and end values.
+    If an end value is ``NaT``
+    or the object contains a filewise index
+    the duration is calculated from the media file
+    by calling :func:`audiofile.duration`.
 
     Args:
         obj: object conform to
             :ref:`table specifications <data-tables:Tables>`
             and containing a segmented index
+        num_workers: number of parallel jobs.
+            Only relevant when the duration of the files
+            needs to be detected from the file.
+            If ``None`` will be set to the number of processors
+            on the machine multiplied by 5
 
     Returns:
-        duration in seconds
-
-    Raises:
-        ValueError: if ``obj`` does not contain a segmented index
+        duration
 
     Example:
 
@@ -239,8 +251,7 @@ def duration(
         Timedelta('0 days 00:00:03')
 
     """
-    if index_type(obj) != define.IndexType.SEGMENTED:
-        raise ValueError('Input does not have a segmented index.')
+    obj = to_segmented_index(obj, allow_nat=False, num_workers=num_workers)
 
     if not isinstance(obj, pd.MultiIndex):
         obj = obj.index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -212,6 +212,50 @@ def concat(
         return df
 
 
+def duration(
+        obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+) -> float:
+    r"""Duration of all segments present in a segmented object.
+
+    Args:
+        obj: object conform to
+            :ref:`table specifications <data-tables:Tables>`
+            and containing a segmented index
+
+    Returns:
+        duration in seconds
+
+    Raises:
+        ValueError: if ``obj`` does not contain a segmented index
+
+    Example:
+
+        >>> idx = segmented_index(
+        ...     files=['a', 'b', 'c'],
+        ...     starts=[0, 1, 3],
+        ...     ends=[1, 2, 4],
+        ... )
+        >>> duration(idx)
+        3.0
+
+    """
+    if index_type(obj) != define.IndexType.SEGMENTED:
+        raise ValueError('Input does not have a segmented index.')
+
+    if not isinstance(obj, pd.MultiIndex):
+        obj = obj.index
+
+    if obj.empty:
+        return 0
+
+    starts = list(obj.get_level_values(define.IndexField.START))
+    ends = list(obj.get_level_values(define.IndexField.END))
+    duration = [end - start for start, end in zip(starts, ends)]
+    duration = np.sum(duration)
+    duration = duration.total_seconds()
+    return duration
+
+
 def intersect(
     objs: typing.Sequence[typing.Union[pd.Index]],
 ) -> pd.Index:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -218,7 +218,7 @@ def duration(
         num_workers: int = 1,
         verbose: bool = False,
 ) -> pd.Timedelta:
-    r"""Duration of all entries present in the object.
+    r"""Total duration of all entries present in the object.
 
     The object might contain a segmented or a filewise index.
     For a segmented index the duration is calculated

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -215,6 +215,7 @@ def concat(
 def duration(
         obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
         *,
+        root: str = None,
         num_workers: int = 1,
         verbose: bool = False,
 ) -> pd.Timedelta:
@@ -231,12 +232,18 @@ def duration(
     Args:
         obj: object conform to
             :ref:`table specifications <data-tables:Tables>`
+        root: root directory under which the files referenced in the index
+            are stored.
+            Only relevant when the duration of the files
+            needs to be detected from the file.
         num_workers: number of parallel jobs.
             Only relevant when the duration of the files
             needs to be detected from the file.
             If ``None`` will be set to the number of processors
             on the machine multiplied by 5
-        verbose: show progress bar when duration needs to be detected
+        verbose: show progress bar.
+            Only relevant when the duration of the files
+            needs to be detected from the file.
 
     Returns:
         duration
@@ -255,6 +262,7 @@ def duration(
     obj = to_segmented_index(
         obj,
         allow_nat=False,
+        root=root,
         num_workers=num_workers,
         verbose=verbose,
     )

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -235,15 +235,15 @@ def duration(
         root: root directory under which the files referenced in the index
             are stored.
             Only relevant when the duration of the files
-            needs to be detected from the file.
+            needs to be detected from the file
         num_workers: number of parallel jobs.
             Only relevant when the duration of the files
-            needs to be detected from the file.
+            needs to be detected from the file
             If ``None`` will be set to the number of processors
             on the machine multiplied by 5
         verbose: show progress bar.
             Only relevant when the duration of the files
-            needs to be detected from the file.
+            needs to be detected from the file
 
     Returns:
         duration

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -231,7 +231,6 @@ def duration(
     Args:
         obj: object conform to
             :ref:`table specifications <data-tables:Tables>`
-            and containing a segmented index
         num_workers: number of parallel jobs.
             Only relevant when the duration of the files
             needs to be detected from the file.

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -216,6 +216,7 @@ def duration(
         obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
         *,
         num_workers: int = 1,
+        verbose: bool = False,
 ) -> pd.Timedelta:
     r"""Duration of all entries present in the object.
 
@@ -236,6 +237,7 @@ def duration(
             needs to be detected from the file.
             If ``None`` will be set to the number of processors
             on the machine multiplied by 5
+        verbose: show progress bar when duration needs to be detected
 
     Returns:
         duration
@@ -251,7 +253,12 @@ def duration(
         Timedelta('0 days 00:00:03')
 
     """
-    obj = to_segmented_index(obj, allow_nat=False, num_workers=num_workers)
+    obj = to_segmented_index(
+        obj,
+        allow_nat=False,
+        num_workers=num_workers,
+        verbose=verbose,
+    )
 
     if not isinstance(obj, pd.MultiIndex):
         obj = obj.index

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -1,5 +1,6 @@
 from audformat.core.utils import (
     concat,
+    duration,
     intersect,
     join_labels,
     join_schemes,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -9,12 +9,15 @@ concat
 
 .. autofunction:: concat
 
+duration
+--------
+
+.. autofunction:: duration
 
 intersect
 ---------
 
 .. autofunction:: intersect
-
 
 join_labels
 -----------
@@ -26,7 +29,6 @@ join_schemes
 ------------
 
 .. autofunction:: join_schemes
-
 
 map_language
 ------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -482,34 +482,34 @@ def test_concat(objs, overwrite, expected):
     [
         (
             audformat.segmented_index(),
-            0,
+            pd.Timedelta(0, unit='s'),
         ),
         (
             audformat.segmented_index(['f1'], [0], [2]),
-            2,
+            pd.Timedelta(2, unit='s'),
         ),
         (
             audformat.segmented_index(['f1'], [0.1], [2]),
-            1.9,
+            pd.Timedelta(1.9, unit='s'),
         ),
         (
             audformat.segmented_index(['f1', 'f2'], [0, 1], [2, 2]),
-            3,
+            pd.Timedelta(3, unit='s'),
         ),
         (
             audformat.segmented_index(['f1'], [0]),
-            np.NaN,
+            pd.Timedelta(np.NaN, unit='s'),
         ),
         (
             pd.Series(
                 index=audformat.segmented_index(['f1'], [1], [2]),
                 dtype='category',
             ),
-            1,
+            pd.Timedelta(1, unit='s'),
         ),
         (
             pd.DataFrame(index=audformat.segmented_index(['f1'], [1], [2])),
-            1,
+            pd.Timedelta(1, unit='s'),
         ),
         pytest.param(
             audformat.filewise_index(['f1']),
@@ -520,8 +520,8 @@ def test_concat(objs, overwrite, expected):
 )
 def test_duration(obj, expected_duration):
     duration = audformat.utils.duration(obj)
-    if np.isnan(expected_duration):
-        assert np.isnan(duration)
+    if pd.isnull(expected_duration):
+        assert pd.isnull(duration)
     else:
         assert duration == expected_duration
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -478,6 +478,55 @@ def test_concat(objs, overwrite, expected):
 
 
 @pytest.mark.parametrize(
+    'obj, expected_duration',
+    [
+        (
+            audformat.segmented_index(),
+            0,
+        ),
+        (
+            audformat.segmented_index(['f1'], [0], [2]),
+            2,
+        ),
+        (
+            audformat.segmented_index(['f1'], [0.1], [2]),
+            1.9,
+        ),
+        (
+            audformat.segmented_index(['f1', 'f2'], [0, 1], [2, 2]),
+            3,
+        ),
+        (
+            audformat.segmented_index(['f1'], [0]),
+            np.NaN,
+        ),
+        (
+            pd.Series(
+                index=audformat.segmented_index(['f1'], [1], [2]),
+                dtype='category',
+            ),
+            1,
+        ),
+        (
+            pd.DataFrame(index=audformat.segmented_index(['f1'], [1], [2])),
+            1,
+        ),
+        pytest.param(
+            audformat.filewise_index(['f1']),
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_duration(obj, expected_duration):
+    duration = audformat.utils.duration(obj)
+    if np.isnan(expected_duration):
+        assert np.isnan(duration)
+    else:
+        assert duration == expected_duration
+
+
+@pytest.mark.parametrize(
     'objs, expected',
     [
         (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -497,10 +497,6 @@ def test_concat(objs, overwrite, expected):
             pd.Timedelta(3, unit='s'),
         ),
         (
-            audformat.segmented_index(['f1'], [0]),
-            pd.Timedelta(np.NaN, unit='s'),
-        ),
-        (
             pd.Series(
                 index=audformat.segmented_index(['f1'], [1], [2]),
                 dtype='category',
@@ -511,10 +507,17 @@ def test_concat(objs, overwrite, expected):
             pd.DataFrame(index=audformat.segmented_index(['f1'], [1], [2])),
             pd.Timedelta(1, unit='s'),
         ),
+        # filewise index, but file is missing
         pytest.param(
             audformat.filewise_index(['f1']),
             None,
-            marks=pytest.mark.xfail(raises=ValueError),
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
+        ),
+        # segmented index with NaT, but file is missing
+        pytest.param(
+            audformat.segmented_index(['f1'], [0]),
+            None,
+            marks=pytest.mark.xfail(raises=FileNotFoundError),
         ),
     ]
 )


### PR DESCRIPTION
Adds a utility function to calculate the total duration of an object with filewise or segmented index.

![image](https://user-images.githubusercontent.com/173624/121146367-26d6b700-c840-11eb-83bd-c542e9436c1c.png)
