### PR TITLE
Set dependency to pandas>=1.1.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     audiofile >=0.4.0,<1.0.0
     iso-639
     oyaml
-    pandas >=1.1.0
+    pandas >=1.1.5
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
The following code fails with `pandas < 1.1.5`:

``` python
import audformat.testing

db = audformat.testing.create_db()
db['segments'].pick_files(db.files[0], inplace=True)  # pandas == 1.1.4
```
```
Traceback (most recent call last):
  File "/media/jwagner/Data/Git/pysmile/my/my.py", line 15, in <module>
    db['segments'].pick_files(db.files[0], inplace=True)
  File "/media/jwagner/Data/Git/pysmile/venv/lib/python3.6/site-packages/audformat/core/table.py", line 693, in pick_files
    self._df = self.get(index, copy=False)
  File "/media/jwagner/Data/Git/pysmile/venv/lib/python3.6/site-packages/audformat/core/table.py", line 499, in get
    if index_type(self.index) == index_type(index):
  File "/media/jwagner/Data/Git/pysmile/venv/lib/python3.6/site-packages/audformat/core/index.py", line 186, in index_type
    assert_index(obj)
  File "/media/jwagner/Data/Git/pysmile/venv/lib/python3.6/site-packages/audformat/core/index.py", line 65, in assert_index
    'Index not conform to audformat. '
ValueError: Index not conform to audformat. Found duplicates:
audio/001.wav
audio/001.wav
audio/001.wav
audio/001.wav
audio/001.wav
audio/001.wav
audio/001.wav
audio/001.wav
```

The cause is a bug in `pandas.MultiIndex.intersection()`, which was fixed in  `1.1.5` (see https://github.com/pandas-dev/pandas/issues/36915). 

With `pandas >= 1.1.5` the above example now works as expected:

```
db['segments'].pick_files(db.files[0], inplace=True)  # pandas == 1.1.5
db['segments'].get()
```
```
                                                                    bool  ...   no_scheme
file          start                     end                               ...            
audio/001.wav 0 days 00:00:00.606116265 0 days 00:00:00.814210835   True  ...        None
              0 days 00:00:00.835800869 0 days 00:00:06.411126104   True  ...  uN48spr1mE
              0 days 00:00:10.098759356 0 days 00:00:24.033057571   True  ...  tYhx60CuTN
              0 days 00:00:32.096650475 0 days 00:00:36.056319391   True  ...  S2L6gWk0ww
              0 days 00:00:38.739336073 0 days 00:00:39.945724106   <NA>  ...  H0GabNTWSI
              0 days 00:00:42.112864135 0 days 00:00:44.361285222  False  ...  BObPkuiBRF
              0 days 00:00:46.998945387 0 days 00:00:48.124511384  False  ...  poyn8hc3qP
              0 days 00:00:49.288456801 0 days 00:00:50.074334247   True  ...  heuzfQvrz6
              0 days 00:00:51.655607688 0 days 00:00:53.618228991   <NA>  ...        None
              0 days 00:00:57.863681986 0 days 00:00:59.149501655   <NA>  ...  XzZfJzwq7w
```

