### PR TITLE
Allow pandas>=1.4.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3,!=1.4.0
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3, <1.4.0
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3,!=1.4.0
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Closes #169

With #171 we can add support for pandas >= 1.4.0.