### PR TITLE
Remove root argument of create_audio_files in 1.0

### DIFF
--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -180,7 +180,8 @@ def create_audio_files(
     if root is not None:  # pragma: no cover
         warnings.warn(
             "The argument 'root' is deprecated, "
-            "'db.root' will be used.'",
+            " and will be removed with version 1.0.0. "
+            "'db.root' will be used instead.'",
             category=UserWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Closes #153 

Marks `root` argument of `audformat.testing.create_audio_files()` to be removed in version 1.0.0.
Note, it was marked as deprecated already before.