### PR TITLE
Ensure table is loaded before written to CSV file

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1154,8 +1154,12 @@ class Table(HeaderBase):
         self._df = df
 
     def _save_csv(self, path: str):
+        # Load table before opening CSV file
+        # to avoid creating a CSV file
+        # that is newer than the PKL file
+        df = self.df
         with open(path, 'w') as fp:
-            self.df.to_csv(fp, encoding='utf-8')
+            df.to_csv(fp, encoding='utf-8')
 
     def _save_pickled(self, path: str):
         self.df.to_pickle(path)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -354,9 +354,20 @@ def test_save_and_load(tmpdir, db, storage_format, load_data, num_workers):
             tmpdir,
             load_data=load_data,
         )
+
+        # Ensure no data is loaded
+        if not load_data:
+            for table in list(db_load.tables):
+                assert db_load[table]._df is None
+
         assert db_load.root == db2.root
         assert db_load == db2
         assert db_load != db
+
+        # After comparing the databases, tables should be loaded
+        if not load_data:
+            for table in list(db_load.tables):
+                assert db_load[table]._df is not None
 
         # Save and not update PKL files,
         # now it should raise an error as CSV file is newer
@@ -395,6 +406,17 @@ def test_save_and_load(tmpdir, db, storage_format, load_data, num_workers):
             tmpdir,
             load_data=load_data,
         )
+        # Ensure saving the database works
+        # when loaded without tables before
+        # https://github.com/audeering/audformat/issues/131
+        if not load_data:
+            db_load.save(
+                tmpdir,
+                storage_format=audformat.define.TableStorageFormat.CSV,
+                num_workers=num_workers,
+                update_other_formats=True,
+            )
+
         assert db_load == db
 
     db_load = audformat.Database.load(


### PR DESCRIPTION
Closes #131.

When loading a database that contains PKL and CSV files with `load_data=False` and storing them afterwards with `db.save()` we have to make sure that the actual tables are loaded first, before any new file is written. Otherwise we can get an error that the CSV file is newer than the PKL file.

I first added a test that failed for the master and afterwards implemented the fix.