### PR TITLE
Remove root argument from testing.create_audio_files()

### DIFF
--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -8,11 +8,11 @@ from typing import (
     Tuple,
     Optional,
 )
+import warnings
 
 import numpy as np
 import pandas as pd
 
-import audeer
 import audiofile as af
 
 from audformat.core import define
@@ -150,6 +150,7 @@ def add_table(
 
 def create_audio_files(
         db: Database,
+        root: str = None,
         *,
         sample_generator: Callable[[float], float] = None,
         sampling_rate: int = 16000,
@@ -174,12 +175,20 @@ def create_audio_files(
         RuntimeError: if database is not portable
 
     """
+    if root is not None:  # pragma: no cover
+        warnings.warn(
+            "The argument 'root' is deprecated, "
+            "'db.root' will be used.'",
+            category=UserWarning,
+            stacklevel=2,
+        )
+
     if db.root is None:  # pragma: no cover
         raise RuntimeError(
             "Cannot create files if databases was not saved."
         )
 
-    if not db.is_portable():  # pragma: no cover
+    if not db.is_portable:  # pragma: no cover
         raise RuntimeError(
             "Cannot create files if databases is not portable."
         )

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -176,12 +176,12 @@ def create_audio_files(
     """
     if db.root is None:  # pragma: no cover
         raise RuntimeError(
-            f"Cannot create files if databases was not saved."
+            "Cannot create files if databases was not saved."
         )
 
     if not db.is_portable():  # pragma: no cover
         raise RuntimeError(
-            f"Cannot create files if databases is not portable."
+            "Cannot create files if databases is not portable."
         )
 
     file_duration = pd.to_timedelta(file_duration)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ pytest.FILE_DUR = pd.to_timedelta('1s')
 def create_audio_files():
     audformat.testing.create_audio_files(
         pytest.DB,
-        root=pytest.DB_ROOT,
         file_duration=pytest.FILE_DUR,
     )
     yield

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -402,7 +402,7 @@ def test_update(tmpdir):
     )
     db_root = audeer.mkdir(os.path.join(tmpdir, 'db'))
     db.save(db_root)
-    audformat.testing.create_audio_files(db, db_root, file_duration='0.1s')
+    audformat.testing.create_audio_files(db, file_duration='0.1s')
 
     assert db.update(db) == db
 
@@ -427,11 +427,7 @@ def test_update(tmpdir):
     )
     other1_root = audeer.mkdir(os.path.join(tmpdir, 'other1'))
     other1.save(other1_root)
-    audformat.testing.create_audio_files(
-        other1,
-        other1_root,
-        file_duration='0.1s',
-    )
+    audformat.testing.create_audio_files(other1, file_duration='0.1s')
 
     # database with new table
 
@@ -446,11 +442,7 @@ def test_update(tmpdir):
     )
     other2_root = audeer.mkdir(os.path.join(tmpdir, 'other2'))
     other2.save(other2_root)
-    audformat.testing.create_audio_files(
-        other2,
-        other2_root,
-        file_duration='0.1s',
-    )
+    audformat.testing.create_audio_files(other2, file_duration='0.1s')
 
     # raises error because schemes do not match
 


### PR DESCRIPTION
Closes #72 

`testing.create_audio_files(db, ...)` now automatically creates files in `db.root`. An error is raised if `db` was not saved or is not portable.