### PR TITLE
Add audformat.Scheme.replace_labels()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -151,12 +151,16 @@ class Database(HeaderBase):
         r"""Dictionary of media information"""
         self.raters = HeaderDict(value_type=Rater)
         r"""Dictionary of raters"""
-        self.schemes = HeaderDict(value_type=Scheme)
+        self.schemes = HeaderDict(
+            value_type=Scheme,
+            set_callback=self._set_scheme,
+        )
         r"""Dictionary of schemes"""
         self.splits = HeaderDict(value_type=Split)
         r"""Dictionary of splits"""
         self.tables = HeaderDict(
-            value_type=Table, set_callback=self._set_table,
+            value_type=Table,
+            set_callback=self._set_table,
         )
         r"""Dictionary of tables"""
 
@@ -732,6 +736,15 @@ class Database(HeaderBase):
                 db[table_id] = table
 
         return db
+
+    def _set_scheme(
+            self,
+            scheme_id: str,
+            scheme: Scheme,
+    ) -> Scheme:
+        scheme._db = self
+        scheme._id = scheme_id
+        return scheme
 
     def _set_table(
             self,

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -229,6 +229,19 @@ class Scheme(HeaderBase):
             self,
             labels: typing.Union[dict, list],
     ):
+        r"""Update labels.
+
+        If scheme is part of a :class:`audformat.Database`
+        the dtype of :class:`audformat.Column`s that reference the scheme
+        will be updated. Values of removed labels are set to ``NaN``.
+
+        Args:
+            labels: new labels
+
+        Raises:
+            RuntimeError: if scheme does not define labels
+
+        """
         if self.labels is None:
             raise RuntimeError(
                 'Cannot update labels because scheme does not define labels.'

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -233,18 +233,42 @@ class Scheme(HeaderBase):
 
         If scheme is part of a :class:`audformat.Database`
         the dtype of :class:`audformat.Column`s that reference the scheme
-        will be updated. Values of removed labels are set to ``NaN``.
+        will be updated. Removed labels are set to ``NaN``.
 
         Args:
             labels: new labels
 
         Raises:
-            RuntimeError: if scheme does not define labels
+            ValueError: if scheme does not define labels
+
+        Example:
+            >>> speaker = Scheme(
+            ...     labels={
+            ...         0: {'gender': 'female'},
+            ...         1: {'gender': 'male'},
+            ...     }
+            ... )
+            >>> speaker
+            dtype: int
+            labels:
+              0: {gender: female}
+              1: {gender: male}
+            >>> speaker.update_labels(
+            ...     labels={
+            ...         1: {'gender': 'male', 'age': 33},
+            ...         2: {'gender': 'female', 'age': 44},
+            ...     }
+            ... )
+            >>> speaker
+            dtype: int
+            labels:
+              1: {gender: male, age: 33}
+              2: {gender: female, age: 44}
 
         """
         if self.labels is None:
-            raise RuntimeError(
-                'Cannot update labels because scheme does not define labels.'
+            raise ValueError(
+                'Cannot update labels when scheme does not define labels.'
             )
 
         self.labels = labels

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -244,7 +244,7 @@ class Scheme(HeaderBase):
               0: {gender: female}
               1: {gender: male}
             >>> speaker.replace_labels(
-            ...     labels={
+            ...     {
             ...         1: {'gender': 'male', 'age': 33},
             ...         2: {'gender': 'female', 'age': 44},
             ...     }

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -113,6 +113,19 @@ class Scheme(HeaderBase):
         self.maximum = maximum if self.is_numeric else None
         r"""Maximum value"""
 
+        self._db = None
+        self._id = None
+
+    @property
+    def db(self):
+        r"""Database object.
+
+        Returns:
+            database object or ``None`` if not assigned yet
+
+        """
+        return self._db
+
     @property
     def is_numeric(self) -> bool:
         r"""Check if data type is numeric.

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -213,11 +213,11 @@ class Scheme(HeaderBase):
             return 'timedelta64[ns]'
         return self.dtype
 
-    def update_labels(
+    def replace_labels(
             self,
             labels: typing.Union[dict, list],
     ):
-        r"""Update labels.
+        r"""Replace labels.
 
         If scheme is part of a :class:`audformat.Database`
         the dtype of :class:`audformat.Column`s that reference the scheme
@@ -243,7 +243,7 @@ class Scheme(HeaderBase):
             labels:
               0: {gender: female}
               1: {gender: male}
-            >>> speaker.update_labels(
+            >>> speaker.replace_labels(
             ...     labels={
             ...         1: {'gender': 'male', 'age': 33},
             ...         2: {'gender': 'female', 'age': 44},
@@ -258,7 +258,7 @@ class Scheme(HeaderBase):
         """
         if self.labels is None:
             raise ValueError(
-                'Cannot update labels when '
+                'Cannot replace labels when '
                 'scheme does not define labels.'
             )
 

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -220,8 +220,9 @@ class Scheme(HeaderBase):
         r"""Replace labels.
 
         If scheme is part of a :class:`audformat.Database`
-        the dtype of all :class:`audformat.Column` objects that reference the scheme
-        will be updated. Removed labels are set to ``NaN``.
+        the dtype of all :class:`audformat.Column` objects
+        that reference the scheme will be updated.
+        Removed labels are set to ``NaN``.
 
         Args:
             labels: new labels

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -105,16 +105,6 @@ class Scheme(HeaderBase):
         self._id = None
 
     @property
-    def db(self):
-        r"""Database object.
-
-        Returns:
-            database object or ``None`` if not assigned yet
-
-        """
-        return self._db
-
-    @property
     def is_numeric(self) -> bool:
         r"""Check if data type is numeric.
 

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -220,7 +220,7 @@ class Scheme(HeaderBase):
         r"""Replace labels.
 
         If scheme is part of a :class:`audformat.Database`
-        the dtype of :class:`audformat.Column`s that reference the scheme
+        the dtype of all :class:`audformat.Column` objects that reference the scheme
         will be updated. Removed labels are set to ``NaN``.
 
         Args:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -366,9 +366,9 @@ def test_update():
             overwrite=True,
         )
 
-    # update scheme to avoid error
+    # replace labels to avoid error
 
-    db.schemes['labels'].update_labels(other1.schemes['labels'].labels)
+    db.schemes['labels'].replace_labels(other1.schemes['labels'].labels)
     df = audformat.utils.concat(
         [db['table'].df, other1['table'].df],
         overwrite=True,

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -46,7 +46,7 @@ def test_scheme_errors():
         audformat.Scheme(labels=[1, '2', 3])
 
     # update labels when scheme has no label
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         scheme = audformat.Scheme(audformat.define.DataType.INTEGER)
         scheme.update_labels(['a', 'b'])
 
@@ -118,6 +118,20 @@ def test_scheme_errors():
                 [None, None],
                 index=audformat.filewise_index(['f1', 'f2']),
                 dtype=pd.CategoricalDtype(['c']),
+            ),
+        ),
+        (
+            pd.Series(
+                [0, 1],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype([0, 1]),
+            ),
+            {0: 'a', 1: 'b'},
+            {1: 'b', 2: 'c'},
+            pd.Series(
+                [None, 1],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype([1, 2]),
             ),
         ),
     ]

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -122,18 +122,60 @@ def test_scheme_errors():
         ),
         (
             pd.Series(
+                ['a', 'b'],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a', 'b']),
+            ),
+            ['a', 'b'],
+            [],
+            pd.Series(
+                [None, None],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype([]),
+            ),
+        ),
+        (
+            pd.Series(
                 [0, 1],
                 index=audformat.filewise_index(['f1', 'f2']),
                 dtype=pd.CategoricalDtype([0, 1]),
             ),
             {0: 'a', 1: 'b'},
-            {1: 'b', 2: 'c'},
+            {1: {'b': 'B'}, 2: {'c': 'C'}},
             pd.Series(
                 [None, 1],
                 index=audformat.filewise_index(['f1', 'f2']),
                 dtype=pd.CategoricalDtype([1, 2]),
             ),
         ),
+        (
+            pd.Series(
+                [0, 1],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype([0, 1]),
+            ),
+            {0: 'a', 1: 'b'},
+            [1, 2],
+            pd.Series(
+                [None, 1],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype([1, 2]),
+            ),
+        ),
+        # error: dtype of labels does not match
+        pytest.param(
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(),
+            ),
+            ['a', 'b'],
+            [0, 1],
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(),
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        )
     ]
 )
 def test_update_labels(values, labels, new_labels, expected):

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -7,7 +7,7 @@ import audformat.testing
 
 def test_scheme():
 
