### PR TITLE
DOC: be more verbose on TIME vs. DATE data types

### DIFF
--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -8,7 +8,7 @@ from audformat.core.common import DefineBase
 
 class DataType(DefineBase):
     r"""Data types of column content.
-    
+
     Use ``DATE``
     to handle time and date information,
     e.g. as provided by :class:`datetime.datetime`.

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -7,7 +7,15 @@ from audformat.core.common import DefineBase
 
 
 class DataType(DefineBase):
-    r"""Data types of column content."""
+    r"""Data types of column content.
+    
+    Use ``DATE``
+    to handle time and date information,
+    e.g. as provided by :class:`datetime.datetime`.
+    Use ``TIME``
+    to handle duration values.
+
+    """
     BOOL = 'bool'
     DATE = 'date'
     INTEGER = 'int'


### PR DESCRIPTION
Closes #19.

This extends the doc to discuss the difference between the `DATE` and `TIME` data types.

![image](https://user-images.githubusercontent.com/173624/148087680-4c90972b-d757-42c0-854a-436228188808.png)
