### PR TITLE
Add audformat.utils.map_country()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -654,7 +654,7 @@ def join_schemes(
 
 
 def map_country(country: str) -> str:
-    r"""Map country to ISO 3166.
+    r"""Map country to ISO 3166-1.
 
     Args:
         country: country string

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -678,7 +678,7 @@ def map_country(country: str) -> str:
         result = iso3166.countries.get(country.lower())
     except KeyError:
         raise ValueError(
-            f"'{country}' is not supported by ISO 3166."
+            f"'{country}' is not supported by ISO 3166-1."
         )
 
     return result.alpha3

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -674,21 +674,14 @@ def map_country(country: str) -> str:
         'GBR'
 
     """
-    result = None
-
     try:
         result = iso3166.countries.get(country.lower())
     except KeyError:
-        pass
-
-    if result is not None:
-        result = result.alpha3
-    else:
         raise ValueError(
             f"'{country}' is not supported by ISO 3166."
         )
 
-    return result
+    return result.alpha3
 
 
 def map_file_path(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -4,6 +4,7 @@ import re
 import sys
 import typing as typing
 
+import iso3166
 import iso639
 import numpy as np
 import pandas as pd
@@ -650,6 +651,44 @@ def join_schemes(
     labels = join_labels([db.schemes[scheme_id].labels for db in dbs])
     for db in dbs:
         db.schemes[scheme_id].replace_labels(labels)
+
+
+def map_country(country: str) -> str:
+    r"""Map country to ISO 3166.
+
+    Args:
+        country: country string
+
+    Returns:
+        mapped string
+
+    Raises:
+        ValueError: if country is not supported
+
+    Example:
+        >>> map_country('gb')
+        'GBR'
+        >>> map_country('gbr')
+        'GBR'
+        >>> map_country('United Kingdom of Great Britain and Northern Ireland')
+        'GBR'
+
+    """
+    result = None
+
+    try:
+        result = iso3166.countries.get(country.lower())
+    except KeyError:
+        pass
+
+    if result is not None:
+        result = result.alpha3
+    else:
+        raise ValueError(
+            f"'{country}' is not supported by ISO 3166."
+        )
+
+    return result
 
 
 def map_file_path(

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -8,6 +8,7 @@ from audformat.core.utils import (
     iter_by_file,
     join_labels,
     join_schemes,
+    map_country,
     map_file_path,
     map_language,
     read_csv,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -49,6 +49,11 @@ join_schemes
 
 .. autofunction:: join_schemes
 
+map_country
+-----------
+
+.. autofunction:: map_country
+
 map_file_path
 -------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     audeer >=1.18.0,<2.0.0
     audiofile >=0.4.0
     iso-639
+    iso3166
     oyaml
     pyyaml >=5.4.1
     # https://github.com/audeering/audformat/pull/101

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1099,6 +1099,31 @@ def test_join_schemes():
 
 
 @pytest.mark.parametrize(
+    'country, expected',
+    [
+        ('uy', 'URY'),
+        ('uy', 'URY'),
+        ('uruguay', 'URY'),
+        ('Uruguay', 'URY'),
+        pytest.param(
+            'xx', None,
+            marks=pytest.mark.xfail(raises=ValueError)
+        ),
+        pytest.param(
+            'xxx', None,
+            marks=pytest.mark.xfail(raises=ValueError)
+        ),
+        pytest.param(
+            'Bad country', None,
+            marks=pytest.mark.xfail(raises=ValueError)
+        )
+    ]
+)
+def test_map_country(country, expected):
+    assert utils.map_country(country) == expected
+
+
+@pytest.mark.parametrize(
     'index, func, expected_index, expected_index_windows',
     [
         (


### PR DESCRIPTION
We do not only store language information in databases, but also country information, and for that I think it might be useful to support https://en.wikipedia.org/wiki/ISO_3166-1

![image](https://user-images.githubusercontent.com/173624/169522602-ce511c71-9e28-42ac-a8a6-60903e632898.png)
