### PR TITLE
WIP: Allow index with additional level entries

### DIFF
--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -223,12 +223,7 @@ def index_type(
         ...             pd.to_timedelta([1], unit='s'),
         ...             [1],
         ...         ],
-        ...         names=[
-        ...             'file',
-        ...             'start',
-        ...             'end',
-        ...             'version',
-        ...         ],
+        ...         names=['file', 'start', 'end', 'version'],
         ...     )
         ... )
         'segmented'


### PR DESCRIPTION
Closes #86.

This expands our implementation of `audformat` by allowing the `pandas` index objects to contain additional columns. I can thing of several applications where this is needed, e.g. comparing two segmented files. I also do not see any harm we introducing it.

I implemented it the following way:
* the first level is always considered to have the name `'file'`
* if we have at least three levels and the second and third are named `'start'` and `'end'` is the index considered a segmented index
All the checks for the correct data type are still performed.

I also expanded the docstring of `audformat.assert_index()` by stating what we expect from the index and highlighting it with examples

![image](https://user-images.githubusercontent.com/173624/148212174-548996cf-c208-4771-aa59-b0dafa7eedb6.png)

In addition, I added two new examples to `audformat.index_type()` including index with extra levels

![image](https://user-images.githubusercontent.com/173624/148212470-d34d19be-df26-488a-9f2c-7ae8a9500a1d.png)

