### PR TITLE
Get table or column data with a segmented index

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -154,7 +154,13 @@ class Column(HeaderBase):
                 assigned to a scheme that contains a dict mapping
                 speaker IDs to age entries, ``map='age'``
                 will replace the ID values with the age of the speaker
-            as_segmented: always return a segmented index
+            as_segmented: if set to ``True``
+                and column has a filewise index,
+                the index of the returned column
+                will be converted to a segmented index.
+                ``start`` will be set to ``0`` and
+                ``end`` to ``NaT`` or to the file duration
+                if ``allow_nat`` is set to ``False``
             allow_nat: if set to ``False``,
                 ``end=NaT`` is replaced with file duration
             root: root directory under which the files are stored.

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -171,6 +171,7 @@ class Column(HeaderBase):
             labels
 
         Raises:
+            FileNotFoundError: if file is not found
             RuntimeError: if column is not assigned to a table
             ValueError: if trying to map without a scheme
             ValueError: if trying to map from a scheme that has no labels

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -131,6 +131,10 @@ class Column(HeaderBase):
             *,
             map: str = None,
             copy: bool = True,
+            as_segmented: bool = False,
+            allow_nat: bool = True,
+            num_workers: typing.Optional[int] = 1,
+            verbose: bool = False,
     ) -> pd.Series:
         r"""Get labels.
 
@@ -149,6 +153,13 @@ class Column(HeaderBase):
                 assigned to a scheme that contains a dict mapping
                 speaker IDs to age entries, ``map='age'``
                 will replace the ID values with the age of the speaker
+            as_segmented: always return with a ``segmented`` index
+            allow_nat: if set to ``False``,
+                ``end=NaT`` is replaced with file duration
+            num_workers: number of parallel jobs.
+                If ``None`` will be set to the number of processors
+                on the machine multiplied by 5
+            verbose: show progress bar
 
         Returns:
             labels
@@ -165,7 +176,14 @@ class Column(HeaderBase):
                 'Column is not assigned to a table.'
             )
 
-        result = self._table.get(index, copy=False)
+        result = self._table.get(
+            index,
+            copy=False,
+            as_segmented=as_segmented,
+            allow_nat=allow_nat,
+            num_workers=num_workers,
+            verbose=verbose,
+        )
         result = result[self._id]
 
         if map is not None:

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -133,6 +133,7 @@ class Column(HeaderBase):
             copy: bool = True,
             as_segmented: bool = False,
             allow_nat: bool = True,
+            root: str = None,
             num_workers: typing.Optional[int] = 1,
             verbose: bool = False,
     ) -> pd.Series:
@@ -153,9 +154,14 @@ class Column(HeaderBase):
                 assigned to a scheme that contains a dict mapping
                 speaker IDs to age entries, ``map='age'``
                 will replace the ID values with the age of the speaker
-            as_segmented: always return with a ``segmented`` index
+            as_segmented: always return a segmented index
             allow_nat: if set to ``False``,
                 ``end=NaT`` is replaced with file duration
+            root: root directory under which the files are stored.
+                Provide if file names are relative and
+                database was not saved or loaded from disk.
+                If ``None`` :attr:`audformat.Database.root` is used.
+                Only relevant if ``allow_nat`` is set to ``False``
             num_workers: number of parallel jobs.
                 If ``None`` will be set to the number of processors
                 on the machine multiplied by 5
@@ -181,6 +187,7 @@ class Column(HeaderBase):
             copy=False,
             as_segmented=as_segmented,
             allow_nat=allow_nat,
+            root=root,
             num_workers=num_workers,
             verbose=verbose,
         )

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -498,7 +498,13 @@ class Table(HeaderBase):
                 values to age and gender, respectively.
                 To also keep the original column with speaker IDS, you can do
                 ``map={'speaker': ['speaker', 'age', 'gender']}``
-            as_segmented: always return a segmented index
+            as_segmented: if set to ``True``
+                and table has a filewise index,
+                the index of the returned table
+                will be converted to a segmented index.
+                ``start`` will be set to ``0`` and
+                ``end`` to ``NaT`` or to the file duration
+                if ``allow_nat`` is set to ``False``
             allow_nat: if set to ``False``,
                 ``end=NaT`` is replaced with file duration
             root: root directory under which the files are stored.

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -467,6 +467,7 @@ class Table(HeaderBase):
             copy: bool = True,
             as_segmented: bool = False,
             allow_nat: bool = True,
+            root: str = None,
             num_workers: typing.Optional[int] = 1,
             verbose: bool = False,
     ) -> pd.DataFrame:
@@ -491,9 +492,14 @@ class Table(HeaderBase):
                 values to age and gender, respectively.
                 To also keep the original column with speaker IDS, you can do
                 ``map={'speaker': ['speaker', 'age', 'gender']}``
-            as_segmented: always return with a ``segmented`` index
+            as_segmented: always return a segmented index
             allow_nat: if set to ``False``,
                 ``end=NaT`` is replaced with file duration
+            root: root directory under which the files are stored.
+                Provide if file names are relative and
+                database was not saved or loaded from disk.
+                If ``None`` :attr:`audformat.Database.root` is used.
+                Only relevant if ``allow_nat`` is set to ``False``
             num_workers: number of parallel jobs.
                 If ``None`` will be set to the number of processors
                 on the machine multiplied by 5
@@ -560,11 +566,15 @@ class Table(HeaderBase):
         is_segmented = index_type(result.index) == define.IndexType.SEGMENTED
         if (not is_segmented and as_segmented)\
                 or (is_segmented and not allow_nat):
-            files_duration = self.db._files_duration if self.db else None
+            files_duration = None
+            if self.db is not None:
+                files_duration = self.db._files_duration
+                root = root or self.db.root
             new_index = utils.to_segmented_index(
                 result.index,
                 allow_nat=allow_nat,
                 files_duration=files_duration,
+                root=root,
                 num_workers=num_workers,
                 verbose=verbose,
             )

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -571,8 +571,10 @@ class Table(HeaderBase):
 
         # if necessary, convert to segmented index and replace NaT
         is_segmented = index_type(result.index) == define.IndexType.SEGMENTED
-        if (not is_segmented and as_segmented)\
-                or (is_segmented and not allow_nat):
+        if (
+                (not is_segmented and as_segmented)
+                or (is_segmented and not allow_nat)
+        ):
             files_duration = None
             if self.db is not None:
                 files_duration = self.db._files_duration

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -515,6 +515,7 @@ class Table(HeaderBase):
             labels
 
         Raises:
+            FileNotFoundError: if file is not found
             RuntimeError: if table is not assign to a database
             ValueError: if trying to map without a scheme
             ValueError: if trying to map from a scheme that has no labels

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -80,6 +80,12 @@ class Table(HeaderBase):
         file
         f1        0
         f2        1
+        >>> table.get(as_segmented=True)
+                        values
+        file start  end
+        f1   0 days NaT      0
+        f2   0 days NaT      1
+        f3   0 days NaT      2
         >>> index_ex = filewise_index('f4')
         >>> table_ex = table.extend_index(
         ...     index_ex,

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -716,6 +716,7 @@ def to_segmented_index(
         obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
         *,
         allow_nat: bool = True,
+        files_duration: typing.MutableMapping[str, pd.Timedelta] = None,
         root: str = None,
         num_workers: typing.Optional[int] = 1,
         verbose: bool = False,
@@ -739,6 +740,13 @@ def to_segmented_index(
             :ref:`table specifications <data-tables:Tables>`
         allow_nat: if set to ``False``, ``end=NaT`` is replaced with file
             duration
+        files_duration: an optional mapping from file to duration.
+            Only relevant if ``allow_nat`` is set to ``False``.
+            If not ``None``,
+            the function will use it to look up durations.
+            If no entry is found for a file,
+            if will be added to the mapping.
+            Expects absolute file names
         root: root directory under which the files referenced in the index
             are stored
         num_workers: number of parallel jobs.
@@ -783,16 +791,26 @@ def to_segmented_index(
             files = index.get_level_values(define.IndexField.FILE)
             starts = index.get_level_values(define.IndexField.START)
 
-            def job(file: str) -> float:
+            def job(file: str) -> pd.Timedelta:
+
                 if root is not None and not os.path.isabs(file):
                     file = os.path.join(root, file)
+                if files_duration is not None and file in files_duration:
+                    return files_duration[file]
+
                 if not os.path.exists(file):
                     raise FileNotFoundError(
                         errno.ENOENT,
                         os.strerror(errno.ENOENT),
                         file,
                     )
-                return audiofile.duration(file)
+                dur = audiofile.duration(file)
+                dur = pd.to_timedelta(dur, unit='s')
+
+                if files_duration is not None:
+                    files_duration[file] = dur
+
+                return dur
 
             params = [([file], {}) for file in files[idx_nat]]
             durs = audeer.run_tasks(
@@ -802,7 +820,7 @@ def to_segmented_index(
                 progress_bar=verbose,
                 task_description='Read duration',
             )
-            ends.values[idx_nat] = pd.to_timedelta(durs, unit='s')
+            ends.values[idx_nat] = durs
 
             index = segmented_index(files, starts, ends)
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -742,7 +742,7 @@ def to_segmented_index(
             duration
         files_duration: mapping from file to duration.
             If not ``None``,
-            the function uses it to look up durations.
+            used to look up durations.
             If no entry is found for a file,
             it is added to the mapping.
             Expects absolute file names.

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -740,13 +740,13 @@ def to_segmented_index(
             :ref:`table specifications <data-tables:Tables>`
         allow_nat: if set to ``False``, ``end=NaT`` is replaced with file
             duration
-        files_duration: an optional mapping from file to duration.
-            Only relevant if ``allow_nat`` is set to ``False``.
+        files_duration: mapping from file to duration.
             If not ``None``,
-            the function will use it to look up durations.
+            the function uses it to look up durations.
             If no entry is found for a file,
-            if will be added to the mapping.
-            Expects absolute file names
+            it is added to the mapping.
+            Expects absolute file names.
+            Only relevant if ``allow_nat`` is set to ``False``
         root: root directory under which the files referenced in the index
             are stored
         num_workers: number of parallel jobs.

--- a/docs/data-tables.rst
+++ b/docs/data-tables.rst
@@ -86,6 +86,12 @@ Access labels as :class:`pandas.Series`
 
     db['filewise']['values'].get()
 
+Access labels with a segmented index:
+
+.. jupyter-execute::
+
+    db['filewise']['values'].get(as_segmented=True)
+
 Create a segmented index:
 
 .. jupyter-execute::

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -118,7 +118,6 @@ def test_filewise(num_files, values):
 def test_get_as_segmented():
 
     db = pytest.DB
-    db._files_duration = {}
 
     y = db['files']['bool'].get()
     assert audformat.index_type(y) == audformat.define.IndexType.FILEWISE

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -167,7 +167,6 @@ def test_drop_and_pick_tables():
 def test_files_duration():
 
     db = pytest.DB
-    db._files_duration = {}
 
     # prepare file names
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -167,6 +167,7 @@ def test_drop_and_pick_tables():
 def test_files_duration():
 
     db = pytest.DB
+    db._files_duration = {}
 
     # prepare file names
 
@@ -217,6 +218,11 @@ def test_files_duration():
         file: dur for file, dur in zip(files_abs, durs)
     }
     assert db._files_duration == expected_cache
+
+    # reset db
+
+    db._files_duration = {}
+    db._root = root
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -809,7 +809,6 @@ def test_filewise(num_files, values):
 def test_get_as_segmented():
 
     db = pytest.DB
-    db._files_duration = {}
 
     df = db['files'].get()
     assert audformat.index_type(df) == audformat.define.IndexType.FILEWISE

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -806,6 +806,44 @@ def test_filewise(num_files, values):
     pd.testing.assert_frame_equal(table.get(), df)
 
 
+def test_get_as_segmented():
+
+    db = pytest.DB
+    db._files_duration = {}
+
+    df = db['files'].get()
+    assert audformat.index_type(df) == audformat.define.IndexType.FILEWISE
+    assert not db._files_duration
+
+    # convert to segmented index
+
+    df = db['files'].get(
+        as_segmented=True,
+        allow_nat=True,
+    )
+    assert audformat.index_type(df) == audformat.define.IndexType.SEGMENTED
+    assert not db._files_duration
+    assert df.index.get_level_values(
+        audformat.define.IndexField.END
+    ).isna().all()
+
+    # replace NaT with file duration
+
+    df = db['files'].get(
+        as_segmented=True,
+        allow_nat=False,
+    )
+    assert audformat.index_type(df) == audformat.define.IndexType.SEGMENTED
+    assert db._files_duration
+    assert not df.index.get_level_values(
+        audformat.define.IndexField.END
+    ).isna().any()
+
+    # reset db
+
+    db._files_duration = {}
+
+
 def test_load(tmpdir):
     # Test backward compatibility
     table_file = os.path.join(tmpdir, 'db.table.pkl')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ from io import StringIO
 import os
 import shutil
 
+import audiofile
 import pytest
 import numpy as np
 import pandas as pd
@@ -1051,14 +1052,17 @@ def test_read_csv(csv, result):
     ]
 )
 def test_to_segmented_index(obj, allow_nat, root, expected):
-    result = audformat.utils.to_segmented_index(
-        obj,
-        allow_nat=allow_nat,
-        root=root,
-    )
-    if not isinstance(result, pd.Index):
-        result = result.index
-    pd.testing.assert_index_equal(result, expected)
+    files_duration = {}
+    for _ in range(2):
+        result = audformat.utils.to_segmented_index(
+            obj,
+            allow_nat=allow_nat,
+            files_duration=files_duration,
+            root=root,
+        )
+        if not isinstance(result, pd.Index):
+            result = result.index
+        pd.testing.assert_index_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,13 +2,11 @@ from io import StringIO
 import os
 import shutil
 
-import audiofile
 import pytest
 import numpy as np
 import pandas as pd
 
 import audformat
-from audformat import testing
 from audformat import utils
 from audformat import define
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -931,18 +931,20 @@ def test_read_csv(csv, result):
 
 
 @pytest.mark.parametrize(
-    'obj, allow_nat, root, expected',
+    'obj, allow_nat, files_duration, root, expected',
     [
         # empty
         (
             audformat.filewise_index(),
             True,
             None,
+            None,
             audformat.segmented_index(),
         ),
         (
             audformat.filewise_index(),
             False,
+            None,
             None,
             audformat.segmented_index(),
         ),
@@ -950,11 +952,13 @@ def test_read_csv(csv, result):
             audformat.segmented_index(),
             True,
             None,
+            None,
             audformat.segmented_index(),
         ),
         (
             audformat.segmented_index(),
             False,
+            None,
             None,
             audformat.segmented_index(),
         ),
@@ -963,11 +967,13 @@ def test_read_csv(csv, result):
             audformat.filewise_index(pytest.DB.files[:2]),
             True,
             None,
+            None,
             audformat.segmented_index(pytest.DB.files[:2]),
         ),
         (
             audformat.segmented_index(pytest.DB.files[:2]),
             True,
+            None,
             None,
             audformat.segmented_index(pytest.DB.files[:2]),
         ),
@@ -978,6 +984,7 @@ def test_read_csv(csv, result):
                 [0.2, pd.NaT],
             ),
             True,
+            None,
             None,
             audformat.segmented_index(
                 pytest.DB.files[:2],
@@ -989,6 +996,7 @@ def test_read_csv(csv, result):
         (
             audformat.filewise_index(pytest.DB.files[:2]),
             False,
+            None,
             pytest.DB_ROOT,
             audformat.segmented_index(
                 pytest.DB.files[:2],
@@ -999,6 +1007,7 @@ def test_read_csv(csv, result):
         (
             audformat.segmented_index(pytest.DB.files[:2]),
             False,
+            None,
             pytest.DB_ROOT,
             audformat.segmented_index(
                 pytest.DB.files[:2],
@@ -1013,6 +1022,7 @@ def test_read_csv(csv, result):
                 [0.2, pd.NaT],
             ),
             False,
+            None,
             pytest.DB_ROOT,
             audformat.segmented_index(
                 pytest.DB.files[:2],
@@ -1020,10 +1030,44 @@ def test_read_csv(csv, result):
                 [0.2, pytest.FILE_DUR],
             ),
         ),
+        # provide file durations
+        (
+            audformat.filewise_index(pytest.DB.files[:2]),
+            False,
+            {
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[1]):
+                    pytest.FILE_DUR * 2,
+            },
+            pytest.DB_ROOT,
+            audformat.segmented_index(
+                pytest.DB.files[:2],
+                [0.0, 0.0],
+                [pytest.FILE_DUR, pytest.FILE_DUR * 2],
+            ),
+        ),
+        (
+            audformat.segmented_index(
+                pytest.DB.files[:2],
+                [0.1, 0.5],
+                [pd.NaT, pd.NaT],
+            ),
+            False,
+            {
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[1]):
+                    pytest.FILE_DUR * 2,
+            },
+            pytest.DB_ROOT,
+            audformat.segmented_index(
+                pytest.DB.files[:2],
+                [0.1, 0.5],
+                [pytest.FILE_DUR, pytest.FILE_DUR * 2],
+            ),
+        ),
         # file not found
         pytest.param(
             audformat.filewise_index(pytest.DB.files[:2]),
             False,
+            None,
             None,
             None,
             marks=pytest.mark.xfail(raises=FileNotFoundError),
@@ -1036,6 +1080,7 @@ def test_read_csv(csv, result):
             ),
             True,
             None,
+            None,
             audformat.segmented_index(pytest.DB.files[:2]),
         ),
         (
@@ -1045,22 +1090,36 @@ def test_read_csv(csv, result):
             ),
             True,
             None,
+            None,
             audformat.segmented_index(pytest.DB.files[:2]),
         ),
     ]
 )
-def test_to_segmented_index(obj, allow_nat, root, expected):
-    files_duration = {}
-    for _ in range(2):
-        result = audformat.utils.to_segmented_index(
-            obj,
-            allow_nat=allow_nat,
-            files_duration=files_duration,
-            root=root,
-        )
-        if not isinstance(result, pd.Index):
-            result = result.index
-        pd.testing.assert_index_equal(result, expected)
+def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
+
+    result = audformat.utils.to_segmented_index(
+        obj,
+        allow_nat=allow_nat,
+        files_duration=files_duration,
+        root=root,
+    )
+    if not isinstance(result, pd.Index):
+        result = result.index
+
+    pd.testing.assert_index_equal(result, expected)
+
+    if files_duration and not allow_nat:
+        # for filewise tables we expect a duration for every file
+        # for segmented only where end == NaT
+        files = result.get_level_values(audformat.define.IndexField.FILE)
+        if audformat.index_type(obj) == audformat.define.IndexType.SEGMENTED:
+            mask = result.get_level_values(
+                audformat.define.IndexField.END
+            ) == pd.NaT
+            files = files[mask]
+        for file in files:
+            file = os.path.join(root, file)
+            assert file in files_duration
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #111 

### Column

![image](https://user-images.githubusercontent.com/10383417/140967048-ac75fecb-dfc8-4c95-b768-55cbdad7be80.png)

### Table

![image](https://user-images.githubusercontent.com/10383417/140967229-4f48ed45-9d87-44ff-bfae-6a92c97d8fa6.png)

To avoid re-implementing a lot stuff we already have, the methods call `utils.to_segmented_index()`, which now has a new argument `files_duration`:

![image](https://user-images.githubusercontent.com/10383417/141004040-56dc9edb-dd0c-43ab-99a6-1971e0a449d7.png)
