### PR TITLE
Sort Database.files and Database.segments

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -189,6 +189,8 @@ class Database(HeaderBase):
         index = utils.union(
             [table.files.drop_duplicates() for table in self.tables.values()]
         )
+        # Sort alphabetical
+        index, _ index.sortlevel()
         return index
 
     @property
@@ -248,6 +250,8 @@ class Database(HeaderBase):
                 if table.is_segmented
             ]
         )
+        # Sort alphabetical
+        index, _ index.sortlevel()
         return index
 
     def drop_files(

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -190,7 +190,7 @@ class Database(HeaderBase):
             [table.files.drop_duplicates() for table in self.tables.values()]
         )
         # Sort alphabetical
-        index, _ index.sortlevel()
+        index, _ = index.sortlevel()
         return index
 
     @property
@@ -251,7 +251,7 @@ class Database(HeaderBase):
             ]
         )
         # Sort alphabetical
-        index, _ index.sortlevel()
+        index, _ = index.sortlevel()
         return index
 
     def drop_files(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import filecmp
 import os

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import filecmp
 import os
@@ -59,6 +60,14 @@ def test_drop_files(files, num_workers):
         if isinstance(files, str):
             files = [files]
     assert len(db.files.intersection(files)) == 0
+
+
+def test_files():
+    db = audformat.testing.create_db()
+    # Shuffle order of files
+    db['files']._df = db['files'].df.sample(frac=1, random_state=0)
+    # Check output is sorted
+    assert list(db.files) == sorted(list(db.files))
 
 
 @pytest.mark.parametrize(
@@ -479,6 +488,15 @@ def test_save_and_load(tmpdir, db, storage_format, load_data, num_workers):
                 load_data=load_data,
             )
             db[table_id].get()
+
+
+def test_segments():
+    db = audformat.testing.create_db()
+    df = pytest.DB['segments'].get()
+    # Shuffle order of segments
+    db['segments']._df = df.sample(frac=1, random_state=0)
+    # Check output is sorted
+    assert db.segments.equals(pytest.DB.segments)
 
 
 def test_string():


### PR DESCRIPTION
In https://github.com/audeering/audformat/pull/146/ we removed sorting from `audformat.uitils.union()`, but in https://github.com/audeering/audb/pull/162 we realized that for `audformat.Database.files` and `audformat.Database.segments` it might still be worth sorting the output.

I added two tests that fail for the current master, but work for the proposed changes.