### PR TITLE
Fix conversion of pickle versions in cache

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -649,7 +649,7 @@ class Table(HeaderBase):
         if pickled:
             try:
                 self._load_pickled(pkl_file)
-            except (ValueError, EOFError) as ex:
+            except (AttributeError, ValueError, EOFError) as ex:
                 # if exception is raised (e.g. unsupported pickle protocol)
                 # try to load from CSV and save it again
                 # otherwise raise error


### PR DESCRIPTION
This also excepts `AttributeError` when a wrong pickle format is found.