### PR TITLE
Don't restrict upper audiofile versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.8.0,<2.0.0
-    audiofile >=0.4.0,<1.0.0
+    audiofile >=0.4.0
     iso-639
     oyaml
     pandas >=1.1.5, <1.3


### PR DESCRIPTION
As we need `audiofile>1.0.0` in `audb` we also have to allow for it here.