### PR TITLE
DOC: correct usage argument for Database

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -34,7 +34,8 @@ class Database(HeaderBase):
         name: name of database
         source: data source (e.g. link to website)
         usage: permission of usage, see :class:`audformat.define.Usage`.
-            Set to ``OTHER`` if none of the other fields fit.
+            Set to ``'other'``
+            if none of the other fields fit.
         expires: expiry date
         languages: list of languages
         description: database description


### PR DESCRIPTION
In the documentation we are writing the following at the moment under `audformat.Database`:

![image](https://user-images.githubusercontent.com/173624/123652410-90892600-d82c-11eb-8831-89ba3355b9ce.png)

This pull request corrects it to

![image](https://user-images.githubusercontent.com/173624/123652499-a4348c80-d82c-11eb-8f50-4175bae9c7d8.png)


We could also write `` :attr:`audformat.define.Usage.OTHER` `` instead of `'other'`, which would be safer, but I prefer to provide the string that a user has to add directly as this is part of the API anyway and we should not change it.
