### PR TITLE
Do no longer test for duplicates in assert_index()

### DIFF
--- a/audformat/__init__.py
+++ b/audformat/__init__.py
@@ -4,6 +4,7 @@ from audformat import utils
 from audformat.core.database import Database
 from audformat.core.index import (
     assert_index,
+    assert_no_duplicates,
     filewise_index,
     segmented_index,
     index_type,

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -117,14 +117,12 @@ def assert_index(
 def assert_no_duplicates(
     obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
 ):
-    r"""Assert object is contains no duplicates in its index.
+    r"""Assert object contains no duplicates in its index.
 
     The :ref:`table specifications <data-tables:Tables>`
     allow no duplicated index entries.
     To save time we do not test for this
-    when initializing :class:`audformat.Table`.
-    This function provides you the possibility
-    to manual check for it.
+    in :func:`audformat.assert_index`.
 
     Args:
         obj: object

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -35,13 +35,21 @@ def to_timedelta(times):
 
 
 def assert_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame]
+    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    *,
+    allow_duplicates: bool = False,
 ):
     r"""Assert object is conform to :ref:`table specifications
     <data-tables:Tables>`.
 
     Args:
         obj: object
+        allow_duplicates: if ``True``
+            it will not check for duplicated entries,
+            which is faster,
+            but should only be used
+            if you know
+            that the index does not contain duplicates
 
     Raises:
         ValueError: if not conform to
@@ -51,7 +59,7 @@ def assert_index(
     if isinstance(obj, (pd.Series, pd.DataFrame)):
         obj = obj.index
 
-    if obj.has_duplicates:
+    if not allow_duplicates and obj.has_duplicates:
         max_display = 10
         duplicates = obj[obj.duplicated()]
         msg_tail = '\n...' if len(duplicates) > max_display else ''
@@ -183,7 +191,7 @@ def index_type(
     if isinstance(obj, (pd.Series, pd.DataFrame)):
         obj = obj.index
 
-    assert_index(obj)
+    assert_index(obj, allow_duplicates=True)
 
     if len(obj.names) == 1:
         return define.IndexType.FILEWISE

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -18,6 +18,7 @@ from audformat.core.errors import (
     BadIdError,
 )
 from audformat.core.index import (
+    assert_index,
     filewise_index,
     index_type,
 )
@@ -140,6 +141,8 @@ class Table(HeaderBase):
 
         if index is None:
             index = filewise_index()
+        else:
+            assert_index(index)
 
         self.type = index_type(index)
         r"""Table type"""

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -18,7 +18,6 @@ from audformat.core.errors import (
     BadIdError,
 )
 from audformat.core.index import (
-    assert_index,
     filewise_index,
     index_type,
 )
@@ -141,8 +140,6 @@ class Table(HeaderBase):
 
         if index is None:
             index = filewise_index()
-        else:
-            assert_index(index)
 
         self.type = index_type(index)
         r"""Table type"""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,11 @@ assert_index
 
 .. autofunction:: assert_index
 
+assert_no_duplicates
+--------------------
+
+.. autofunction:: assert_no_duplicates
+
 Column
 ------
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -105,6 +105,34 @@ def test_assert_index(obj):
 
 
 @pytest.mark.parametrize(
+    'obj',
+    [
+        audformat.filewise_index(),
+        audformat.filewise_index(['f1', 'f2']),
+        pd.Series(
+            index=audformat.filewise_index(['f1', 'f2']),
+            dtype=float,
+        ),
+        pd.DataFrame(
+            index=audformat.filewise_index(['f1', 'f2']),
+        ),
+        audformat.segmented_index(),
+        audformat.segmented_index(['f1', 'f2']),
+        pytest.param(  # duplicates
+            audformat.filewise_index(['f1', 'f1']),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # duplicates
+            audformat.segmented_index(['f1', 'f1']),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_assert_no_duplicates(obj):
+    audformat.assert_no_duplicates(obj)
+
+
+@pytest.mark.parametrize(
     'files',
     [
         None,
@@ -112,10 +140,7 @@ def test_assert_index(obj):
         '1.wav',
         ['1.wav', '2.wav'],
         pytest.DB['files'].files,
-        pytest.param(  # duplicates
-            ['f1', 'f2', 'f2'],
-            marks=pytest.mark.xfail(raises=ValueError),
-        )
+        ['f1', 'f2', 'f2'],  # duplicates
     ]
 )
 def test_create_filewise_index(files):
@@ -205,23 +230,10 @@ def test_create_filewise_index(files):
             [pd.Timedelta('1s'), pd.Timedelta('2s')],
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        pytest.param(  # duplicates
+        (  # duplicates
             ['f1', 'f1'],
             None,
             None,
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-        pytest.param(  # duplicates
-            ['f1', 'f1'],
-            [0, 0],
-            [1, 1],
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
-        pytest.param(  # duplicates
-            ['f1', 'f1'],
-            [0, 0],
-            None,
-            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ]
 )


### PR DESCRIPTION
Closes #125 

As discussed below, we decided to no longer test for duplicates in `audformat.assert_index()`.
Instead, we add `audformat.assert_no_duplicates()`, that can then be used inside `audb.publish()` to ensure only tables without duplicates are published.

This modification brings down the execution time in https://github.com/audeering/audb/pull/149 from 20 s to 0.004 s.

![image](https://user-images.githubusercontent.com/173624/142383043-c0104b39-84f7-401d-9763-c3c5b327f3d3.png)

I also mention the new function in the docstring of `audformat.assert_index()`

![image](https://user-images.githubusercontent.com/173624/142383258-c7ac8d88-2d90-4c3f-b569-d08ae01a3aae.png)


