### PR TITLE
WIP: Replace iso-639 with pycountry

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -4,9 +4,9 @@ import re
 import sys
 import typing as typing
 
-import iso639
 import numpy as np
 import pandas as pd
+import pycountry
 
 import audeer
 import audiofile
@@ -715,28 +715,16 @@ def map_language(language: str) -> str:
         'eng'
 
     """
-    result = None
-
     if len(language) == 2:
-        try:
-            result = iso639.languages.get(alpha2=language.lower())
-        except KeyError:
-            pass
+        result = pycountry.languages.get(alpha_2=language.lower())
     elif len(language) == 3:
-        try:
-            result = iso639.languages.get(part3=language.lower())
-        except KeyError:
-            pass
+        result = pycountry.languages.get(alpha_3=language.lower())
     else:
-        try:
-            result = iso639.languages.get(name=language.title())
-        except KeyError:
-            pass
+        result = pycountry.languages.get(name=language.title())
 
     if result is not None:
-        result = result.part3
-
-    if not result:
+        result = result.alpha_3
+    else:
         raise ValueError(
             f"'{language}' is not supported by ISO 639-3."
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,12 +29,12 @@ packages = find:
 install_requires =
     audeer >=1.18.0,<2.0.0
     audiofile >=0.4.0
-    iso-639
     oyaml
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101
     # https://github.com/audeering/audformat/pull/142
     pandas >=1.1.5,!=1.3.0,!=1.3.1,!=1.3.2,!=1.3.3,!=1.4.0
+    pycountry
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
As I would like to add `audformat.utils.map_country()` besides `audformat.utils.map_language()` in order to support ISO 3166 for countries, I would propose to switch to `pycountry` instead which will then also allow us to use ISO 3166 for countries.

I guess the main reason we used https://github.com/noumar/iso639 instead of `pycountry` was that it is smaller as it only contains language codes, correct?

* `pycountry` wheel size: 11MB
* `iso-639` wheel size: 165K
