### PR TITLE
FIX: assert_index() checks for correct dtypes

### DIFF
--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -77,33 +77,53 @@ def assert_index(
             f'levels, but expected 1 or 3 levels.'
         )
 
-    if num == 1 and not (
-            obj.names[0] == define.IndexField.FILE
-    ):
-        raise ValueError(
-            'Index not conform to audformat. '
-            'Found single level with name '
-            f'{obj.names[0]}, '
-            f'but expected name '
-            f"'{define.IndexField.FILE}'."
-        )
-    elif num == 3 and not (
-            obj.names[0] == define.IndexField.FILE
-            and obj.names[1] == define.IndexField.START
-            and obj.names[2] == define.IndexField.END
-    ):
-        expected_names = [
-            define.IndexField.FILE,
-            define.IndexField.START,
-            define.IndexField.END,
-        ]
-        raise ValueError(
-            'Index not conform to audformat. '
-            'Found three levels with names '
-            f'{obj.names}, '
-            f'but expected names '
-            f'{expected_names}.'
-        )
+    if num == 1:
+        if obj.names[0] != define.IndexField.FILE:
+            raise ValueError(
+                'Index not conform to audformat. '
+                'Found single level with name '
+                f'{obj.names[0]}, '
+                f'but expected name '
+                f"'{define.IndexField.FILE}'."
+            )
+        if not pd.api.types.is_string_dtype(obj.dtype):
+            raise ValueError(
+                "Index not conform to audformat. "
+                "Level 'file' must contain values of type 'string'."
+            )
+    elif num == 3:
+        if not (
+                obj.names[0] == define.IndexField.FILE
+                and obj.names[1] == define.IndexField.START
+                and obj.names[2] == define.IndexField.END
+        ):
+            expected_names = [
+                define.IndexField.FILE,
+                define.IndexField.START,
+                define.IndexField.END,
+            ]
+            raise ValueError(
+                'Index not conform to audformat. '
+                'Found three levels with names '
+                f'{obj.names}, '
+                f'but expected names '
+                f'{expected_names}.'
+            )
+        if not pd.api.types.is_string_dtype(obj.levels[0].dtype):
+            raise ValueError(
+                "Index not conform to audformat. "
+                "Level 'file' must contain values of type 'string'."
+            )
+        if not pd.api.types.is_timedelta64_dtype(obj.levels[1].dtype):
+            raise ValueError(
+                "Index not conform to audformat. "
+                "Level 'start' must contain values of type 'timedelta64[ns]'."
+            )
+        if not pd.api.types.is_timedelta64_dtype(obj.levels[2].dtype):
+            raise ValueError(
+                "Index not conform to audformat. "
+                "Level 'end' must contain values of type 'timedelta64[ns]'."
+            )
 
 
 def filewise_index(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -627,7 +627,7 @@ def union(
     for obj in objs[1:]:
         index = index.union(obj)
 
-    if index_type(index) == define.IndexType.SEGMENTED:
+    if isinstance(index, pd.MultiIndex) and len(index.levels) == 3:
         # asserts that start and end are of type 'timedelta64[ns]'
         if index.empty:
             index = segmented_index()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -61,6 +61,43 @@ def to_array(value):
             ),
             marks=pytest.mark.xfail(raises=ValueError),
         ),
+        pytest.param(  # invalid file type
+            pd.Index([1, 2], name='file'),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid file type
+            pd.MultiIndex.from_arrays(
+                [
+                    [1, 2],
+                    pd.to_timedelta([0.0, 1.0], unit='s'),
+                    pd.to_timedelta([1.0, 2.0], unit='s'),
+                ],
+                names=['file', 'start', 'end'],
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid start type
+            pd.MultiIndex.from_arrays(
+                [
+                    ['f1', 'f2'],
+                    [0.0, 1.0],
+                    pd.to_timedelta([1.0, 2.0], unit='s'),
+                ],
+                names=['file', 'start', 'end'],
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid end type
+            pd.MultiIndex.from_arrays(
+                [
+                    ['f1', 'f2'],
+                    pd.to_timedelta([0.0, 1.0], unit='s'),
+                    [1.0, 2.0],
+                ],
+                names=['file', 'start', 'end'],
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_assert_index(obj):


### PR DESCRIPTION
Closes #56 

`audformat.assert_index()` now checks for correct `dtypes` in all levels.

### Examples

```python
index = pd.Index([1, 2], name='file')
db = audformat.testing.create_db(minimal=True)
db['table'] = audformat.Table(index=index)
```
```
ValueError: Index not conform to audformat. Level 'file' must contain values of type 'string'.
```

```python
index = pd.MultiIndex.from_arrays(
    [
        ['f1', 'f2'],
        [0.0, 1.0],
        pd.to_timedelta([1.0, 2.0], unit='s'),
    ],
    names=['file', 'start', 'end'],
)
db = audformat.testing.create_db(minimal=True)
db['table'] = audformat.Table(index=index)
```
```
ValueError: Index not conform to audformat. Level 'start' must contain values of type 'timedelta64[ns]'.
```

The latter could be be avoided by using `audformat.segmented_index` to create the index, i.e.

```python

index = audformat.segmented_index(
    ['f1', 'f2'],
    [0.0, 1.0],
    pd.to_timedelta([1.0, 2.0], unit='s'),
)
db = audformat.testing.create_db(minimal=True)
db['table'] = audformat.Table(index=index)
```