### PR TITLE
DOC: streamline table specification

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -256,9 +256,11 @@ def format_series_as_html():  # pragma: no cover (only used in documentation)
 
 
 def index_to_html(self):  # pragma: no cover
-    return self.to_frame(index=False)._repr_html_()
+    df = self.to_frame()
+    df = df.drop(columns=df.columns)
+    return df.to_html()
 
 
 def series_to_html(self):  # pragma: no cover
     df = self.to_frame()
-    return df._repr_html_()
+    return df.to_html()

--- a/docs/data-tables.rst
+++ b/docs/data-tables.rst
@@ -86,30 +86,21 @@ Access labels as :class:`pandas.Series`
 
     db['filewise']['values'].get()
 
-Access labels with a segmented index:
+Access labels and convert index to a segmented index:
 
 .. jupyter-execute::
 
     db['filewise']['values'].get(as_segmented=True)
 
-Create a segmented index:
-
-.. jupyter-execute::
-
-    import pandas as pd
-
-
-    segmented_index = audformat.segmented_index(
-        files=['f1', 'f1', 'f1', 'f2'],
-        starts=['0s', '1s', '2s', '0s'],
-        ends=['1s', '2s', '3s', pd.NaT],
-    )
-    segmented_index
-
 Access labels from a filewise table with a segmented index:
 
 .. jupyter-execute::
 
+    segmented_index = audformat.segmented_index(
+        files=['f1', 'f1', 'f1', 'f2'],
+        starts=['0s', '1s', '2s', '0s'],
+        ends=['1s', '2s', '3s', None],
+    )
     db['filewise'].get(segmented_index)
 
 Access labels from a filewise column with a segmented index:
@@ -142,7 +133,7 @@ Create a segmented index:
     segmented_index = audformat.segmented_index(
         files=['f1', 'f1', 'f1', 'f2', 'f3'],
         starts=['0s', '1s', '2s', '0s', '1m'],
-        ends=['1s', '2s', '3s', pd.NaT, '1h'],
+        ends=['1s', '2s', '3s', None, '1h'],
     )
     segmented_index
 
@@ -160,9 +151,7 @@ Assign labels to the whole table:
 
     values_list = [1, 2, 3, 4, 5]
     values_dict = {'values': values_list}
-    db['segmented'].set(
-        values_dict,
-    )
+    db['segmented'].set(values_dict)
 
 Access all labels as :class:`pandas.DataFrame`:
 
@@ -182,19 +171,13 @@ Access labels from a column as :class:`pandas.Series`:
 
     db['segmented']['values'].get()
 
-Create a filewise index:
+Access labels from a segmented table with a filewise index:
 
 .. jupyter-execute::
 
     filewise_index = audformat.filewise_index(
         ['f1', 'f2'],
     )
-    filewise_index
-
-Access labels from a segmented table with a filewise index:
-
-.. jupyter-execute::
-
     db['segmented'].get(filewise_index)
 
 Access labels from a segmented column with a filewise index:

--- a/docs/data-tables.rst
+++ b/docs/data-tables.rst
@@ -13,7 +13,7 @@ Tables
 
 
 A table links labels to media files.
-It consists of one or more index columns
+It consists of one or three index columns
 followed by an arbitrary number of label columns.
 Labels can either refer to whole files or part of files.
 An empty label means that no label has been assigned (yet).


### PR DESCRIPTION
This enhances the table specification page by the following changes.

* Explicitly mention that the number of allowed index columns
* Improve index HTML representation from 
![image](https://user-images.githubusercontent.com/173624/167351408-e7f903f5-ae61-4835-9286-3262e4f881a9.png)
 to 
![image](https://user-images.githubusercontent.com/173624/167351427-024891a2-4c71-448f-a9b6-f0b12b8cb94d.png)
* Make text easier to understand by focusing on the respective index, e.g. changing 
![image](https://user-images.githubusercontent.com/173624/167351578-51b9b1d2-d4c2-45d0-be74-94b20b64c04d.png)
to 
![image](https://user-images.githubusercontent.com/173624/167351616-59f95a1f-2cd4-453a-ac8f-e78c05d789fb.png)
 to make it more obvious that we are still inside the `filewise` index section