-    db = audformat.testing.create_db()
+    db = pytest.DB
 
     for scheme_id in db.schemes:
         assert db.schemes[scheme_id].db == db
@@ -22,6 +22,9 @@ def test_scheme():
     assert 'label1' in db.schemes['label']
     assert 'label1' in db.schemes['label_map_str']
     assert 1 in db.schemes['label_map_int']
+
+
+def test_scheme_errors():
 
     # dtype mismatch
     with pytest.raises(ValueError):
@@ -41,3 +44,94 @@ def test_scheme():
     # labels do not have the same type
     with pytest.raises(ValueError):
         audformat.Scheme(labels=[1, '2', 3])
+
+    # update labels when scheme has no label
+    with pytest.raises(RuntimeError):
+        scheme = audformat.Scheme(audformat.define.DataType.INTEGER)
+        scheme.update_labels(['a', 'b'])
+
+
+@pytest.mark.parametrize(
+    'values, labels, new_labels, expected',
+    [
+        (
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(),
+            ),
+            [],
+            [],
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(),
+            ),
+        ),
+        (
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(['a', 'b']),
+            ),
+            ['a', 'b'],
+            ['b', 'c', 'd'],
+            pd.Series(
+                index=audformat.filewise_index(),
+                dtype=pd.CategoricalDtype(['b', 'c', 'd']),
+            ),
+        ),
+        (
+            pd.Series(
+                ['a', 'b'],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a', 'b']),
+            ),
+            ['a', 'b'],
+            ['a'],
+            pd.Series(
+                ['a', None],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a']),
+            ),
+        ),
+        (
+            pd.Series(
+                ['a', 'b'],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a', 'b']),
+            ),
+            ['a', 'b'],
+            ['a', 'b', 'c'],
+            pd.Series(
+                ['a', 'b'],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a', 'b', 'c']),
+            ),
+        ),
+        (
+            pd.Series(
+                ['a', 'b'],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['a', 'b']),
+            ),
+            ['a', 'b'],
+            ['c'],
+            pd.Series(
+                [None, None],
+                index=audformat.filewise_index(['f1', 'f2']),
+                dtype=pd.CategoricalDtype(['c']),
+            ),
+        ),
+    ]
+)
+def test_update_labels(values, labels, new_labels, expected):
+
+    db = audformat.testing.create_db(minimal=True)
+    db.schemes['scheme'] = audformat.Scheme(labels=labels)
+    db['table'] = audformat.Table(index=values.index)
+    db['table']['columns'] = audformat.Column(scheme_id='scheme')
+    db['table']['columns'].set(values)
+    db.schemes['scheme'].update_labels(new_labels)
+    pd.testing.assert_series_equal(
+        db['table']['columns'].get(),
+        expected,
+        check_names=False,
+    )

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -48,7 +48,7 @@ def test_scheme_errors():
     # update labels when scheme has no label
     with pytest.raises(ValueError):
         scheme = audformat.Scheme(audformat.define.DataType.INTEGER)
