### PR TITLE
Ensure testing.create_database uses unix path sep

### DIFF
--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -96,12 +96,12 @@ def add_table(
 
     if isinstance(num_files, int):
         files = [
-            os.path.join(file_root, f'{idx + 1:03}.{audio_format}')
+            f'{file_root}/{idx + 1:03}.{audio_format}'
             for idx in range(num_files)
         ]
     else:
         files = [
-            os.path.join(file_root, f'{idx:03}.{audio_format}')
+            f'{file_root}/{idx:03}.{audio_format}'
             for idx in num_files
         ]
         num_files = len(num_files)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -228,7 +228,7 @@ def test_files_duration():
     # make sure we have only absolute file names in cache
 
     expected_cache = {
-        file: dur for os.path.normpath(file), dur in zip(files_abs, durs)
+        os.path.normpath(file): dur for file, dur in zip(files_abs, durs)
     }
     assert db._files_duration == expected_cache
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -228,7 +228,7 @@ def test_files_duration():
     # make sure we have only absolute file names in cache
 
     expected_cache = {
-        file: dur for file, dur in zip(files_abs, durs)
+        file: dur for os.path.normpath(file), dur in zip(files_abs, durs)
     }
     assert db._files_duration == expected_cache
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -28,6 +28,11 @@ def full_path(
             )
 
 
+def test_create_db():
+    db = audformat.testing.create_db()
+    assert all(['\\' not in file for file in db.files])
+
+
 @pytest.mark.parametrize(
     'files, num_workers',
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1382,7 +1382,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
         files = [os.path.join(pytest.DB_ROOT, f) for f in files]
     assert all(os.path.exists(f) for f in files)
 
-    file_names = [f.split(os.path.sep)[-1].rsplit('.', 1)[0] for f in files]
+    file_names = [f.split('/')[-1].rsplit('.', 1)[0] for f in files]
     assert file_names == expected_file_names
 
     # clean-up


### PR DESCRIPTION
As a first step towards compatibility between Windows and Unix based systems in `audb`,
this changes `audformat.testing.create_database()` to always create databases with a `/` a separator.

In a next step, I will propose to extend `audformat.Database.is_portable()` by checking that the path does not include `\` (see https://github.com/audeering/audformat/pull/155).