### PR TITLE
Add audformat.utils.join_labels()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -286,6 +286,89 @@ def intersect(
     return index
 
 
+def join_labels(
+        labels: typing.Sequence[typing.Union[typing.List, typing.Dict]],
+):
+    r"""Combine scheme labels.
+
+    This might be helpful,
+    if you would like to combine two databases
+    that have the same schene,
+    but with different labels:
+
+    .. code-block:: python
+
+        labels = audformat.utils.join_labels(
+            [
+                db.schemes['scheme'].labels,
+                db_new.schemes['scheme'].labels,
+            ]
+        )
+        db.schemes['scheme'].replace_labels(labels)
+        db_new.schemes['scheme'].replace_labels(labels)
+        db.update(db_new)
+
+    Args:
+        labels: sequence of labels to join
+
+    Returns:
+        joined labels
+
+    Raises:
+        ValueError: if labels are of different type
+        ValueError: if labels are dicts
+            and contain different values for the same key
+        RuntimeError: if label type is not ``list`` or ``dict``
+
+    Example:
+        >>> join_labels([{'a': 0, 'b': 1}, {'b': 1, 'c': 2}])
+        {'a': 0, 'b': 1, 'c': 2}
+
+    """
+    if len(labels) == 0 or isinstance(labels, dict):
+        return labels
+
+    if not isinstance(labels, list):
+        labels = list(labels)
+
+    label_type = type(labels[0])
+    joined_labels = labels[0]
+
+    for label in labels[1:]:
+        if type(label) != label_type:
+            raise ValueError(
+                f"Labels are of different type:\n"
+                f"{label_type}\n"
+                f"!=\n"
+                f"{type(label)}"
+            )
+
+    if label_type == dict:
+        for label in labels[1:]:
+            for key, value in label.items():
+                if key not in joined_labels:
+                    joined_labels[key] = value
+                elif joined_labels[key] != value:
+                    raise ValueError(
+                        f"Values for key '{key}' are different:\n"
+                        f"{joined_labels[key]}\n"
+                        f"!=\n"
+                        f"{value}"
+                    )
+    elif label_type == list:
+        joined_labels = list(
+            set(list(joined_labels) + audeer.flatten_list(labels[1:]))
+        )
+        joined_labels = sorted(audeer.flatten_list(joined_labels))
+    else:
+        raise RuntimeError(
+            f"Supported label types are 'list' and 'dict', "
+            f"but your is '{label_type}'"
+        )
+
+    return joined_labels
+
+
 def map_language(language: str) -> str:
     r"""Map language to ISO 639-3.
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -309,20 +309,21 @@ def join_labels(
         db.update(db_new)
 
     Args:
-        labels: sequence of labels to join
+        labels: sequence of labels to join.
+            For dictionary labels,
+            labels further to the right
+            can overwrite previous labels
 
     Returns:
         joined labels
 
     Raises:
         ValueError: if labels are of different type
-        ValueError: if the labels are dicts
-            and contain different values for the same key
         RuntimeError: if label type is not ``list`` or ``dict``
 
     Example:
-        >>> join_labels([{'a': 0, 'b': 1}, {'b': 1, 'c': 2}])
-        {'a': 0, 'b': 1, 'c': 2}
+        >>> join_labels([{'a': 0, 'b': 1}, {'b': 2, 'c': 2}])
+        {'a': 0, 'b': 2, 'c': 2}
 
     """
     if len(labels) == 0 or isinstance(labels, dict):
@@ -346,15 +347,8 @@ def join_labels(
     if label_type == dict:
         for label in labels[1:]:
             for key, value in label.items():
-                if key not in joined_labels:
+                if key not in joined_labels or joined_labels[key] != value:
                     joined_labels[key] = value
-                elif joined_labels[key] != value:
-                    raise ValueError(
-                        f"Values for key '{key}' are different:\n"
-                        f"{joined_labels[key]}\n"
-                        f"!=\n"
-                        f"{value}"
-                    )
     elif label_type == list:
         joined_labels = list(
             set(list(joined_labels) + audeer.flatten_list(labels[1:]))

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -326,7 +326,7 @@ def join_labels(
         {'a': 0, 'b': 2, 'c': 2}
 
     """
-    if len(labels) == 0 or isinstance(labels, dict):
+    if len(labels) == 0:
         return labels
 
     if not isinstance(labels, list):

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -15,6 +15,7 @@ from audformat.core.index import (
     filewise_index,
     segmented_index,
 )
+from audformat.core.scheme import Scheme
 
 
 def concat(
@@ -359,6 +360,10 @@ def join_labels(
             f"Supported label types are 'list' and 'dict', "
             f"but your is '{label_type}'"
         )
+
+    # Check if joined labels have a valid format,
+    # e.g. {0: {'age': 20}, '0': {'age': 30}} is not allowed
+    Scheme(labels=joined_labels)
 
     return joined_labels
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -320,7 +320,7 @@ def join_labels(
 
     Raises:
         ValueError: if labels are of different type
-        RuntimeError: if label type is not ``list`` or ``dict``
+        ValueError: if label type is not ``list`` or ``dict``
 
     Example:
         >>> join_labels([{'a': 0, 'b': 1}, {'b': 2, 'c': 2}])
@@ -356,7 +356,7 @@ def join_labels(
         )
         joined_labels = sorted(audeer.flatten_list(joined_labels))
     else:
-        raise RuntimeError(
+        raise ValueError(
             f"Supported label types are 'list' and 'dict', "
             f"but your is '{label_type}'"
         )

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -293,7 +293,7 @@ def join_labels(
 
     This might be helpful,
     if you would like to combine two databases
-    that have the same schene,
+    that have the same scheme,
     but with different labels:
 
     .. code-block:: python

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -315,7 +315,6 @@ def join_labels(
         joined labels
 
     Raises:
-        ValueError: if labels argument is a dict
         ValueError: if labels are of different type
         ValueError: if the labels are dicts
             and contain different values for the same key
@@ -326,11 +325,6 @@ def join_labels(
         {'a': 0, 'b': 1, 'c': 2}
 
     """
-    if isinstance(labels, dict):
-        raise ValueError(
-            "'labels' has to be a sequence, yours is a 'dict'"
-        )
-
     if len(labels) == 0 or isinstance(labels, dict):
         return labels
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -315,8 +315,9 @@ def join_labels(
         joined labels
 
     Raises:
+        ValueError: if labels argument is a dict
         ValueError: if labels are of different type
-        ValueError: if labels are dicts
+        ValueError: if the labels are dicts
             and contain different values for the same key
         RuntimeError: if label type is not ``list`` or ``dict``
 
@@ -325,6 +326,11 @@ def join_labels(
         {'a': 0, 'b': 1, 'c': 2}
 
     """
+    if isinstance(labels, dict):
+        raise ValueError(
+            "'labels' has to be a sequence, yours is a 'dict'"
+        )
+
     if len(labels) == 0 or isinstance(labels, dict):
         return labels
 

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -1,6 +1,7 @@
 from audformat.core.utils import (
     concat,
     intersect,
+    join_labels,
     map_language,
     read_csv,
     to_filewise_index,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -16,6 +16,12 @@ intersect
 .. autofunction:: intersect
 
 
+join_labels
+-----------
+
+.. autofunction:: join_labels
+
+
 map_language
 ------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -607,7 +607,12 @@ def test_intersect(objs, expected):
             [['a', 'b'], ['b', 'c'], 'd'],
             [],
             marks=pytest.mark.xfail(raises=ValueError),
-        )
+        ),
+        pytest.param(
+            [{0: {'age': 20}}, {'0': {'age': 30}}],
+            [],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_join_labels(labels, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -591,12 +591,12 @@ def test_intersect(objs, expected):
         pytest.param(
             ['a', 'b', 'c'],
             [],
-            marks=pytest.mark.xfail(raises=RuntimeError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             ('a', 'b', 'c'),
             [],
-            marks=pytest.mark.xfail(raises=RuntimeError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             [{'a': 0, 'b': 1}, ['c']],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -591,11 +591,6 @@ def test_intersect(objs, expected):
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
         pytest.param(
-            {'a': 0},
-            [],
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-        pytest.param(
             [{'a': 0, 'b': 1}, {'b': 2, 'c': 2}],
             [],
             marks=pytest.mark.xfail(raises=ValueError),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -557,6 +557,10 @@ def test_intersect(objs, expected):
             ['a', 'b'],
         ),
         (
+            (['a'], ['b', 'c']),
+            ['a', 'b', 'c'],
+        ),
+        (
             (['a'], ['a']),
             ['a'],
         ),
@@ -567,6 +571,10 @@ def test_intersect(objs, expected):
         (
             [{'a': 0}, {'b': 1}],
             {'a': 0, 'b': 1},
+        ),
+        (
+            [{'a': 0}, {'b': 1, 'c': 2}],
+            {'a': 0, 'b': 1, 'c': 2},
         ),
         (
             [{'a': 0, 'b': 1}, {'b': 1, 'c': 2}],
@@ -581,6 +589,11 @@ def test_intersect(objs, expected):
             ('a', 'b', 'c'),
             [],
             marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            {'a': 0},
+            [],
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             [{'a': 0, 'b': 1}, {'b': 2, 'c': 2}],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -546,6 +546,64 @@ def test_intersect(objs, expected):
 
 
 @pytest.mark.parametrize(
+    'labels, expected',
+    [
+        (
+            [],
+            [],
+        ),
+        (
+            (['a'], ['b']),
+            ['a', 'b'],
+        ),
+        (
+            (['a'], ['a']),
+            ['a'],
+        ),
+        (
+            [{'a': 0}],
+            {'a': 0},
+        ),
+        (
+            [{'a': 0}, {'b': 1}],
+            {'a': 0, 'b': 1},
+        ),
+        (
+            [{'a': 0, 'b': 1}, {'b': 1, 'c': 2}],
+            {'a': 0, 'b': 1, 'c': 2},
+        ),
+        pytest.param(
+            ['a', 'b', 'c'],
+            [],
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            ('a', 'b', 'c'),
+            [],
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            [{'a': 0, 'b': 1}, {'b': 2, 'c': 2}],
+            [],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [{'a': 0, 'b': 1}, ['c']],
+            [],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [['a', 'b'], ['b', 'c'], 'd'],
+            [],
+            marks=pytest.mark.xfail(raises=ValueError),
+        )
+    ]
+)
+def test_join_labels(labels, expected):
+    assert utils.join_labels(labels) == expected
+
+
+@pytest.mark.parametrize(
     'language, expected',
     [
         ('en', 'eng'),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -580,6 +580,14 @@ def test_intersect(objs, expected):
             [{'a': 0, 'b': 1}, {'b': 1, 'c': 2}],
             {'a': 0, 'b': 1, 'c': 2},
         ),
+        (
+            [{'a': 0, 'b': 1}, {'b': 2, 'c': 2}],
+            {'a': 0, 'b': 2, 'c': 2},
+        ),
+        (
+            [{'a': 0}, {'a': 1}, {'a': 2}],
+            {'a': 2},
+        ),
         pytest.param(
             ['a', 'b', 'c'],
             [],
@@ -589,11 +597,6 @@ def test_intersect(objs, expected):
             ('a', 'b', 'c'),
             [],
             marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
-        pytest.param(
-            [{'a': 0, 'b': 1}, {'b': 2, 'c': 2}],
-            [],
-            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(
             [{'a': 0, 'b': 1}, ['c']],


### PR DESCRIPTION
As discussed in https://github.com/audeering/audformat/pull/66#pullrequestreview-648192732 this adds `audformat.utils.join_labels()` as a helper function to join scheme labels before merging two databases.

![image](https://user-images.githubusercontent.com/173624/117249483-ec918880-ae41-11eb-8bc5-f838cd598604.png)
