### PR TITLE
Use audeer>=1.18.0

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -358,7 +358,7 @@ class Database(HeaderBase):
                 full_file = os.path.join(root, file)
 
             # check cache
-            full_file = audeer.safe_path(full_file)
+            full_file = audeer.path(full_file)
             if full_file in self._files_duration:
                 return self._files_duration[full_file]
 
@@ -810,7 +810,7 @@ class Database(HeaderBase):
 
         """
         ext = '.yaml'
-        root = audeer.safe_path(root)
+        root = audeer.path(root)
         path = os.path.join(root, name + ext)
 
         if not os.path.exists(path):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -618,7 +618,7 @@ class Table(HeaderBase):
             RuntimeError: if CSV file is newer than PKL file
 
         """
-        path = audeer.safe_path(path)
+        path = audeer.path(path)
         pkl_file = f'{path}.{define.TableStorageFormat.PICKLE}'
         csv_file = f'{path}.{define.TableStorageFormat.CSV}'
 
@@ -782,7 +782,7 @@ class Table(HeaderBase):
                 but update all files stored in other storage formats as well
 
         """
-        path = audeer.safe_path(path)
+        path = audeer.path(path)
         define.TableStorageFormat.assert_has_attribute_value(storage_format)
 
         pickle_file = path + f'.{define.TableStorageFormat.PICKLE}'

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -315,7 +315,7 @@ def expand_file_path(
     if len(index) == 0:
         return index
 
-    root = audeer.safe_path(root) + os.path.sep
+    root = audeer.path(root) + os.path.sep
     is_segmented = index_type(index) == define.IndexType.SEGMENTED
 
     if is_segmented:
@@ -822,13 +822,13 @@ def to_filewise_index(
 
     test_path = obj.index.get_level_values(define.IndexField.FILE)[0]
     is_abs = os.path.isabs(test_path)
-    test_path = audeer.safe_path(test_path)
+    test_path = audeer.path(test_path)
 
     # keep ``output_folder`` relative if it's relative
-    if audeer.safe_path(output_folder) in test_path:
+    if audeer.path(output_folder) in test_path:
         raise ValueError(
             f'``output_folder`` may not be contained in path to files of '
-            f'original data: {audeer.safe_path(output_folder)} != {test_path}')
+            f'original data: {audeer.path(output_folder)} != {test_path}')
 
     obj = obj.copy()
     original_files = obj.index.get_level_values(define.IndexField.FILE)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audeer >=1.8.0,<2.0.0
+    audeer >=1.18.0,<2.0.0
     audiofile >=0.4.0
     iso-639
     oyaml

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -547,8 +547,8 @@ def test_duration(obj, expected_duration):
             '.',
             audformat.filewise_index(
                 [
-                    audeer.safe_path('f1'),
-                    audeer.safe_path('f2'),
+                    audeer.path('f1'),
+                    audeer.path('f2'),
                 ]
             ),
         ),
@@ -557,8 +557,8 @@ def test_duration(obj, expected_duration):
             os.path.join('some', 'where'),
             audformat.filewise_index(
                 [
-                    audeer.safe_path(os.path.join('some', 'where', 'f1')),
-                    audeer.safe_path(os.path.join('some', 'where', 'f2')),
+                    audeer.path('some', 'where', 'f1'),
+                    audeer.path('some', 'where', 'f2'),
                 ]
             ),
         ),
@@ -567,37 +567,37 @@ def test_duration(obj, expected_duration):
             os.path.join('some', 'where') + os.path.sep,
             audformat.filewise_index(
                 [
-                    audeer.safe_path(os.path.join('some', 'where', 'f1')),
-                    audeer.safe_path(os.path.join('some', 'where', 'f2')),
+                    audeer.path('some', 'where', 'f1'),
+                    audeer.path('some', 'where', 'f2'),
                 ]
             ),
         ),
         (
             audformat.filewise_index(['f1', 'f2']),
-            audeer.safe_path(os.path.join('some', 'where')),
+            audeer.path('some', 'where'),
             audformat.filewise_index(
                 [
-                    audeer.safe_path(os.path.join('some', 'where', 'f1')),
-                    audeer.safe_path(os.path.join('some', 'where', 'f2')),
+                    audeer.path('some', 'where', 'f1'),
+                    audeer.path('some', 'where', 'f2'),
                 ]
             ),
         ),
         (
             audformat.filewise_index(
                 [
-                    audeer.safe_path('f1'),
-                    audeer.safe_path('f2'),
+                    audeer.path('f1'),
+                    audeer.path('f2'),
                 ]
             ),
-            audeer.safe_path(os.path.join('some', 'where')),
+            audeer.path('some', 'where'),
             audformat.filewise_index(
                 [
-                    audeer.safe_path(os.path.join('some', 'where'))
+                    audeer.path('some', 'where')
                     + os.path.sep
-                    + audeer.safe_path('f1'),
-                    audeer.safe_path(os.path.join('some', 'where'))
+                    + audeer.path('f1'),
+                    audeer.path('some', 'where')
                     + os.path.sep
-                    + audeer.safe_path('f2'),
+                    + audeer.path('f2'),
                 ]
             ),
         ),
@@ -610,8 +610,8 @@ def test_duration(obj, expected_duration):
             '.',
             audformat.segmented_index(
                 [
-                    audeer.safe_path('f1'),
-                    audeer.safe_path('f2'),
+                    audeer.path('f1'),
+                    audeer.path('f2'),
                 ],
                 ['1s', '3s'],
                 ['2s', '4s'],


### PR DESCRIPTION
Uses the new `audeer.path()` syntax to clean up the code.