### PR TITLE
WIP: Remove oyaml dependency

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -1,5 +1,5 @@
 import inspect
-import oyaml as yaml
+import yaml
 from typing import Sequence, Callable
 import textwrap
 from collections import OrderedDict

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -5,7 +5,7 @@ import shutil
 import typing
 
 import audiofile
-import oyaml as yaml
+import yaml
 import pandas as pd
 
 import audeer

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     audeer >=1.8.0,<2.0.0
     audiofile >=0.4.0
     iso-639
-    oyaml
+    pyyaml >=3.4.1
     # https://github.com/audeering/audformat/pull/101
     pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,5 +8,5 @@ scipy
 pandas
 tqdm
 audiofile
-oyaml
+pyyaml >=3.4.1
 dohq-artifactory


### PR DESCRIPTION
Seems by just replacing `oyaml` with `pyyaml` we get a lot of failing tests.