### PR TITLE
Database.files_duration: always store full path

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -330,14 +330,10 @@ class Database(HeaderBase):
 
         def duration(file: str) -> pd.Timedelta:
 
-            # check cache
-            if file in self._files_duration:
-                return self._files_duration[file]
-
+            # expand file path
             if os.path.isabs(file):
                 full_file = file
             else:
-                # expand file path
                 if root is None:
                     raise ValueError(
                         f"Found relative file name "
@@ -347,14 +343,15 @@ class Database(HeaderBase):
                         f"provide a root folder."
                     )
                 full_file = os.path.join(root, file)
-                # check cache again with full path
-                if full_file in self._files_duration:
-                    return self._files_duration[full_file]
+
+            # check cache
+            if full_file in self._files_duration:
+                return self._files_duration[full_file]
 
             # calculate duration and cache it
             dur = audiofile.duration(full_file)
             dur = pd.to_timedelta(dur, unit='s')
-            self._files_duration[file] = dur
+            self._files_duration[full_file] = dur
 
             return dur
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -345,6 +345,7 @@ class Database(HeaderBase):
                 full_file = os.path.join(root, file)
 
             # check cache
+            full_file = audeer.safe_path(full_file)
             if full_file in self._files_duration:
                 return self._files_duration[full_file]
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -177,17 +177,6 @@ def test_files_duration():
         for file in files_abs
     ]
 
-    # test with absolute file names
-
-    expected_abs = pd.Series(
-        durs,
-        index=files_abs,
-        name=audformat.define.IndexField.FILE,
-    )
-    for _ in range(2):
-        y = db.files_duration(files_abs)
-        pd.testing.assert_series_equal(y, expected_abs)
-
     # test with relative file names
 
     expected_rel = pd.Series(
@@ -198,6 +187,17 @@ def test_files_duration():
     for _ in range(2):
         y = db.files_duration(files_rel)
         pd.testing.assert_series_equal(y, expected_rel)
+
+    # test with absolute file names
+
+    expected_abs = pd.Series(
+        durs,
+        index=files_abs,
+        name=audformat.define.IndexField.FILE,
+    )
+    for _ in range(2):
+        y = db.files_duration(files_abs)
+        pd.testing.assert_series_equal(y, expected_abs)
 
     # simulate that we have not loaded db from disk
 


### PR DESCRIPTION
In #114 we had discussed if it makes sense to store duration with the relative path. But the more obvious solution is to always store the full path. As the following examples show, we can now request durations with a relative and absolute path and independent of the `full_path` argument we never get duplicated entries in the dictionary:

```python
db = audb.load(
    'emodb',
    version='1.1.1',
    format='wav',
    mixdown=True,
    sampling_rate=16000,
    only_metadata=True,
    full_path=False,
)

file = db.files[0]
db.files_duration(file)

full_file = os.path.join(db.root, file)
db.files_duration(full_file)

db._files_duration
```
```
{'/media/jwagner/Data/audb/emodb/1.1.1/fe182b91/wav/03a01Fa.wav': Timedelta('0 days 00:00:01.898250')}
```

```python
db = audb.load(
    'emodb',
    version='1.1.1',
    format='wav',
    mixdown=True,
    sampling_rate=16000,
    only_metadata=True,
    full_path=True,
)

file = full_file[len(db.root) + 1:]
db.files_duration(file)

full_file = os.path.join(db.root, file)
db.files_duration(full_file)

db._files_duration
```
```
{'/media/jwagner/Data/audb/emodb/1.1.1/fe182b91/wav/03a01Fa.wav': Timedelta('0 days 00:00:01.898250')}
```

With the current master you get in both cases:

```python
{'wav/03a01Fa.wav': Timedelta('0 days 00:00:01.898250'), '/media/jwagner/Data/audb/emodb/1.1.1/fe182b91/wav/03a01Fa.wav': Timedelta('0 days 00:00:01.898250')}
```