### PR TITLE
Don't allow \ in a portable database

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -201,7 +201,9 @@ class Database(HeaderBase):
 
         To be portable,
         media must not be referenced with an absolute path,
-        or contain ``.`` or ``..`` to specify a folder.
+        and not contain ``\``,
+        ``.``,
+        or ``..``.
         If a database is portable
         it can be moved to another folder
         or updated by another database.
@@ -215,10 +217,11 @@ class Database(HeaderBase):
         return not any(
             (
                 os.path.isabs(f)
-                or f.startswith(f'.{os.path.sep}')
-                or f'{os.path.sep}.{os.path.sep}' in f
-                or f.startswith(f'..{os.path.sep}')
-                or f'{os.path.sep}..{os.path.sep}' in f
+                or '\\' in f
+                or f.startswith('./')
+                or '/./' in f
+                or f.startswith('../')
+                or '/../' in f
             )
             for f in self.files
         )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -94,27 +94,35 @@ def test_files():
             True,
         ),
         (
-            [os.path.join(os.path.sep, 'a', 'b', 'c', '.file.txt')],
+            ['/a/b/c/.file.txt'],
             False,
         ),
         (
-            [os.path.join('a', 'b', 'c', '.file.txt')],
+            ['a/b/c/.file.txt'],
             True,
         ),
         (
-            [os.path.join('.', 'file.txt')],
+            ['./file.txt'],
             False,
         ),
         (
-            [os.path.join('..', 'file.txt')],
+            ['../file.txt'],
             False,
         ),
         (
-            [os.path.join('a', 'b', 'c', '.', 'file.txt')],
+            ['a/b/c/./file.txt'],
             False,
         ),
         (
-            [os.path.join('a', 'b', 'c', '..', 'file.txt')],
+            ['a/b/c/../file.txt'],
+            False,
+        ),
+        (
+            ['D:\\absolute\\windows\\path'],
+            False,
+        ),
+        (
+            ['relative\\windows\\path'],
             False,
         ),
     ]


### PR DESCRIPTION
This extends `audformat.Database.is_portable` to not allow for Windows path notation `\`.

![image](https://user-images.githubusercontent.com/173624/155512995-76c492a9-285d-4c64-8e8e-f139d4e4a25b.png)
