### PR TITLE
Store category with integers as int64 instead of Int64

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -188,7 +188,7 @@ class Scheme(HeaderBase):
             labels = list(self.labels)
             if len(labels) > 0 and isinstance(labels[0], int):
                 # allow nullable
-                labels = pd.array(labels, dtype=pd.Int64Dtype())
+                labels = pd.array(labels, dtype='int64')
             return pd.api.types.CategoricalDtype(
                 categories=labels,
                 ordered=False,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1147,20 +1147,6 @@ class Table(HeaderBase):
         except pickle.UnpicklingError:
             df = pd.read_pickle(path, compression='xz')
 
-        for column_id in df:
-            # Categories of type Int64 are somehow converted to int64.
-            # We have to change back to Int64 to make column nullable.
-            if isinstance(df[column_id].dtype,
-                          pd.core.dtypes.dtypes.CategoricalDtype):
-                if isinstance(df[column_id].dtype.categories,
-                              pd.core.indexes.numeric.Int64Index):
-                    labels = df[column_id].dtype.categories.values
-                    labels = pd.array(labels, dtype=pd.Int64Dtype())
-                    dtype = pd.api.types.CategoricalDtype(
-                        categories=labels,
-                        ordered=False)
-                    df[column_id] = df[column_id].astype(dtype)
-
         self._df = df
 
     def _save_csv(self, path: str):

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -171,8 +171,7 @@ to the emotion table.
         encoding='Latin-1',
         decimal=',',
         converters={'Satz': lambda x: os.path.join('wav', x)},
-        squeeze=True,
-    )
+    ).squeeze('columns')
     y = y.loc[files]
     y = y.replace(to_replace=u'\xa0', value='', regex=True)
     y = y.replace(to_replace=',', value='.', regex=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3, <1.4.0
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
-    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3, <1.4.0
+    pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
In #170 we propose a workaround for storing categories with integer values as dtype `Int64` (it's currently not working when saving to CSV). However, as the following example shows, the type categories is nullable per se, i.e. we actually don't have to use `Int64` but can stick with a regular (not-nullable) `int64` instead:

```python
pd.Series(
  [1, 2, 1, None],
  dtype='category',  
)
```
```
0      1
1      2
2      1
3    NaN
dtype: category
Categories (2, int64): [1, 2]
```

I guess that's also the reason why they don't care to support `Int64` with categories in pandas. The only limitation I could think of is that you cannot have None as a category item, but since we anyway implicitly support None, there is not need for that anyway.