### PR TITLE
Raise custom BadKeyError when key is not found

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -6,7 +6,11 @@ from collections import OrderedDict
 
 import pandas as pd
 
-from audformat.core.errors import BadTypeError, BadValueError
+from audformat.core.errors import (
+    BadKeyError,
+    BadTypeError,
+    BadValueError,
+)
 
 
 class HeaderDict(OrderedDict):
@@ -73,6 +77,8 @@ class HeaderDict(OrderedDict):
         super().__setitem__(key, value)
 
     def __getitem__(self, key):
+        if key not in self:
+            raise BadKeyError(key, list(self))
         value = super().__getitem__(key)
         if self.get_callback is not None:
             value = self.get_callback(key, value)

--- a/audformat/core/errors.py
+++ b/audformat/core/errors.py
@@ -1,38 +1,6 @@
 import typing
 
 
-class BadValueError(ValueError):
-    """Raised when a value is not in a list of pre-defined strings.
-
-    Args:
-        invalid_value: value causing the error
-        valid_values: list of valid strings
-
-    """
-    def __init__(self, invalid_value: str, valid_values: typing.Sequence[str]):
-        message = (
-            f"Bad value '{invalid_value}', "
-            f"expected one of {list(valid_values)}"
-        )
-        super().__init__(message)
-
-
-class BadTypeError(ValueError):
-    r"""Raised when a value has an unexpected type.
-
-    Args:
-        invalid_value: value causing the error
-        expected_type: expected value type
-
-    """
-    def __init__(self, invalid_value: typing.Any, expected_type: type):
-        message = (
-            f"Bad type '{type(invalid_value)}', "
-            f"expected '{expected_type}'"
-        )
-        super().__init__(message)
-
-
 class BadIdError(ValueError):
     r"""Raised when a field identifier is unknown.
 
@@ -53,4 +21,52 @@ class BadIdError(ValueError):
                 f"Bad {name} ID '{invalid_id}', "
                 f"expected one of {list(dictionary)}"
             )
+        super().__init__(message)
+
+
+class BadKeyError(KeyError):
+    """Raised when a key is not found.
+
+    Args:
+        invalid_key: value causing the error
+        valid_keys: list of valid strings
+
+    """
+    def __init__(self, invalid_key: str, valid_keys: typing.Sequence[str]):
+        message = (
+            f"Bad key '{invalid_key}', "
+            f"expected one of {list(valid_keys)}"
+        )
+        super().__init__(message)
+
+
+class BadTypeError(TypeError):
+    r"""Raised when a value has an unexpected type.
+
+    Args:
+        invalid_value: value causing the error
+        expected_type: expected value type
+
+    """
+    def __init__(self, invalid_value: typing.Any, expected_type: type):
+        message = (
+            f"Bad type '{type(invalid_value)}', "
+            f"expected '{expected_type}'"
+        )
+        super().__init__(message)
+
+
+class BadValueError(ValueError):
+    """Raised when a value is not in a list of pre-defined strings.
+
+    Args:
+        invalid_value: value causing the error
+        valid_values: list of valid strings
+
+    """
+    def __init__(self, invalid_value: str, valid_values: typing.Sequence[str]):
+        message = (
+            f"Bad value '{invalid_value}', "
+            f"expected one of {list(valid_values)}"
+        )
         super().__init__(message)

--- a/audformat/core/errors.py
+++ b/audformat/core/errors.py
@@ -5,9 +5,9 @@ class BadIdError(ValueError):
     r"""Raised when a field identifier is unknown.
 
     Args:
-         name: name of the field
-         invalid_id: identifier causing the error
-         dictionary: dictionary with valid identifiers
+        name: name of the field
+        invalid_id: identifier causing the error
+        dictionary: dictionary with valid identifiers
 
     """
     def __init__(self, name: str, invalid_id: str, dictionary: dict):

--- a/audformat/errors/__init__.py
+++ b/audformat/errors/__init__.py
@@ -1,5 +1,6 @@
 from audformat.core.errors import (
-    BadValueError,
-    BadTypeError,
     BadIdError,
+    BadKeyError,
+    BadTypeError,
+    BadValueError,
 )

--- a/docs/api-errors.rst
+++ b/docs/api-errors.rst
@@ -10,6 +10,12 @@ BadIdError
 .. autoclass:: BadIdError
     :members:
 
+BadKeyError
+-----------
+
+.. autoclass:: BadKeyError
+    :members:
+
 BadTypeError
 ------------
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -49,3 +49,6 @@ def test_errors():
 
     with pytest.raises(audformat.errors.BadValueError):
         audformat.Database('foo', 'internal', 'bad')
+
+    with pytest.raises(audformat.errors.BadKeyError):
+        db['bad']


### PR DESCRIPTION
Introduces custom error class `BadKeyError`, which prints valid keys in the error message.

### Example

At the moment when a table is requested that does not exist, we get:

```python
import audformat.testing


db = audformat.testing.create_db()
db['bad-table']
```
```
Traceback (most recent call last):
  File "/media/jwagner/Data/Git/pyaudformat/my/my.py", line 16, in <module>
    db['bad']
  File "/media/jwagner/Data/Git/pyaudformat/audformat/core/database.py", line 652, in __getitem__
    return self.tables[table_id]
  File "/media/jwagner/Data/Git/pyaudformat/audformat/core/common.py", line 84, in __getitem__
    value = super().__getitem__(key)
KeyError: 'bad-table'
```

Now it prints the names of available tables in the error message:

```
...
  File "/media/jwagner/Data/Git/pyaudformat/audformat/core/common.py", line 81, in __getitem__
    raise BadKeyError(key, list(self))
audformat.core.errors.BadKeyError: "Bad key 'bad-table', expected one of ['files', 'segments']"
```

This also works in other places, e.g. with schemes:

```python
db.schemes['bad-scheme']
```
```
...
audformat.core.errors.BadKeyError: "Bad key 'bad-scheme', expected one of ['bool', 'date', 'float', 'int', 'label', 'label_map_int', 'label_map_str', 'string', 'time']"
```