### PR TITLE
Restrict pandas to versions <1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     audiofile >=0.4.0,<1.0.0
     iso-639
     oyaml
-    pandas >=1.1.5, <1.5
+    pandas >=1.1.5, <1.3
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     audiofile >=0.4.0,<1.0.0
     iso-639
     oyaml
-    pandas >=1.1.5
+    pandas >=1.1.5, <1.5
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
As `audformat` fails for `pandas >=1.3` (#93) and there is no easy solution, we first fix the tests by restricting the `pandas` versions.