### PR TITLE
Add allow_nat argument to utils.to_segmented_index()

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,27 @@
+import os
+import shutil
+
+import pandas as pd
 import pytest
 
 import audformat.testing
 
 
+pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
+
 pytest.DB = audformat.testing.create_db()
+pytest.DB_ROOT = os.path.join(pytest.ROOT, 'db')
+pytest.DB.save(pytest.DB_ROOT)
+
+pytest.FILE_DUR = pd.to_timedelta('1s')
+
+
+@pytest.fixture(scope='session', autouse=True)
+def create_audio_files():
+    audformat.testing.create_audio_files(
+        pytest.DB,
+        root=pytest.DB_ROOT,
+        file_duration=pytest.FILE_DUR,
+    )
+    yield
+    shutil.rmtree(pytest.DB_ROOT)


### PR DESCRIPTION
Adds  the option to replace `NaT` with file duration when converting to a segmented index.

![image](https://user-images.githubusercontent.com/10383417/114044445-8b4cb880-9887-11eb-966d-aa7a7c8a67c1.png)

### Example:

```python
import audformat

root = '/media/jwagner/Data/audb/emodb/1'
db = audformat.Database.load(root)
audformat.utils.to_segmented_index(db['emotion'].get())
```
```
                              emotion @emotion
file            start  end                    
wav/03a01Fa.wav 0 days NaT  happiness      0.9
wav/03a01Nc.wav 0 days NaT    neutral      1.0
wav/03a01Wa.wav 0 days NaT      anger     0.95
wav/03a02Fc.wav 0 days NaT  happiness     0.85
wav/03a02Nc.wav 0 days NaT    neutral      1.0
...                               ...      ...
wav/16b10Lb.wav 0 days NaT    boredom      1.0
wav/16b10Tb.wav 0 days NaT    sadness      0.9
wav/16b10Td.wav 0 days NaT    sadness     0.95
wav/16b10Wa.wav 0 days NaT      anger      1.0
wav/16b10Wb.wav 0 days NaT      anger      1.0
```
```python
audformat.utils.to_segmented_index(db['emotion'].get(), allow_nat=False, root=root)
```
```
                                                    emotion @emotion
file            start  end                                          
wav/03a01Fa.wav 0 days 0 days 00:00:01.898250     happiness      0.9
wav/03a01Nc.wav 0 days 0 days 00:00:01.611250       neutral      1.0
wav/03a01Wa.wav 0 days 0 days 00:00:01.877812500      anger     0.95
wav/03a02Fc.wav 0 days 0 days 00:00:02.006250     happiness     0.85
wav/03a02Nc.wav 0 days 0 days 00:00:01.439812500    neutral      1.0
...                                                     ...      ...
wav/16b10Lb.wav 0 days 0 days 00:00:03.442687500    boredom      1.0
wav/16b10Tb.wav 0 days 0 days 00:00:03.500625       sadness      0.9
wav/16b10Td.wav 0 days 0 days 00:00:03.934187500    sadness     0.95
wav/16b10Wa.wav 0 days 0 days 00:00:02.414125         anger      1.0
wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999      anger      1.0
```


