### PR TITLE
WIP: Set dtype when reading index from CSV file

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1084,6 +1084,7 @@ class Table(HeaderBase):
 
         # index columns
 
+        dtypes[define.IndexField.FILE] = 'str'
         if self.type == define.IndexType.SEGMENTED:
             converters[define.IndexField.START] = \
                 lambda x: pd.to_timedelta(x)


### PR DESCRIPTION
Closes #33.

In #33 we realized that we don't specify the `dtype` for the index columns when reading from CSV. I think for `start` and `end` we don't need to specify the data type as we use `converters` anyway. The [pandas documentation](https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html) is not explicit if `dtype` is applied to `index_col` as well.
At least my implementation does not raise an error. But I haven't tested yet that it is faster.