### PR TITLE
TST: don't install sox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,16 +38,8 @@ jobs:
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes graphviz libsndfile1 sox
+        sudo apt-get install --no-install-recommends --yes graphviz libsndfile1
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
-
-    - name: Prepare Windows
-      run: choco install sox.portable
-      if: matrix.os == 'windows-latest'
-
-    - name: Prepare OSX
-      run: brew install sox
-      if: matrix.os == 'macOS-latest'
 
     - name: Install dependencies
       run: |

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audiofile >=1.1.0
 pytest
 pytest-flake8
 pytest-doctestplus


### PR DESCRIPTION
With the new version of `audiofile` we no longer need `sox` binaries installed.