### PR TITLE
Replace using Index.empty by len(Index) == 0

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -172,7 +172,8 @@ def concat(
                         column.index,
                     ]
                 )
-                if not intersection.empty:
+                # We use len() here as index.empty takes a very long time
+                if len(intersection) > 0:
                     combine = pd.DataFrame(
                         {
                             'left': columns_reindex[column.name][intersection],
@@ -275,7 +276,8 @@ def duration(
     if not isinstance(obj, pd.MultiIndex):
         obj = obj.index
 
-    if obj.empty:
+    # We use len() here as index.empty takes a very long time
+    if len(obj) == 0:
         return pd.Timedelta(0, unit='s')
 
     starts = obj.get_level_values(define.IndexField.START)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -56,7 +56,7 @@ def test_drop_files(files, num_workers):
     else:
         if isinstance(files, str):
             files = [files]
-    assert db.files.intersection(files).empty
+    assert len(db.files.intersection(files)) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -540,7 +540,7 @@ def test_drop_files(files, table):
         files = table.files.to_series().apply(files)
     elif isinstance(files, str):
         files = [files]
-    assert table.files.intersection(files).empty
+    assert len(table.files.intersection(files)) == 0
 
 
 @pytest.mark.parametrize(
@@ -597,7 +597,7 @@ def test_empty():
     db['table'] = audformat.Table()
 
     assert db['table'].type == audformat.define.IndexType.FILEWISE
-    assert db['table'].files.empty
+    assert len(db['table'].files) == 0
     assert len(db['table']) == 0
 
     db['table']['column'] = audformat.Column()


### PR DESCRIPTION
Closes #109.

Replaces using `pandas.Index.empty` with using `len()` instead inside `audformat.utils.concat()`, `audformat.utils.duration()` and in some tests.