### PR TITLE
WIP: Support pandas 1.4.x

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1149,7 +1149,7 @@ class Table(HeaderBase):
 
         for column_id in df:  # pragma: no cover
             # TODO: Fixed with pandas 1.4.0 and can be removed
-            #   once we drop support for Python 3.6
+            #   once we drop support for < Python 3.8
 
             # Categories of type Int64 are somehow converted to int64.
             # We have to change back to Int64 to make column nullable.
@@ -1172,17 +1172,23 @@ class Table(HeaderBase):
         # that is newer than the PKL file
         df = self.df
         with open(path, 'w') as fp:
-            # Since pandas 1.4.0 DataFrame.to_csv()
-            # no longer works for categories with dtype Int64
-            # we have to temporarily convert column to plain Int64
+            # TODO: Include into code coverage
+            #   once we drop support for < Python 3.8
+
             tmp_cols = {}
-            for column, dtype in zip(df, df.dtypes):
+            for column, dtype in zip(df, df.dtypes):  # pragma: no cover
+                # Since pandas 1.4.0 DataFrame.to_csv()
+                # no longer works for categories with dtype Int64
+                # we have to temporarily convert column to plain Int64
                 if dtype.name == 'category' and \
                         dtype.categories.dtype.name == 'Int64':
                     tmp_cols[column] = df[column]
                     df[column] = df[column].astype('Int64')
+
             df.to_csv(fp, encoding='utf-8')
-            for column, y in tmp_cols.items():
+
+            for column, y in tmp_cols.items():  # pragma: no cover
+                # Revert changes to dtype
                 df[column] = y
 
     def _save_pickled(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1174,7 +1174,7 @@ class Table(HeaderBase):
         with open(path, 'w') as fp:
             # Since pandas 1.4.0 DataFrame.to_csv()
             # no longer works for categories with dtype Int64
-            # so we have to convert column to plain Int64
+            # we have to temporarily convert column to plain Int64
             tmp_cols = {}
             for column, dtype in zip(df, df.dtypes):
                 if dtype.name == 'category' and \

--- a/docs/data-example.rst
+++ b/docs/data-example.rst
@@ -21,7 +21,12 @@ and as CSV:
 .. jupyter-execute::
     :hide-code:
 
-    print(db['files'].get().to_csv())
+    df = db['files'].get()
+    # Since pandas 1.4.0 DataFrame.to_csv()
+    # no longer works for categories with dtype Int64
+    # we have to convert column to plain Int64
+    df['label_map_int'] = df['label_map_int'].astype('Int64')
+    print(df.to_csv())
 
 Segmented table as :class:`pd.DataFrame`:
 
@@ -34,4 +39,9 @@ and as CSV:
 .. jupyter-execute::
     :hide-code:
 
-    print(db['segments'].get().to_csv())
+    df = db['segments'].get()
+    # Since pandas 1.4.0 DataFrame.to_csv()
+    # no longer works for categories with dtype Int64
+    # we have to convert column to plain Int64
+    df['label_map_int'] = df['label_map_int'].astype('Int64')
+    print(df.to_csv())

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -171,8 +171,7 @@ to the emotion table.
         encoding='Latin-1',
         decimal=',',
         converters={'Satz': lambda x: os.path.join('wav', x)},
-        squeeze=True,
-    )
+    ).squeeze('columns')
     y = y.loc[files]
     y = y.replace(to_replace=u'\xa0', value='', regex=True)
     y = y.replace(to_replace=',', value='.', regex=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3, <1.4.0
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
Closes #169 

Since pandas 1.4.0 `DataFrame.to_csv()` no longer works for categories with dtype `Int64` so we have to temporarily convert to plain `Int64`. With older pandas versions we don't need the workaround so we have to exclude it from code coverage for the moment.

At least they also fixed a bug where categories of type `Int64` were converted to `int64` when saving to pickle (maybe removing this bug is related to the introduction of the new bug). Since we still need to support older pandas versions because of Python 3.6, I removed our workaround from code coverage.