### PR TITLE
Speed up Database.segments

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -233,12 +233,14 @@ class Database(HeaderBase):
             segments
 
         """
-        index = segmented_index()
-        for table in self.tables.values():
-            if table.is_segmented:
-                index = index.union(table.df.index)
-        assert isinstance(index, pd.MultiIndex)
-        return index.drop_duplicates()
+        index = utils.union(
+            [
+                table.df.index
+                for table in self.tables.values()
+                if table.is_segmented
+            ]
+        )
+        return index
 
     def drop_files(
             self,


### PR DESCRIPTION
Similar to #107 this speeds up the creation of a union index by using `audformat.utils.union()` instead of `pandas.Index.union()`.

Before when calling `Database.segments` on a large database it took 75s to execute. After thios change the time is down to 0.5s.