### PR TITLE
MiscTable: add table base class

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -362,6 +362,8 @@ class Base(HeaderBase):
             self,
             index: pd.Index,
     ) -> (pd.DataFrame, bool):  # pragma: no cover
+        # Executed when calling `self.get(index=index)`.
+        # Returns `df, df_is_copy`
         raise NotImplementedError()
 
     def _index_levels_and_converters(self) -> typing.Tuple[

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -152,7 +152,7 @@ class Base(HeaderBase):
         r"""Copy table.
 
         Return:
-            new object
+            new table object
 
         """
         table = self.__class__(
@@ -776,7 +776,7 @@ class Table(Base):
         r"""Copy table.
 
         Return:
-            new object
+            new table object
 
         """
         return super().copy()

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -426,6 +426,8 @@ class Base(HeaderBase):
             typing.Sequence[str],
             typing.Dict[str, typing.Callable],
     ]:  # pragma: no cover
+        # Executed when loading table from CSV file.
+        # Returns: `index_levels, index_converters`
         raise NotImplementedError()
 
     def _load_csv(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -148,6 +148,29 @@ class Base(HeaderBase):
         if self.split_id is not None and self.db is not None:
             return self.db.splits[self.split_id]
 
+    def copy(self) -> 'Base':
+        r"""Copy table.
+
+        Return:
+            new object
+
+        """
+        table = self.__class__(
+            self.df.index,
+            media_id=self.media_id,
+            split_id=self.split_id,
+        )
+        table._db = self.db
+        for column_id, column in self.columns.items():
+            table.columns[column_id] = Column(
+                scheme_id=column.scheme_id,
+                rater_id=column.rater_id,
+                description=column.description,
+                meta=column.meta.copy()
+            )
+        table._df = self.df.copy()
+        return table
+
     def drop_columns(
             self,
             column_ids: typing.Union[str, typing.Sequence[str]],
@@ -753,24 +776,10 @@ class Table(Base):
         r"""Copy table.
 
         Return:
-            new ``Table`` object
+            new object
 
         """
-        table = Table(
-            self.df.index,
-            media_id=self.media_id,
-            split_id=self.split_id,
-        )
-        table._db = self.db
-        for column_id, column in self.columns.items():
-            table.columns[column_id] = Column(
-                scheme_id=column.scheme_id,
-                rater_id=column.rater_id,
-                description=column.description,
-                meta=column.meta.copy()
-            )
-        table._df = self.df.copy()
-        return table
+        return super().copy()
 
     def drop_files(
             self,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,4 +84,5 @@ There are two types of tables:
 
 .. autoclass:: Table
     :members:
-    :special-members:
+    :inherited-members:
+    :special-members: __add__, __getitem__, __setitem__

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -84,5 +84,5 @@ There are two types of tables:
 
 .. autoclass:: Table
     :members:
-    :inherited-members:
+    :inherited-members: HeaderBase
     :special-members: __add__, __getitem__, __setitem__

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 graphviz
 jupyter-sphinx
 sphinx
-sphinx-audeering-theme
+sphinx-audeering-theme>=1.1.9
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinxcontrib-katex


### PR DESCRIPTION
We decided to split up #183 in smaller PRs. Here is the first one. It introduces a table base class to share code between `Table` and `MiscTable`, which we will add in another PR. Currently, the base class implements the following methods:

* `copy()`
* `drop_columns()`
* `get()`
* `load()`
* `pick_columns()`
* `save()`
* `set()`
 
Two abstract functions `_get_by_index()` and `_index_levels_and_converters()` have been added to inject code specific to filewise / segmented tables.