### PR TITLE
Save pickled tables with protocol 4

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1171,10 +1171,10 @@ class Table(HeaderBase):
         with open(path, 'w') as fp:
             df.to_csv(fp, encoding='utf-8')
 
-    def _save_pickled(self, path: str):        
+    def _save_pickled(self, path: str):
         self.df.to_pickle(
             path,
-            protocol=4,  # supported by Python >= 3.4 
+            protocol=4,  # supported by Python >= 3.4
         )
 
     def _set_column(self, column_id: str, column: Column) -> Column:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -647,7 +647,17 @@ class Table(HeaderBase):
             pickled = True
 
         if pickled:
-            self._load_pickled(pkl_file)
+            try:
+                self._load_pickled(pkl_file)
+            except Exception as ex:
+                # if exception is raised (e.g. unsupported pickle protocol)
+                # try to load from CSV and save it again
+                # otherwise raise error
+                if os.path.exists(csv_file):
+                    self._load_csv(csv_file)
+                    self._save_pickled(pkl_file)
+                else:
+                    raise ex
         else:
             self._load_csv(csv_file)
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1161,8 +1161,11 @@ class Table(HeaderBase):
         with open(path, 'w') as fp:
             df.to_csv(fp, encoding='utf-8')
 
-    def _save_pickled(self, path: str):
-        self.df.to_pickle(path)
+    def _save_pickled(self, path: str):        
+        self.df.to_pickle(
+            path,
+            protocol=4,  # supported by Python >= 3.4 
+        )
 
     def _set_column(self, column_id: str, column: Column) -> Column:
         if column.scheme_id is not None and \

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -649,7 +649,7 @@ class Table(HeaderBase):
         if pickled:
             try:
                 self._load_pickled(pkl_file)
-            except Exception as ex:
+            except (ValueError, EOFError) as ex:
                 # if exception is raised (e.g. unsupported pickle protocol)
                 # try to load from CSV and save it again
                 # otherwise raise error


### PR DESCRIPTION
Closes #141 

* Force protocol = 4 when storing tables to pickle files.
* Try to recover from CSV file if PKL cannot be loaded.