### PR TITLE
WIP: CI: use conda to install sox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,19 +35,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Set up conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        activate-conda: false  # don't switch Python version
+
+    - name: Install sox using conda
+      # MP3 support under Linux and macOS, see
+      # https://github.com/conda-forge/sox-feedstock/pull/18
+      run: |
+        conda config --add channels conda-forge
+        conda config --set channel_priority strict
+        conda install sox
+
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes graphviz libsndfile1 sox
+        sudo apt-get install --no-install-recommends --yes graphviz libsndfile1
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
-
-    - name: Prepare Windows
-      run: choco install sox.portable
-      if: matrix.os == 'windows-latest'
-
-    - name: Prepare OSX
-      run: brew install sox
-      if: matrix.os == 'macOS-latest'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This uses conda to install sox on all platforms as it was failing with choco under Windows.

As an alternative we can also still wait for a new release of `audiofile` and remove the installation of `sox` altogether.