### PR TITLE
DOC: fix description of Database.is_portable

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -189,7 +189,7 @@ class Database(HeaderBase):
         r"""Check if a database can be moved to another location.
 
         To be portable,
-        media may be referenced with an absolute path,
+        media mus not be referenced with an absolute path,
         or contain ``.`` or ``..`` to specify a folder.
         If a database is portable
         it can be moved to another folder

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -189,7 +189,7 @@ class Database(HeaderBase):
         r"""Check if a database can be moved to another location.
 
         To be portable,
-        media mus not be referenced with an absolute path,
+        media must not be referenced with an absolute path,
         or contain ``.`` or ``..`` to specify a folder.
         If a database is portable
         it can be moved to another folder


### PR DESCRIPTION
Before we stated

![image](https://user-images.githubusercontent.com/173624/118821482-939d0800-b8b7-11eb-86c2-3dc14aeeade9.png)

this pull request changes it to 

![image](https://user-images.githubusercontent.com/173624/118821758-d7900d00-b8b7-11eb-8904-3fcebfbc9882.png)
