### PR TITLE
Speed up creation of Database.files index

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -178,10 +178,10 @@ class Database(HeaderBase):
             files
 
         """
-        index = pd.Index([], name=define.IndexField.FILE)
-        for table in self.tables.values():
-            index = index.union(table.files.drop_duplicates())
-        return index.drop_duplicates()
+        index = utils.union(
+            [table.files.drop_duplicates() for table in self.tables.values()]
+        )
+        return index
 
     @property
     def is_portable(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -199,7 +199,7 @@ class Table(HeaderBase):
         """
         # We use len() here as self.df.index.empty takes a very long time
         if len(self.df.index) == 0:
-             return filewise_index()
+            return filewise_index()
         else:
             index = self.df.index.get_level_values(define.IndexField.FILE)
             index.name = define.IndexField.FILE

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -197,8 +197,9 @@ class Table(HeaderBase):
             files
 
         """
-        if self.df.index.empty:
-            return filewise_index()
+        # We use len() here as self.df.index.empty takes a very long time
+        if len(self.df.index) == 0:
+             return filewise_index()
         else:
             index = self.df.index.get_level_values(define.IndexField.FILE)
             index.name = define.IndexField.FILE

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -355,7 +355,8 @@ def intersect(
             index_segmented.isin(index_filewise, 0)
         ]
 
-    if index.empty and index_type(index) == define.IndexType.SEGMENTED:
+    # We use len() here as index.empty takes a very long time
+    if len(index) == 0 and index_type(index) == define.IndexType.SEGMENTED:
         # asserts that start and end are of type 'timedelta64[ns]'
         index = segmented_index()
 


### PR DESCRIPTION
This contains two parts:

* When calling `audformat.Database.files` we used `pandas.Index.union` before with is slow as discussed in https://pandas.pydata.org/docs/reference/index.html#api. I replace it here with `audformat.utils.union()` instead
* It also has to call `audformat.Table.files` which was slow due to using `df.index.empty` which takes a long time for no reason. I replaced it by `len(df.index) == 0`