### PR TITLE
Remove deprecated pandas code

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -268,10 +268,10 @@ class Scheme(HeaderBase):
             for table in self._db.tables.values():
                 for column in table.columns.values():
                     if column.scheme_id == self._id:
-                        column.get(copy=False).cat.set_categories(
+                        y = column.get(copy=False)
+                        y.cat.set_categories(
                             new_categories=self.labels,
                             ordered=False,
-                            inplace=True,
                         )
 
     def _dtype_from_labels(

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -268,11 +268,12 @@ class Scheme(HeaderBase):
             for table in self._db.tables.values():
                 for column in table.columns.values():
                     if column.scheme_id == self._id:
-                        y = column.get(copy=False)
-                        y.cat.set_categories(
+                        y = column._table.df[column._id]
+                        y = y.cat.set_categories(
                             new_categories=self.labels,
                             ordered=False,
                         )
+                        column._table.df[column._id] = y
 
     def _dtype_from_labels(
             self,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -22,8 +22,9 @@ def full_path(
             table.df.index = root + table.df.index
             table.df.index.name = 'file'
         elif len(table.df.index) > 0:
-            table.df.index.set_levels(
-                root + table.df.index.levels[0], 'file', inplace=True,
+            table.df.index = table.df.index.set_levels(
+                root + table.df.index.levels[0],
+                level='file',
             )
 
 


### PR DESCRIPTION
This avoids deprecation warnings when running the tests.