### PR TITLE
Update license year and authors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,11 @@
 MIT License
 
-Copyright (c) 2018-2020 audEERING GmbH and Contributors
+Copyright (c) 2018-present audEERING GmbH and Contributors
 
 Authors:
     Johannes Wagner
     Hagen Wierstorf
+    Baha Eddine Abrougui
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = audformat
-author = Johannes Wagner, Hagen Wierstorf
-author_email = jwagner@audeering.com, hwierstorf@audeering.com
+author = Johannes Wagner, Hagen Wierstorf, Baha Eddine Abrougui
+author_email = jwagner@audeering.com, hwierstorf@audeering.com, beddine@audeering.com
 url = https://github.com/audeering/audformat/
 project_urls =
     Documentation = https://audeering.github.io/audformat/


### PR DESCRIPTION
This adds @Bahaabrougui as author to `setup.cfg` and `LICENSE` and updates the second year in `LICENSE` to `present`.