-        scheme.update_labels(['a', 'b'])
+        scheme.replace_labels(['a', 'b'])
 
 
 @pytest.mark.parametrize(
@@ -178,14 +178,14 @@ def test_scheme_errors():
         )
     ]
 )
-def test_update_labels(values, labels, new_labels, expected):
+def test_replace_labels(values, labels, new_labels, expected):
 
     db = audformat.testing.create_db(minimal=True)
     db.schemes['scheme'] = audformat.Scheme(labels=labels)
     db['table'] = audformat.Table(index=values.index)
     db['table']['columns'] = audformat.Column(scheme_id='scheme')
     db['table']['columns'].set(values)
-    db.schemes['scheme'].update_labels(new_labels)
+    db.schemes['scheme'].replace_labels(new_labels)
     pd.testing.assert_series_equal(
         db['table']['columns'].get(),
         expected,

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -9,9 +9,6 @@ def test_scheme():
 
     db = pytest.DB
 
-    for scheme_id in db.schemes:
-        assert db.schemes[scheme_id].db == db
-
     assert 'tests' in db.schemes['string']
     assert 0.0 in db.schemes['float']
     assert 1.0 in db.schemes['float']

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -9,6 +9,9 @@ def test_scheme():
 
     db = audformat.testing.create_db()
 
+    for scheme_id in db.schemes:
+        assert db.schemes[scheme_id].db == db
+
     assert 'tests' in db.schemes['string']
     assert 0.0 in db.schemes['float']
     assert 1.0 in db.schemes['float']


### PR DESCRIPTION
Relates to https://github.com/audeering/audformat/issues/61

Currently, `Database.update()` fails when two different schemes with same ID are detected. This can be problematic if we have to extend a scheme with new values, e.g. we want to add data from new speakers. This adds `Scheme.replace_labels()`, which replaces the labels of a scheme. It will look for all columns that reference the scheme and change the `dtype` accordingly. When labels are removed, values are set to `NaN`. 

### Example

Initial database has labels `'a'` and `'b'`.

```python
db = audformat.testing.create_db(minimal=True)
scheme = audformat.Scheme(labels=['a', 'b'])
db.schemes['scheme'] = scheme
audformat.testing.add_table(db, 'table', 'filewise')
print(scheme)
print(db['table']['scheme'].get())
```
```
dtype: str
labels: [a, b]
file
audio/001.wav    a
audio/002.wav    a
audio/003.wav    b
audio/004.wav    b
audio/005.wav    b
Name: scheme, dtype: category
Categories (2, object): ['a', 'b']
```

New database has labels  `'b'` and `'c'`.

```python
db_new = audformat.testing.create_db(minimal=True)
scheme_new = audformat.Scheme(labels=['b', 'c'])
db_new.schemes['scheme'] = scheme_new
audformat.testing.add_table(db_new, 'table', 'filewise')
print(scheme_new)
print(db_new['table']['scheme'].get())
```
```
dtype: str
labels: [b, c]
file
audio/001.wav    c
audio/002.wav    b
audio/003.wav    c
audio/004.wav    c
audio/005.wav    b
Name: scheme, dtype: category
Categories (2, object): ['b', 'c']
```

Update fails because schemes do not match.

```python
try:
    db.update(db_new, overwrite=True)
except Exception as ex:
    print(ex)
```
```
Cannot update database, found different value for 'db.schemes['scheme']':
dtype: str
labels: [a, b]
!=
dtype: str
labels: [b, c]
```

Now we replace the labels in original database to  `'b'` and `'c'`, this will set `'a'` to `Nan`.

```python
scheme.replace_labels(scheme_new.labels)
print(scheme)
print(db['table']['scheme'].get())
```
```
dtype: str
labels: [b, c]
file
audio/001.wav    NaN
audio/002.wav    NaN
audio/003.wav      b
audio/004.wav      b
audio/005.wav      b
Name: scheme, dtype: category
Categories (2, object): ['b', 'c']
```

Now we can update the database.

```python
db.update(db_new, overwrite=True)
print(db['table']['scheme'].get())
```
```
file
audio/001.wav    c
audio/002.wav    b
audio/003.wav    c
audio/004.wav    c
audio/005.wav    b
Name: scheme, dtype: category
Categories (2, object): ['b', 'c']
```