### PR TITLE
Improve speed of drop_files() on segmented index

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -371,7 +371,11 @@ class Table(HeaderBase):
         else:
             index = self.files.intersection(files)
             index.name = define.IndexField.FILE
-            self.df.drop(index, inplace=True)
+            if self.is_segmented:
+                level = 'file'
+            else:
+                level = None
+            self.df.drop(index, inplace=True, level=level)
 
         return self
 


### PR DESCRIPTION
Closes #174 

This checks if we have a filewise or segmented index and sets the `level` argument accordingly when calling `self.df.drop()` inside `audformat.Table.drop_files()`.