### PR TITLE
DOC: remove duration from conventions

### DIFF
--- a/docs/data-conventions.rst
+++ b/docs/data-conventions.rst
@@ -252,25 +252,22 @@ Temporal data
 -------------
 
 Temporal duration data
-like response time of a rater,
+like response time of a rater
 should be stored as :class:`pd.Timedelta`.
 Temporal dates
-like time of rating,
+like time of rating
 should be stored as :class:`datetime.datetime`.
 
 .. jupyter-execute::
 
-    import datetime
     import pandas as pd
 
 
     times = [2.1, 0.1]  # in seconds
-    dates = ['2021/08/01', '2021/08/02']
 
     db = audformat.Database('mydata')
 
     db.schemes['time'] = audformat.Scheme(audformat.define.DataType.TIME)
-    db.schemes['date'] = audformat.Scheme(audformat.define.DataType.DATE)
     db.raters['rater'] = audformat.Rater()
 
     db['files'] = audformat.Table(
@@ -280,13 +277,6 @@ should be stored as :class:`datetime.datetime`.
         scheme_id='time',
         rater_id='rater',
     )
-    db['files']['date'] = audformat.Column(
-        scheme_id='date',
-        rater_id='rater',
-    )
     db['files']['time'].set(pd.to_timedelta(times))
-    db['files']['date'].set(
-        [datetime.date(*[int(a) for a in d.split('/')]) for d in dates]
-    )
 
     db['files'].get()

--- a/docs/data-conventions.rst
+++ b/docs/data-conventions.rst
@@ -277,6 +277,6 @@ should be stored as :class:`datetime.datetime`.
         scheme_id='time',
         rater_id='rater',
     )
-    db['files']['time'].set(pd.to_timedelta(times))
+    db['files']['time'].set(pd.to_timedelta(times, unit='s'))
 
     db['files'].get()

--- a/docs/data-conventions.rst
+++ b/docs/data-conventions.rst
@@ -37,7 +37,6 @@ emotion                        emotion categories
 arousal / valence / dominance  emotion dimensions
 speaker                        unique speaker id
 role                           the role a speaker has, e.g. agent vs. client
-duration                       file duration
 transcription                  transcriptions on word or phonetic level
                                accurate enough to be used for ASR
 text                           transcriptions that are not accurate enough
@@ -202,7 +201,7 @@ File and speaker information
 ----------------------------
 
 Meta information like speaker ID
-or file duration
+that is not included in another table
 should be collected in a table ``files``.
 If you have metadata
 belonging only to segments,
@@ -249,74 +248,45 @@ for an extended documentation.
     db['files'].get(map={'speaker': 'gender'})
 
 
-File duration and temporal data
--------------------------------
+Temporal data
+-------------
 
-It is recommended to store file durations
-for every database
-in a table ``files``.
-This information is in principle redundant
-as you can calculate the duration always on the fly,
-but if you have thousands of files
-this might take some time.
-
-Every temporal data
-like file durations
-should be stored as :class:`pandas.Timedelta`
-or :class:`datetime.datetime`.
-
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audiofile as af
-    import numpy as np
-
-
-    signal = np.ones([0, 1000])
-
+Temporal duration data
+like response time of a rater,
+should be stored as :class:`pd.Timedelta`.
+Temporal dates
+like time of rating,
+should be stored as :class:`datetime.datetime`.
 
 .. jupyter-execute::
 
-    import audeer
-    import audiofile as af
-    import numpy as np
+    import datetime
     import pandas as pd
 
 
-    # Create dummy WAV files
-    sampling_rate = 1000
-    af.write('a.wav', np.ones([1, 1000]), sampling_rate)
-    af.write('b.wav', np.ones([1, 500]), sampling_rate)
+    times = [2.1, 0.1]  # in seconds
+    dates = ['2021/08/01', '2021/08/02']
 
     db = audformat.Database('mydata')
 
-    db.schemes['duration'] = audformat.Scheme(dtype=audformat.define.DataType.TIME)
+    db.schemes['time'] = audformat.Scheme(audformat.define.DataType.TIME)
+    db.schemes['date'] = audformat.Scheme(audformat.define.DataType.DATE)
+    db.raters['rater'] = audformat.Rater()
+
     db['files'] = audformat.Table(
         index=audformat.filewise_index(['a.wav', 'b.wav'])
     )
-    db['files']['duration'] = audformat.Column(scheme_id='duration')
-    durations = audeer.run_tasks(
-        task_func=lambda x: pd.to_timedelta(af.duration(x), unit='s'),
-        params=[([f], {}) for f in db.files],
-        num_workers=12,
-        progress_bar=False,
+    db['files']['time'] = audformat.Column(
+        scheme_id='time',
+        rater_id='rater',
     )
-    db['files']['duration'].set(durations)
-
-    db
-
-.. jupyter-execute::
+    db['files']['date'] = audformat.Column(
+        scheme_id='date',
+        rater_id='rater',
+    )
+    db['files']['time'].set(pd.to_timedelta(times))
+    db['files']['date'].set(
+        [datetime.date(*[int(a) for a in d.split('/')]) for d in dates]
+    )
 
     db['files'].get()
-
-
-.. Clean up
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import os
-
-    os.remove('a.wav')
-    os.remove('b.wav')

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -214,15 +214,6 @@ to the emotion table.
     }
     transcriptions = list(parse_names(names, from_i=2, to_i=5))
 
-    durations = audeer.run_tasks(
-        task_func=lambda x: pd.to_timedelta(
-            af.duration(os.path.join(src_dir, x)),
-            unit='s',
-        ),
-        params=[([f], {}) for f in files],
-        num_workers=12,
-    )
-
 
 Create audformat database
 -------------------------
@@ -280,14 +271,10 @@ and assign the information to it.
         labels=transcription_mapping,
         description='Sentence produced by actor.',
     )
-    db.schemes['duration'] = audformat.Scheme(dtype=audformat.define.DataType.TIME)
 
     # Tables
     index = audformat.filewise_index(files)
     db['files'] = audformat.Table(index)
-
-    db['files']['duration'] = audformat.Column(scheme_id='duration')
-    db['files']['duration'].set(durations, index=index)
 
     db['files']['speaker'] = audformat.Column(scheme_id='speaker')
     db['files']['speaker'].set(speakers)


### PR DESCRIPTION
As we store the duration information in the dependency table automatically every time we publish data with `audb`,
there is no longer a need to store that information in a table as well.

This adjusts the conventions to discuss only `Timedelta` and `datetime`

![image](https://user-images.githubusercontent.com/173624/128673731-515b35e0-ae45-407f-8ac7-3724dab6f69f.png)

And removes the duration column and scheme from the `emodb` example.