### PR TITLE
Add utility iter_index_by_file

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1095,28 +1095,3 @@ def iter_index_by_file(
     for file in files:
         select = index[index.get_loc(file)]
         yield file, select
-
-
-def has_overlap(
-        index: pd.Index,
-) -> bool:
-    r"""Check if one or more segments overlap.
-    Args:
-        index: index object conform to
-            :ref:`table specifications <data-tables:Tables>`
-
-    Returns:
-        boolean
-    """
-
-    if index_type(index) == define.IndexType.FILEWISE:
-        return False
-
-    for _, sub_index in iter_index_by_file(index):
-        sub_index = sub_index.sortlevel(define.IndexField.START)[0]
-        starts = sub_index.get_level_values(define.IndexField.START)
-        ends = sub_index.get_level_values(define.IndexField.END)
-        if any(ends[:-1] > starts[1:]):
-            return True
-
-    return False

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -13,4 +13,6 @@ from audformat.core.utils import (
     to_filewise_index,
     to_segmented_index,
     union,
+    iter_index_by_file,
+    has_overlap
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1598,24 +1598,3 @@ def test_union(objs, expected):
         expected,
     )
 
-
-@pytest.mark.parametrize(
-    'index, expected',
-    [
-        (
-            audformat.segmented_index(['f1'] * 2, [0, 1], [2, 3]),
-            True
-        ),
-        (
-            audformat.segmented_index(['f1'] * 2, [0, 2], [2, 3]),
-            False
-        ),
-        (
-            audformat.filewise_index(['f1'] * 2),
-            False
-        ),
-    ]
-)
-def test_has_overlap(index, expected):
-    has_overlap = audformat.utils.has_overlap(index)
-    assert has_overlap == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1597,3 +1597,25 @@ def test_union(objs, expected):
         audformat.utils.union(objs),
         expected,
     )
+
+
+@pytest.mark.parametrize(
+    'index, expected',
+    [
+        (
+            audformat.segmented_index(['f1'] * 2, [0, 1], [2, 3]),
+            True
+        ),
+        (
+            audformat.segmented_index(['f1'] * 2, [0, 2], [2, 3]),
+            False
+        ),
+        (
+            audformat.filewise_index(['f1'] * 2),
+            False
+        ),
+    ]
+)
+def test_has_overlap(index, expected):
+    has_overlap = audformat.utils.has_overlap(index)
+    assert has_overlap == expected


### PR DESCRIPTION
Adds the function `iter_index_by_file`. Doesn't implement separate test for it.  
If we merge this first, merging this [PR](https://github.com/audeering/audformat/pull/163) next should be fine. Or should I close the previous PR and only wait until this one is merged, and open a new PR from the new Master ? 