### PR TITLE
Depend on pandas<1.4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ install_requires =
     oyaml
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
+    # https://github.com/audeering/audformat/pull/142
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3, <1.4.0
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Closes #143 

I think it is better to change the `pandas` dependency with a single commit.