### PR TITLE
union(): do not sort level

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1000,21 +1000,20 @@ def union(
         MultiIndex([('f1', '0 days 00:00:00', '0 days 00:00:01'),
                     ('f2', '0 days 00:00:00', '0 days 00:00:01'),
                     ('f3', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:01', '0 days 00:00:02'),
-                    ('f4', '0 days 00:00:00', '0 days 00:00:01')],
+                    ('f4', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('f3', '0 days 00:00:01', '0 days 00:00:02')],
                    names=['file', 'start', 'end'])
-
         >>> union([index1, index2, index3, index4])
         MultiIndex([('f1', '0 days 00:00:00',               NaT),
-                    ('f1', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f2', '0 days 00:00:00',               NaT),
-                    ('f2', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:00',               NaT),
-                    ('f3', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:01', '0 days 00:00:02'),
-                    ('f4', '0 days 00:00:00',               NaT),
-                    ('f4', '0 days 00:00:00', '0 days 00:00:01')],
-                   names=['file', 'start', 'end'])
+                ('f2', '0 days 00:00:00',               NaT),
+                ('f3', '0 days 00:00:00',               NaT),
+                ('f4', '0 days 00:00:00',               NaT),
+                ('f1', '0 days 00:00:00', '0 days 00:00:01'),
+                ('f2', '0 days 00:00:00', '0 days 00:00:01'),
+                ('f3', '0 days 00:00:00', '0 days 00:00:01'),
+                ('f4', '0 days 00:00:00', '0 days 00:00:01'),
+                ('f3', '0 days 00:00:01', '0 days 00:00:02')],
+               names=['file', 'start', 'end'])
 
     """
     if not objs:
@@ -1031,6 +1030,5 @@ def union(
     df = pd.concat([o.to_frame() for o in objs])
     index = df.index
     index = index.drop_duplicates()
-    index, _ = index.sortlevel()
 
     return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1005,15 +1005,15 @@ def union(
                    names=['file', 'start', 'end'])
         >>> union([index1, index2, index3, index4])
         MultiIndex([('f1', '0 days 00:00:00',               NaT),
-                ('f2', '0 days 00:00:00',               NaT),
-                ('f3', '0 days 00:00:00',               NaT),
-                ('f4', '0 days 00:00:00',               NaT),
-                ('f1', '0 days 00:00:00', '0 days 00:00:01'),
-                ('f2', '0 days 00:00:00', '0 days 00:00:01'),
-                ('f3', '0 days 00:00:00', '0 days 00:00:01'),
-                ('f4', '0 days 00:00:00', '0 days 00:00:01'),
-                ('f3', '0 days 00:00:01', '0 days 00:00:02')],
-               names=['file', 'start', 'end'])
+                    ('f2', '0 days 00:00:00',               NaT),
+                    ('f3', '0 days 00:00:00',               NaT),
+                    ('f4', '0 days 00:00:00',               NaT),
+                    ('f1', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('f2', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('f3', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('f4', '0 days 00:00:00', '0 days 00:00:01'),
+                    ('f3', '0 days 00:00:01', '0 days 00:00:02')],
+                   names=['file', 'start', 'end'])
 
     """
     if not objs:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -377,22 +377,22 @@ from audformat import define
                     name='c1',
                 ),
                 pd.Series(
-                    ['a', np.nan, 'd'],
-                    audformat.filewise_index(['f1', 'f2', 'f4']),
+                    ['a', np.nan, 'c'],
+                    audformat.filewise_index(['f1', 'f2', 'f3']),
                     name='c2',
                 ),
                 pd.DataFrame(
                     {
-                        'c1': [np.nan, 3.],
-                        'c2': ['b', 'c'],
+                        'c1': [np.nan, 4.],
+                        'c2': ['b', 'd'],
                     },
-                    audformat.segmented_index(['f2', 'f3']),
+                    audformat.segmented_index(['f2', 'f4']),
                 ),
             ],
             False,
             pd.DataFrame(
                 {
-                    'c1': [1., 2., 3., np.nan],
+                    'c1': [1., 2., np.nan, 4.],
                     'c2': ['a', 'b', 'c', 'd']
                 },
                 audformat.segmented_index(['f1', 'f2', 'f3', 'f4']),
@@ -1519,9 +1519,9 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 audformat.filewise_index(['f1', 'f2']),
             ],
             audformat.segmented_index(
-                ['f1', 'f1', 'f2', 'f2', 'f3'],
+                ['f1', 'f2', 'f3', 'f1', 'f2'],
                 [0, 0, 0, 0, 0],
-                [pd.NaT, 1, pd.NaT, 1, 1],
+                [1, 1, 1, pd.NaT, pd.NaT],
             ),
         ),
         (
@@ -1531,9 +1531,9 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 audformat.filewise_index('f1'),
             ],
             audformat.segmented_index(
-                ['f1', 'f1', 'f2', 'f3'],
+                ['f1', 'f2', 'f3', 'f1'],
                 [0, 0, 0, 0],
-                [pd.NaT, 1, 1, 1],
+                [1, 1, 1, pd.NaT],
             ),
         ),
         (
@@ -1543,9 +1543,21 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 audformat.filewise_index(['f2', 'f3']),
             ],
             audformat.segmented_index(
-                ['f1', 'f1', 'f2', 'f2', 'f3'],
+                ['f1', 'f2', 'f1', 'f2', 'f3'],
                 [0, 0, 0, 0, 0],
-                [pd.NaT, 1, pd.NaT, 1, pd.NaT],
+                [1, 1, pd.NaT, pd.NaT, pd.NaT],
+            ),
+        ),
+        (
+            [
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f2', 'f3']),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f2', 'f1', 'f2', 'f3'],
+                [0, 0, 0, 0, 0],
+                [pd.NaT, pd.NaT, 1, 1, pd.NaT],
             ),
         ),
     ]


### PR DESCRIPTION
Removes again the sorting from `utils.union()` introduced in https://github.com/audeering/audformat/pull/98 as it might lead to expected results.

E.g. instead of:

```python
d1 = [1, 3]
i1 = audformat.filewise_index(['f1', 'f3'])

d2 = [2, 4]
i2 = audformat.filewise_index(['f2', 'f4'])

pd.Series(
    d1 + d2,
    audformat.utils.union([i1, i2]),
)
```
```
file
f1    1
f2    3
f3    2
f4    4
dtype: int64
```

we now get:

```
file
f1    1
f3    3
f2    2
f4    4
dtype: int64
```