### PR TITLE
DOC: fix typings from define to str

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -108,7 +108,7 @@ class Database(HeaderBase):
             self,
             name: str,
             source: str = '',
-            usage: define.Usage = define.Usage.UNRESTRICTED,
+            usage: str = define.Usage.UNRESTRICTED,
             *,
             expires: datetime.date = None,
             languages: typing.Union[str, typing.Sequence[str]] = None,
@@ -393,9 +393,7 @@ class Database(HeaderBase):
             *,
             name: str = 'db',
             indent: int = 2,
-            storage_format: define.TableStorageFormat = (
-                define.TableStorageFormat.CSV
-            ),
+            storage_format: str = define.TableStorageFormat.CSV,
             update_other_formats: bool = True,
             header_only: bool = False,
             num_workers: typing.Optional[int] = 1,

--- a/audformat/core/media.py
+++ b/audformat/core/media.py
@@ -10,7 +10,9 @@ class Media(HeaderBase):
     File ``format`` is always converted to lower case.
 
     Args:
-        type: media type
+        type: media type,
+            see :class:`audformat.define.MediaType`
+            for available media types
         format: file format (e.g. 'wav', 'flac', 'mp4')
         sampling_rate: audio sampling rate in Hz
         channels: number of audio channels
@@ -37,7 +39,7 @@ class Media(HeaderBase):
     """
     def __init__(
             self,
-            type: define.MediaType = define.MediaType.OTHER,
+            type: str = define.MediaType.OTHER,
             *,
             format: str = None,
             sampling_rate: int = None,

--- a/audformat/core/rater.py
+++ b/audformat/core/rater.py
@@ -6,7 +6,9 @@ class Rater(HeaderBase):
     r"""A rater is the author of an annotation.
 
     Args:
-        type: rater type
+        type: rater type,
+            see :class:`audformat.define.RaterType`
+            for available rater types
         description: rater description
         meta: additional meta fields
 
@@ -21,7 +23,7 @@ class Rater(HeaderBase):
     """
     def __init__(
             self,
-            type: define.RaterType = define.RaterType.HUMAN,
+            type: str = define.RaterType.HUMAN,
             *,
             description: str = None,
             meta: dict = None,

--- a/audformat/core/split.py
+++ b/audformat/core/split.py
@@ -11,7 +11,9 @@ class Split(HeaderBase):
     development or testing.
 
     Args:
-        type: split type
+        type: split type,
+            see :class:`audformat.define.SplitType`
+            for available split types
         description: split description
         meta: additional meta fields
 
@@ -25,7 +27,7 @@ class Split(HeaderBase):
     """
     def __init__(
             self,
-            type: define.SplitType = define.SplitType.OTHER,
+            type: str = define.SplitType.OTHER,
             *,
             description: str = None,
             meta: dict = None,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -699,9 +699,7 @@ class Table(HeaderBase):
             self,
             path: str,
             *,
-            storage_format: define.TableStorageFormat = (
-                define.TableStorageFormat.CSV
-            ),
+            storage_format: str = define.TableStorageFormat.CSV,
             update_other_formats: bool = True,
     ):
         r"""Save table data to disk.

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -32,7 +32,7 @@ from audformat.core.column import Column
 def add_table(
         db: Database,
         table_id: str,
-        index_type: define.IndexType,
+        index_type: str,
         *,
         columns: Union[
             str,
@@ -59,7 +59,9 @@ def add_table(
     Args:
         db: a database
         table_id: ID of table that will be created
-        index_type: the table type
+        index_type: the index type,
+            see :class:`audformat.define.IndexType`
+            for available index types
         columns: a list of scheme_ids or a dictionary with column names as
             keys and tuples of ``(scheme_id, rater_id)`` as values. ``None``
             values are allowed


### PR DESCRIPTION
Closes #39.

At several places in the documentation we used `audformat.define.*` as the type, but the type was always `str` in those cases, that should then be set to a value given by the define setting.

I fixed this, e.g. by changing

![image](https://user-images.githubusercontent.com/173624/130202319-a3decb5f-1267-4d22-96ce-17d58189dd0c.png)

to

![image](https://user-images.githubusercontent.com/173624/130202349-3ba87e22-c804-44c6-8c41-b408a8357bff.png)
