### PR TITLE
Use yaml.CLoader for faster header reading

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -805,7 +805,7 @@ class Database(HeaderBase):
 
         with open(path, 'r') as fp:
 
-            header = yaml.load(fp, Loader=yaml.Loader)
+            header = yaml.load(fp, Loader=yaml.CLoader)
             db = Database.load_header_from_yaml(header)
 
             if 'tables' in header and header['tables']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -6,6 +6,10 @@ import typing
 
 import audiofile
 import oyaml as yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:  # pragma: nocover
+    from yaml import Loader
 import pandas as pd
 
 import audeer
@@ -805,7 +809,7 @@ class Database(HeaderBase):
 
         with open(path, 'r') as fp:
 
-            header = yaml.load(fp, Loader=yaml.CLoader)
+            header = yaml.load(fp, Loader=Loader)
             db = Database.load_header_from_yaml(header)
 
             if 'tables' in header and header['tables']:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     audiofile >=0.4.0
     iso-639
     oyaml
-    pyyaml >=3.4.1
+    pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     audiofile >=0.4.0
     iso-639
     oyaml
+    pyyaml >=3.4.1
     # https://github.com/audeering/audformat/pull/101
     pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =


### PR DESCRIPTION
Try to speed up YAML header file loading by using the `CLoader`.

I use a `try`-`except` statement to handle missing `CLoader`.

In addition, I added a `pyyaml >=5.4.1` requirement as locally this version was providing the `CLoader` for me.
I could also try lower versions, but I don't think there is a need to support lower versions.