### PR TITLE
Add audformat.utils.join_schemes()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -364,9 +364,9 @@ def join_schemes(
         dbs: typing.Sequence[Database],
         scheme_id: str,
 ):
-    r"""Join and update scheme of two databases.
+    r"""Join and update scheme of databases.
 
-    This joins the given scheme of two databases
+    This joins the given scheme of several databases
     using :func:`audformat.utils.join_labels`
     and replaces the scheme in each database
     with the joined one.

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -361,8 +361,7 @@ def join_labels(
 
 
 def join_schemes(
-        db1: Database,
-        db2: Database,
+        dbs: typing.Sequence[Database],
         scheme: str,
 ):
     r"""Join and update scheme of two databases.
@@ -377,30 +376,25 @@ def join_schemes(
     with :meth:`audformat.Database.update`.
 
     Args:
-        db1: database
-        db2: database
-        scheme: scheme with labels contained in both databases
+        dbs: sequence of databases
+        scheme: scheme ID of a scheme with labels
+            that should be joined
 
     Example:
         >>> db1 = Database('db1')
         >>> db2 = Database('db2')
         >>> db1.schemes['scheme_id'] = Scheme(labels=['a'])
         >>> db2.schemes['scheme_id'] = Scheme(labels=['b'])
-        >>> join_schemes(db1, db2, 'scheme_id')
+        >>> join_schemes([db1, db2], 'scheme_id')
         >>> db1.schemes
         scheme_id:
           dtype: str
           labels: [a, b]
 
     """
-    labels = join_labels(
-        [
-            db1.schemes[scheme].labels,
-            db2.schemes[scheme].labels,
-        ]
-    )
-    db1.schemes[scheme].replace_labels(labels)
-    db2.schemes[scheme].replace_labels(labels)
+    labels = join_labels([db.schemes[scheme].labels for db in dbs])
+    for db in dbs:
+        db.schemes[scheme].replace_labels(labels)
 
 
 def map_language(language: str) -> str:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -10,6 +10,7 @@ import audeer
 import audiofile
 
 from audformat.core import define
+from audformat.core.database import Database
 from audformat.core.index import index_type
 from audformat.core.index import (
     filewise_index,
@@ -374,6 +375,52 @@ def join_labels(
     Scheme(labels=joined_labels)
 
     return joined_labels
+
+
+def join_schemes(
+        db1: Database,
+        db2: Database,
+        scheme: str,
+):
+    r"""Join and update scheme of two databases.
+
+    This joins the given scheme of two databases
+    using :func:`audformat.utils.join_labels`
+    and replaces the scheme in each database
+    with the joined one.
+
+    This might be useful,
+    if you want to combine both databases
+    with :meth:`audformat.Database.update`.
+
+    It uses :func:`audformat.utils.join_labels`
+    to combine the scheme labels.
+
+    Args:
+        db1: database
+        db2: database
+        scheme: scheme with labels contained in both databases
+
+    Example:
+        >>> db1 = Database('db1')
+        >>> db2 = Database('db2')
+        >>> db1.schemes['scheme_id'] = Scheme(labels=['a'])
+        >>> db2.schemes['scheme_id'] = Scheme(labels=['b'])
+        >>> join_schemes(db1, db2, 'scheme_id')
+        >>> db1.schemes
+        scheme_id:
+          dtype: str
+          labels: [a, b]
+
+    """
+    labels = join_labels(
+        [
+            db1.schemes[scheme].labels,
+            db2.schemes[scheme].labels,
+        ]
+    )
+    db1.schemes[scheme].replace_labels(labels)
+    db2.schemes[scheme].replace_labels(labels)
 
 
 def map_language(language: str) -> str:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -370,7 +370,6 @@ def join_schemes(
     using :func:`audformat.utils.join_labels`
     and replaces the scheme in each database
     with the joined one.
-
     The dtype of all :class:`audformat.Column` objects
     that reference the scheme in the databases
     will be updated.

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -372,7 +372,7 @@ def join_schemes(
     with the joined one.
 
     This might be useful,
-    if you want to combine both databases
+    if you want to combine databases
     with :meth:`audformat.Database.update`.
 
     Args:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -301,23 +301,6 @@ def join_labels(
 ):
     r"""Combine scheme labels.
 
-    This might be helpful,
-    if you would like to combine two databases
-    that have the same scheme,
-    but with different labels:
-
-    .. code-block:: python
-
-        labels = audformat.utils.join_labels(
-            [
-                db.schemes['scheme'].labels,
-                db_new.schemes['scheme'].labels,
-            ]
-        )
-        db.schemes['scheme'].replace_labels(labels)
-        db_new.schemes['scheme'].replace_labels(labels)
-        db.update(db_new)
-
     Args:
         labels: sequence of labels to join.
             For dictionary labels,

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -376,9 +376,6 @@ def join_schemes(
     if you want to combine both databases
     with :meth:`audformat.Database.update`.
 
-    It uses :func:`audformat.utils.join_labels`
-    to combine the scheme labels.
-
     Args:
         db1: database
         db2: database

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -362,7 +362,7 @@ def join_labels(
 
 def join_schemes(
         dbs: typing.Sequence[Database],
-        scheme: str,
+        scheme_id: str,
 ):
     r"""Join and update scheme of two databases.
 
@@ -377,7 +377,7 @@ def join_schemes(
 
     Args:
         dbs: sequence of databases
-        scheme: scheme ID of a scheme with labels
+        scheme_id: scheme ID of a scheme with labels
             that should be joined
 
     Example:
@@ -392,9 +392,9 @@ def join_schemes(
           labels: [a, b]
 
     """
-    labels = join_labels([db.schemes[scheme].labels for db in dbs])
+    labels = join_labels([db.schemes[scheme_id].labels for db in dbs])
     for db in dbs:
-        db.schemes[scheme].replace_labels(labels)
+        db.schemes[scheme_id].replace_labels(labels)
 
 
 def map_language(language: str) -> str:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -371,6 +371,11 @@ def join_schemes(
     and replaces the scheme in each database
     with the joined one.
 
+    The dtype of all :class:`audformat.Column` objects
+    that reference the scheme in the databases
+    will be updated.
+    Removed labels are set to ``NaN``.
+
     This might be useful,
     if you want to combine databases
     with :meth:`audformat.Database.update`.

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -2,6 +2,7 @@ from audformat.core.utils import (
     concat,
     intersect,
     join_labels,
+    join_schemes,
     map_language,
     read_csv,
     to_filewise_index,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -22,6 +22,12 @@ join_labels
 .. autofunction:: join_labels
 
 
+join_schemes
+------------
+
+.. autofunction:: join_schemes
+
+
 map_language
 ------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -712,7 +712,9 @@ def test_join_schemes(scheme1, scheme2, expected):
     db2 = audformat.Database('db2')
     db1.schemes['scheme_id'] = scheme1
     db2.schemes['scheme_id'] = scheme2
-    audformat.utils.join_schemes(db1, db2, 'scheme_id')
+    audformat.utils.join_schemes([db1], 'scheme_id')
+    assert db1.schemes['scheme_id'] == scheme1
+    audformat.utils.join_schemes([db1, db2], 'scheme_id')
     assert db1.schemes['scheme_id'] == expected
     assert db2.schemes['scheme_id'] == expected
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -691,32 +691,34 @@ def test_join_labels(labels, expected):
     assert utils.join_labels(labels) == expected
 
 
-@pytest.mark.parametrize(
-    'scheme1, scheme2, expected',
-    [
-        (
-            audformat.Scheme(labels={'a': [1, 2]}),
-            audformat.Scheme(labels={'b': [3]}),
-            audformat.Scheme(labels={'a': [1, 2], 'b': [3]}),
-        ),
-        pytest.param(
-            audformat.Scheme('str'),
-            audformat.Scheme('str'),
-            audformat.Scheme('str'),
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-    ]
-)
-def test_join_schemes(scheme1, scheme2, expected):
+def test_join_schemes():
+    # Empty list
+    audformat.utils.join_schemes([], 'scheme_id')
+    # One database
     db1 = audformat.Database('db1')
-    db2 = audformat.Database('db2')
+    scheme1 = audformat.Scheme(labels={'a': [1, 2]})
     db1.schemes['scheme_id'] = scheme1
-    db2.schemes['scheme_id'] = scheme2
     audformat.utils.join_schemes([db1], 'scheme_id')
     assert db1.schemes['scheme_id'] == scheme1
+    # Two databases
+    db2 = audformat.Database('db2')
+    scheme2 = audformat.Scheme(labels={'b': [3]})
+    db2.schemes['scheme_id'] = scheme2
+    expected = audformat.Scheme(labels={'a': [1, 2], 'b': [3]})
     audformat.utils.join_schemes([db1, db2], 'scheme_id')
     assert db1.schemes['scheme_id'] == expected
     assert db2.schemes['scheme_id'] == expected
+    # Three database
+    db3 = audformat.Database('db3')
+    scheme3 = audformat.Scheme(labels={'a': [4]})
+    db3.schemes['scheme_id'] = scheme3
+    expected = audformat.Scheme(labels={'a': [4], 'b': [3]})
+    audformat.utils.join_schemes([db1, db2, db3], 'scheme_id')
+    # Fail for schemes without labels
+    with pytest.raises(ValueError):
+        db = audformat.Database('db')
+        db.schemes['scheme_id'] = audformat.Scheme('str')
+        audformat.utils.join_schemes([db], 'scheme_id')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -692,6 +692,32 @@ def test_join_labels(labels, expected):
 
 
 @pytest.mark.parametrize(
+    'scheme1, scheme2, expected',
+    [
+        (
+            audformat.Scheme(labels={'a': [1, 2]}),
+            audformat.Scheme(labels={'b': [3]}),
+            audformat.Scheme(labels={'a': [1, 2], 'b': [3]}),
+        ),
+        pytest.param(
+            audformat.Scheme('str'),
+            audformat.Scheme('str'),
+            audformat.Scheme('str'),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_join_schemes(scheme1, scheme2, expected):
+    db1 = audformat.Database('db1')
+    db2 = audformat.Database('db2')
+    db1.schemes['scheme_id'] = scheme1
+    db2.schemes['scheme_id'] = scheme2
+    audformat.utils.join_schemes(db1, db2, 'scheme_id')
+    assert db1.schemes['scheme_id'] == expected
+    assert db2.schemes['scheme_id'] == expected
+
+
+@pytest.mark.parametrize(
     'language, expected',
     [
         ('en', 'eng'),


### PR DESCRIPTION
As we would need to implement this helper function in every data project, I thought it is better to add it directly here.

![image](https://user-images.githubusercontent.com/173624/117971420-2d9a0900-b32a-11eb-8353-c7d8f9aa425e.png)

I also simplified the docstring of `audformat.utils.join_labels()` where we mentioned the code that is now provided by `audformat.utils.join_schemes()`.