### PR TITLE
WIP: Allow audformat.Column.set() to set duplicated index

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -277,7 +277,10 @@ class Column(HeaderBase):
             assert_values(values, scheme)
 
         if index is None:
-            df[column_id] = to_array(values)
+            if is_scalar(values):
+                values = [values] * len(df)
+            values = to_array(values)
+            df[column_id] = values
         elif index_type(df.index) == index_type(index):
             if is_scalar(values):
                 values = [values] * len(index)

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -272,14 +272,13 @@ class Column(HeaderBase):
         column_id = self._id
         df = self._table.df
 
-        if index is None:
-            index = df.index
-
         if self.scheme_id is not None:
             scheme = self._table._db.schemes[self.scheme_id]
             assert_values(values, scheme)
 
-        if index_type(df.index) == index_type(index):
+        if index is None:
+            df[column_id] = to_array(values)
+        elif index_type(df.index) == index_type(index):
             if is_scalar(values):
                 values = [values] * len(index)
             values = to_array(values)


### PR DESCRIPTION
This provides the possibility that `audformat.Column.set(values)` will not result in an error when the underlying index of the table has duplicated entries. This will only work if a user does not provide the `index` argument.