### PR TITLE
FIX: concat returns DataFrame if at least one object is a DataFrame

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -931,8 +931,6 @@ class Table(HeaderBase):
             [self.df] + [other.df for other in others],
             overwrite=overwrite,
         )
-        if isinstance(df, pd.Series):
-            df = df.to_frame()
 
         # insert missing schemes and raters
         for scheme_id, scheme in missing_schemes.items():
@@ -980,8 +978,6 @@ class Table(HeaderBase):
 
         """
         df = utils.concat([self._df, other._df])
-        if isinstance(df, pd.Series):
-            df = df.to_frame()
 
         table = Table(df.index)
         for column_id in df:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -120,10 +120,12 @@ def concat(
 
     # list with all columns we need to concatenate
     columns = []
+    return_as_frame = False
     for obj in objs:
         if isinstance(obj, pd.Series):
             columns.append(obj)
         else:
+            return_as_frame = True
             for column in obj:
                 columns.append(obj[column])
 
@@ -203,7 +205,7 @@ def concat(
 
     df = pd.DataFrame(columns_reindex, index=index)
 
-    if len(df.columns) == 1:
+    if not return_as_frame and len(df.columns) == 1:
         return df[df.columns[0]]
     else:
         return df

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,11 @@ from audformat import define
             False,
             pd.Series([], audformat.segmented_index(), dtype='object')
         ),
+        (
+            [pd.DataFrame([], audformat.segmented_index(), dtype='object')],
+            False,
+            pd.DataFrame([], audformat.segmented_index(), dtype='object')
+        ),
         # combine series with same name
         (
             [
@@ -342,6 +347,28 @@ from audformat import define
             ),
         ),
         # combine series and data frame
+        (
+            [
+                pd.Series(
+                    [1., 2.],
+                    audformat.filewise_index(['f1', 'f2']),
+                    name='c',
+                ),
+                pd.DataFrame(
+                    {
+                        'c': [2., 3.]
+                    },
+                    audformat.filewise_index(['f2', 'f3']),
+                ),
+            ],
+            False,
+            pd.DataFrame(
+                {
+                    'c': [1., 2., 3.],
+                },
+                audformat.filewise_index(['f1', 'f2', 'f3']),
+            ),
+        ),
         (
             [
                 pd.Series(


### PR DESCRIPTION
`utils.concat()` now always returns a `pd.DataFrame` if at least one of the objects is a `pd.DataFrame`.

This is also what `pd.concat()` does.

### Example:

Return `pd.Series` only if all elements are of type `pd.Series`:

```python
objs = [
    pd.Series([0], index=audformat.filewise_index('f1')),
    pd.Series([1], index=audformat.filewise_index('f2')),
]
type(audformat.utils.concat(objs))
```
```
<class 'pandas.core.series.Series'>
```

but if at least one object is a `pd.DataFrame` return a `pd.DataFrame`:

```python
objs = [
    pd.Series([0], index=audformat.filewise_index('f1')),
    pd.DataFrame([1], index=audformat.filewise_index('f2')),
]
type(audformat.utils.concat(objs))
```
```
<class 'pandas.core.frame.DataFrame'>  # was a pd.Series before
```
