### PR TITLE
List all tables with Database.__iter__

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -118,6 +118,8 @@ class Database(HeaderBase):
             media_id: audio
             columns:
               column: {scheme_id: emotion, rater_id: rater}
+        >>> list(db)
+        ['table']
 
     """
     def __init__(
@@ -780,6 +782,11 @@ class Database(HeaderBase):
             if self[table_id] != other[table_id]:
                 return False
         return True
+
+    def __iter__(
+            self,
+    ) -> typing.Union[MiscTable, Table]:
+        yield from sorted(list(self.tables) + list(self.misc_tables))
 
     def __setitem__(
             self,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -83,22 +83,21 @@ class Database(HeaderBase):
         usage: commercial
         languages: [eng, deu]
         >>> labels = ['positive', 'neutral', 'negative']
-        >>> db.schemes['emotion'] = Scheme(
-        ...     labels=labels,
-        ... )
+        >>> db.schemes['emotion'] = Scheme(labels=labels)
+        >>> db.schemes['match'] = Scheme(dtype='bool')
         >>> db.raters['rater'] = Rater()
         >>> db.media['audio'] = Media(
         ...     define.MediaType.AUDIO,
         ...     format='wav',
         ...     sampling_rate=16000,
         ... )
-        >>> db['table'] = Table(
-        ...     media_id='audio',
-        ... )
+        >>> db['table'] = Table(media_id='audio')
         >>> db['table']['column'] = Column(
         ...     scheme_id='emotion',
         ...     rater_id='rater',
         ... )
+        >>> db['misc-table'] = MiscTable(pd.Index([], name='idx'))
+        >>> db['misc-table']['column'] = Column(scheme_id='match')
         >>> db
         name: mydb
         source: https://www.audeering.com/
@@ -112,14 +111,20 @@ class Database(HeaderBase):
           emotion:
             dtype: str
             labels: [positive, neutral, negative]
+          match: {dtype: bool}
         tables:
           table:
             type: filewise
             media_id: audio
             columns:
               column: {scheme_id: emotion, rater_id: rater}
+        misc_tables:
+          misc-table:
+            levels: [idx]
+            columns:
+              column: {scheme_id: match}
         >>> list(db)
-        ['table']
+        ['misc-table', 'table']
 
     """
     def __init__(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -246,6 +246,13 @@ def test_files_duration():
     db._root = root
 
 
+def test_iter():
+    db = audformat.testing.create_db(minimal=True)
+    assert list(db) == []
+    db = audformat.testing.create_db()
+    assert list(db) == ['files', 'misc', 'segments']
+
+
 @pytest.mark.parametrize(
     'license, license_url, expected_license, expected_url',
     [


### PR DESCRIPTION
Closes #191.

This implements `audformat.Database.__iter__` in order to use `list(db)` to get a sorted list of all table and misc table IDs.

I extended the docstring example to also contain a misc table and use the `list(db)` statement at the end:

![image](https://user-images.githubusercontent.com/173624/172589753-44914532-1c82-4981-bad1-e42fcab8debb.png)
