### PR TITLE
Speedup audformat.utils.union()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -874,24 +874,10 @@ def union(
 
     # Combine all MultiIndex entries and drop duplicates afterwards,
     # faster than using index.union(),
-    # compare https://github.com/audeering/audformat/issues/97
+    # compare https://github.com/audeering/audformat/pull/98
     df = pd.concat([o.to_frame() for o in objs])
     index = df.index
     index = index.drop_duplicates()
     index, _ = index.sortlevel()
-
-    if isinstance(index, pd.MultiIndex) and len(index.levels) == 3:
-        # asserts that start and end are of type 'timedelta64[ns]'
-        if index.empty:
-            index = segmented_index()
-        elif index.levels[2].empty:
-            # If all end values are NaT, pandas stores an empty array and
-            # since pd.Index.union() in that case sets the type to
-            # DatetimeArray, we need to set it back to 'timedelta64[ns]'.
-            index.set_levels(
-                [pd.to_timedelta([])],
-                level=[2],
-                inplace=True,
-            )
 
     return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -872,9 +872,13 @@ def union(
     if len(set(types)) != 1:
         objs = [to_segmented_index(obj) for obj in objs]
 
-    index = objs[0]
-    for obj in objs[1:]:
-        index = index.union(obj)
+    # Combine all MultiIndex entries and drop duplicates afterwards,
+    # faster than using index.union(),
+    # compare https://github.com/audeering/audformat/issues/97
+    df = pd.concat([o.to_frame() for o in objs])
+    index = df.index
+    index = index.drop_duplicates()
+    index, _ = index.sortlevel()
 
     if isinstance(index, pd.MultiIndex) and len(index.levels) == 3:
         # asserts that start and end are of type 'timedelta64[ns]'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1257,7 +1257,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
             audformat.segmented_index(
                 ['f1', 'f1', 'f2', 'f2', 'f3'],
                 [0, 0, 0, 0, 0],
-                [1, pd.NaT, 1, pd.NaT, 1],
+                [pd.NaT, 1, pd.NaT, 1, 1],
             ),
         ),
         (
@@ -1269,7 +1269,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
             audformat.segmented_index(
                 ['f1', 'f1', 'f2', 'f3'],
                 [0, 0, 0, 0],
-                [1, pd.NaT, 1, 1],
+                [pd.NaT, 1, 1, 1],
             ),
         ),
         (
@@ -1281,7 +1281,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
             audformat.segmented_index(
                 ['f1', 'f1', 'f2', 'f2', 'f3'],
                 [0, 0, 0, 0, 0],
-                [1, pd.NaT, 1, pd.NaT, pd.NaT],
+                [pd.NaT, 1, pd.NaT, 1, pd.NaT],
             ),
         ),
     ]


### PR DESCRIPTION
Closes #97 

This avoids calling `index.union()` several times and replaces it by transforming each index to a dataframe and using `pd.concat` to combine them and remove duplicated index entries afterwards.

This decreases the execution times reported in #97 to:

```python
>>> measure(idx[:10])
0.043624162673950195
>>> measure(idx[:20])
0.09886717796325684
>>> measure(idx[:30])
0.137054443359375
>>> measure(idx[:40])
0.21222424507141113
>>> measure(idx[:50])
0.2929871082305908
>>> measure(idx[:60])
0.36236071586608887
```

Now we are similar to the 0.15899324417114258 for `idx[:60]` when not caring about duplicates and not sorting the results,
and a lot better than the 274.86833333969116 it took before.

There is a small change in the order of the returned arrays, as now we always put `np.NaT` before any number as this is the default behavior of `index.sortlevel()` which we cannot change.