### PR TITLE
Add Database.files_duration()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -303,9 +303,9 @@ class Database(HeaderBase):
         database is reloaded from disk.
 
         Use ``db.files_duration(db.files).sum()``
-        to get the total duration of a database.
-        Or ``db.files_duration(db['table'].files).sum()``
-        to get the total duration of a table.
+        to get the total duration of all files in a database.
+        Or ``db.files_duration(db[table_id].files).sum()``
+        to get the total duration of all files assigned to a table.
 
         Args:
             files: file names

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -298,16 +298,16 @@ class Database(HeaderBase):
     ) -> pd.Series:
         r"""Duration of files in the database.
 
-        Note that durations are cached,
-        i.e. changing the files on disk after calling
-        this function can lead to wrong results.
-        The cache is cleared when the
-        database is reloaded from disk.
-
         Use ``db.files_duration(db.files).sum()``
         to get the total duration of all files in a database.
         Or ``db.files_duration(db[table_id].files).sum()``
         to get the total duration of all files assigned to a table.
+
+        .. note:: Durations are cached,
+            i.e. changing the files on disk after calling
+            this function can lead to wrong results.
+            The cache is cleared when the
+            database is reloaded from disk.
 
         Args:
             files: file names

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -339,7 +339,7 @@ class Database(HeaderBase):
                 # expand file path
                 if root is None:
                     raise ValueError(
-                        "Found relative file name "
+                        f"Found relative file name "
                         f"{file}, "
                         f"but db.root is None. "
                         f"Please save database or "

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -166,7 +166,7 @@ class Database(HeaderBase):
         )
         r"""Dictionary of tables"""
 
-        self._file_duration = {}
+        self._files_duration = {}
         self._name = None
         self._root = None
 
@@ -319,17 +319,17 @@ class Database(HeaderBase):
         """
         if not isinstance(files, str):
             return pd.Series(files, index=files).map(self.files_duration)
-        elif files not in self._file_duration:
+        elif files not in self._files_duration:
             if not os.path.isabs(files) and self.root is not None:
                 path = os.path.join(self.root, files)
             else:
                 path = files
             dur = audiofile.duration(path)
             dur = pd.to_timedelta(dur, unit='s')
-            self._file_duration[files] = dur
+            self._files_duration[files] = dur
             return dur
         else:
-            return self._file_duration[files]
+            return self._files_duration[files]
 
     def map_files(
             self,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -295,11 +295,11 @@ class Database(HeaderBase):
             self,
             file: str = None,
     ) -> pd.Timedelta:
-        r"""Duration of file or database.
+        r"""Duration of a single file or all files in the database.
 
         Args:
             file: if a file name is given,
-                returns duration of this file.
+                returns duration of the file.
                 If ``None`` returns the summed duration
                 of all files in the database
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -313,7 +313,8 @@ class Database(HeaderBase):
             files: file names
             root: root directory under which the files are stored.
                 Provide if file names are relative and
-                database was not saved or loaded from disk
+                database was not saved or loaded from disk.
+                If ``None`` :attr:`audformat.Database.root` is used
 
         Returns:
             mapping from file to duration

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -204,14 +204,7 @@ def test_files_duration():
     root = db._root
     db._root = None
 
-    message = (
-        "Found relative file name "
-        f"{files_rel[0]}, "
-        f"but db.root is None. "
-        f"Please save database or "
-        f"provide a root folder."
-    )
-    with pytest.raises(ValueError, match=message):
+    with pytest.raises(ValueError):
         db.files_duration(files_rel)
 
     for _ in range(2):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -164,7 +164,7 @@ def test_drop_and_pick_tables():
     assert 'segments' not in db
 
 
-def test_file_duration():
+def test_files_duration():
 
     db = pytest.DB
 
@@ -173,10 +173,10 @@ def test_file_duration():
     file = db.files[0]
     full_file = os.path.join(db.root, file)
     dur = pd.to_timedelta(audiofile.duration(full_file), unit='s')
-    assert db.file_duration(file) == dur
-    assert db.file_duration(full_file) == dur
-    assert db.file_duration(file) == dur
-    assert db.file_duration(full_file) == dur
+    assert db.files_duration(file) == dur
+    assert db.files_duration(full_file) == dur
+    assert db.files_duration(file) == dur
+    assert db.files_duration(full_file) == dur
 
     # duration of whole database
 
@@ -185,8 +185,8 @@ def test_file_duration():
         full_file = os.path.join(db.root, file)
         dur = audiofile.duration(full_file)
         total_dur += pd.to_timedelta(dur, unit='s')
