### PR TITLE
DOC: more details on language Database argument

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -41,7 +41,9 @@ class Database(HeaderBase):
             Set to ``'other'``
             if none of the other fields fit.
         expires: expiry date
-        languages: list of languages
+        languages: list of languages.
+            Will be mapped to ISO 639-3 strings
+            with :func:`audformat.utils.map_language`
         description: database description
         author: database author(s)
         organization: organization(s) maintaining the database


### PR DESCRIPTION
Closes #128.

This provides additional information to the `audformat.Database` docstring regarding the `language` argument:

![image](https://user-images.githubusercontent.com/173624/148080255-cf672f10-6e06-4431-9ddf-7f05380ab457.png)