-    assert db.file_duration() == total_dur
-    assert db.file_duration() == total_dur
+    assert db.files_duration(db.files).sum() == total_dur
+    assert db.files_duration(db.files).sum() == total_dur
 
 
 @pytest.mark.parametrize(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -175,6 +175,8 @@ def test_file_duration():
     dur = pd.to_timedelta(audiofile.duration(full_file), unit='s')
     assert db.file_duration(file) == dur
     assert db.file_duration(full_file) == dur
+    assert db.file_duration(file) == dur
+    assert db.file_duration(full_file) == dur
 
     # duration of whole database
 
@@ -183,6 +185,7 @@ def test_file_duration():
         full_file = os.path.join(db.root, file)
         dur = audiofile.duration(full_file)
         total_dur += pd.to_timedelta(dur, unit='s')
+    assert db.file_duration() == total_dur
     assert db.file_duration() == total_dur
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -173,10 +173,10 @@ def test_files_duration():
     file = db.files[0]
     full_file = os.path.join(db.root, file)
     dur = pd.to_timedelta(audiofile.duration(full_file), unit='s')
-    assert db.files_duration(file) == dur
-    assert db.files_duration(full_file) == dur
-    assert db.files_duration(file) == dur
-    assert db.files_duration(full_file) == dur
+    assert db.files_duration(file)[file] == dur
+    assert db.files_duration(full_file)[full_file] == dur
+    assert db.files_duration(file)[file] == dur
+    assert db.files_duration(full_file)[full_file] == dur
 
     # duration of whole database
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,6 +3,7 @@ import filecmp
 import os
 
 import audeer
+import audiofile
 import pandas as pd
 import pytest
 
@@ -161,6 +162,28 @@ def test_drop_and_pick_tables():
     assert 'segments' in db
     db.drop_tables('segments')
     assert 'segments' not in db
+
+
+def test_file_duration():
+
+    db = pytest.DB
+
+    # duration of single file
+
+    file = db.files[0]
+    full_file = os.path.join(db.root, file)
+    dur = pd.to_timedelta(audiofile.duration(full_file), unit='s')
+    assert db.file_duration(file) == dur
+    assert db.file_duration(full_file) == dur
+
+    # duration of whole database
+
+    total_dur = pd.to_timedelta(0)
+    for file in db.files:
+        full_file = os.path.join(db.root, file)
+        dur = audiofile.duration(full_file)
+        total_dur += pd.to_timedelta(dur, unit='s')
+    assert db.file_duration() == total_dur
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As discussed in #111 this adds `Database.file_duration()`.

![image](https://user-images.githubusercontent.com/10383417/140804334-10b3766b-190e-4092-bb8e-697a3c6fe2f3.png)

Uses `audiofile.duration()` to calculate the duration of a file and caches the result Internally in `Database._files_duration`. I decided to name it `files_duration()` to not confuse it with `utils.duration()` which returns the duration of the segments in a table.

I decided to use a dictionary instead of a `pd.Series`, as the latter is much slower as the following test shows:

```python
ts = [pd.to_timedelta(random.random(), unit='s') for _ in range(10000)]

d = {}
tt = time.time()
for idx, t in enumerate(ts):
    d[f'{idx}'] = t
time.time() - tt
```
```
0.0021936893463134766
```

```python
y = pd.Series()
tt = time.time()
for idx, t in enumerate(ts):
    y[f'{idx}'] = t
time.time() - tt
```
```
9.314390182495117
```

### Example

```python
db = audb.load(
    'emodb',
    version='1.1.1',
    format='wav',
    mixdown=True,
    sampling_rate=16000,
    only_metadata=True,
    full_path=False,
)
```

```python
db.files_duration(db.files).sum()
```
```
0 days 00:24:47.092187490
```

```python
db.files_duration(db['emotion'].files[:10])
```
```
file
wav/03a01Fa.wav      0 days 00:00:01.898250
wav/03a01Nc.wav      0 days 00:00:01.611250
wav/03a01Wa.wav   0 days 00:00:01.877812500
wav/03a02Fc.wav      0 days 00:00:02.006250
wav/03a02Nc.wav   0 days 00:00:01.439812500
wav/03a02Ta.wav   0 days 00:00:01.735687500
wav/03a02Wb.wav      0 days 00:00:02.123625
wav/03a02Wc.wav   0 days 00:00:01.498062500
wav/03a04Ad.wav   0 days 00:00:01.504874999
wav/03a04Fd.wav   0 days 00:00:01.696812500
Name: file, dtype: timedelta64[ns]
```
