### PR TITLE
Support MiscTable as labels in audformat.Scheme

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -224,7 +224,8 @@ class Column(HeaderBase):
                     f"Column '{self._id}' is not assigned to a scheme."
                 )
 
-            labels = self._table._db.schemes[self.scheme_id].labels
+            scheme = self._table._db.schemes[self.scheme_id]
+            labels = scheme._get_labels()
 
             if labels is None:
                 raise ValueError(

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -226,14 +226,14 @@ class Column(HeaderBase):
                 )
 
             scheme = self._table._db.schemes[self.scheme_id]
-            labels = scheme._get_labels()
+            labels = scheme._labels_to_dict()
 
             if labels is None:
                 raise ValueError(
                     f"Scheme '{self.scheme_id}' has no labels."
                 )
 
-            if isinstance(labels, list):
+            if not any(labels.values()):
                 raise ValueError(
                     f"Scheme '{self.scheme_id}' provides no mapping "
                     "for its labels."

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # allow typing without string
+
 import typing
 
 import numpy as np
@@ -11,8 +13,13 @@ from audformat.core.index import (
     to_array,
 )
 from audformat.core.rater import Rater
-from audformat.core.scheme import Scheme
 from audformat.core.typing import Values
+
+if typing.TYPE_CHECKING:
+    # Fix to make mypy work without circular imports,
+    # compare
+    # https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
+    from audformat.core.scheme import Scheme  # pragma: nocover
 
 
 def assert_values(

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -188,9 +188,10 @@ class Column(HeaderBase):
         Raises:
             FileNotFoundError: if file is not found
             RuntimeError: if column is not assigned to a table
-            ValueError: if trying to map without a scheme
-            ValueError: if trying to map from a scheme that has no labels
-            ValueError: if trying to map to a non-existing field
+            ValueError: if trying to map without a scheme,
+                or from a scheme that has no labels,
+                or from a scheme that has only a list of labels,
+                or to a non-existing field
 
         """
         if self._table is None:
@@ -230,6 +231,12 @@ class Column(HeaderBase):
             if labels is None:
                 raise ValueError(
                     f"Scheme '{self.scheme_id}' has no labels."
+                )
+
+            if isinstance(labels, list):
+                raise ValueError(
+                    f"Scheme '{self.scheme_id}' has no mappings "
+                    "for its labels."
                 )
 
             mapping = {}

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -235,7 +235,7 @@ class Column(HeaderBase):
 
             if isinstance(labels, list):
                 raise ValueError(
-                    f"Scheme '{self.scheme_id}' has no mappings "
+                    f"Scheme '{self.scheme_id}' provides no mapping "
                     "for its labels."
                 )
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1008,8 +1008,11 @@ class Database(HeaderBase):
         scheme._db = self
         scheme._id = scheme_id
 
-        if scheme.dtype == 'misc-table':
-            table_id = Scheme.label
+        # If a misc table is used as a database
+        # we check for errors
+        # when assigning the scheme a database
+        if hasattr(scheme, 'labels') and isinstance(scheme.labels, str):
+            table_id = scheme.labels
             if table_id not in self:
                 raise ValueError(
                     f"The misc table '{table_id}' used as scheme labels "
@@ -1024,6 +1027,15 @@ class Database(HeaderBase):
                 raise ValueError(
                     f"Index of misc table '{table_id}' used as scheme labels "
                     'is not allowed to contain duplicates.'
+                )
+            labels = list(self[table_id].index)
+            dtype_labels = scheme._dtype_from_labels(labels)
+            if scheme.dtype != dtype_labels:
+                raise ValueError(
+                    "Data type is set to "
+                    f"'{scheme.dtype}', "
+                    "but data type of labels in misc table is "
+                    f"'{dtype_labels}'."
                 )
 
         return scheme

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1018,6 +1018,11 @@ class Database(HeaderBase):
                     f"The misc table '{table_id}' used as scheme labels "
                     "needs to be assigned to the database."
                 )
+            if table_id not in self.misc_tables:
+                raise ValueError(
+                    f"The table '{table_id}' used as scheme labels "
+                    "needs to be a misc table."
+                )
             if self[table_id].index.nlevels > 1:
                 raise ValueError(
                     f"Index of misc table '{table_id}' used as scheme labels "

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1007,6 +1007,25 @@ class Database(HeaderBase):
     ) -> Scheme:
         scheme._db = self
         scheme._id = scheme_id
+
+        if scheme.dtype == 'misc-table':
+            table_id = Scheme.label
+            if table_id not in self:
+                raise ValueError(
+                    f"The misc table '{table_id}' used as scheme labels "
+                    "needs to be assigned to the database."
+                )
+            if self[table_id].index.nlevels > 1:
+                raise ValueError(
+                    f"Index of misc table '{table_id}' used as scheme labels "
+                    'is only allowed to have a single level.'
+                )
+            if sum(self[table_id].index.duplicated()) > 0:
+                raise ValueError(
+                    f"Index of misc table '{table_id}' used as scheme labels "
+                    'is not allowed to contain duplicates.'
+                )
+
         return scheme
 
     def _set_table(

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1008,9 +1008,9 @@ class Database(HeaderBase):
         scheme._db = self
         scheme._id = scheme_id
 
-        # If a misc table is used as a database
+        # If a misc table is used as a scheme
         # we check for errors
-        # when assigning the scheme a database
+        # when assigning the scheme to a database
         if hasattr(scheme, 'labels') and isinstance(scheme.labels, str):
             table_id = scheme.labels
             if table_id not in self:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1007,42 +1007,8 @@ class Database(HeaderBase):
     ) -> Scheme:
         scheme._db = self
         scheme._id = scheme_id
-
-        # If a misc table is used as a scheme
-        # we check for errors
-        # when assigning the scheme to a database
-        if hasattr(scheme, 'labels') and isinstance(scheme.labels, str):
-            table_id = scheme.labels
-            if table_id not in self:
-                raise ValueError(
-                    f"The misc table '{table_id}' used as scheme labels "
-                    "needs to be assigned to the database."
-                )
-            if table_id not in self.misc_tables:
-                raise ValueError(
-                    f"The table '{table_id}' used as scheme labels "
-                    "needs to be a misc table."
-                )
-            if self[table_id].index.nlevels > 1:
-                raise ValueError(
-                    f"Index of misc table '{table_id}' used as scheme labels "
-                    'is only allowed to have a single level.'
-                )
-            if sum(self[table_id].index.duplicated()) > 0:
-                raise ValueError(
-                    f"Index of misc table '{table_id}' used as scheme labels "
-                    'is not allowed to contain duplicates.'
-                )
-            labels = list(self[table_id].index)
-            dtype_labels = scheme._dtype_from_labels(labels)
-            if scheme.dtype != dtype_labels:
-                raise ValueError(
-                    "Data type is set to "
-                    f"'{scheme.dtype}', "
-                    "but data type of labels in misc table is "
-                    f"'{dtype_labels}'."
-                )
-
+        if hasattr(scheme, 'labels') and scheme.labels is not None:
+            scheme._check_labels(scheme.labels)
         return scheme
 
     def _set_table(

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -71,7 +71,7 @@ class Scheme(HeaderBase):
         >>> db['speaker'] = audformat.MiscTable(
         ...     pd.Index(['spk1', 'spk2'], name='speaker')
         ... )
-        >>> Scheme(str, labels='speaker')
+        >>> Scheme('str', labels='speaker')
         {dtype: str, labels: speaker}
 
     """

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -45,7 +45,7 @@ class Scheme(HeaderBase):
         ValueError: ``dtype`` does not match type of ``labels``
             if ``labels`` is a list or dictionary
         ValueError: when assigning a scheme,
-            that contains a table ID as ``lables``,
+            that contains a table ID as ``labels``,
             to a database,
             but the corresponding misc table is not part of the database,
             or the given table ID is not a misc table,

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -91,6 +91,7 @@ class Scheme(HeaderBase):
         pd.Timedelta: define.DataType.TIME,
         'date': define.DataType.DATE,
         datetime.datetime: define.DataType.DATE,
+        pd.Timestamp: define.DataType.DATE,
     }
 
     def __init__(

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -48,6 +48,7 @@ class Scheme(HeaderBase):
             that contains a table ID as ``lables``,
             to a database,
             but the corresponding misc table is not part of the database,
+            or the given table ID is not a misc table,
             or its index is multi-dimensional,
             or its index contains duplicates,
             or ``dtype`` doe snot match type of labels

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -35,9 +35,10 @@ class Scheme(HeaderBase):
         BadValueError: if an invalid ``dtype`` is passed
         ValueError: if ``labels`` are not passed as list or dictionary
         ValueError: if ``labels`` are not of same data type
-        ValueError: if ``labels`` is a misc table not assigned to any database
-        ValueError: if ``labels`` is a misc table contain duplicates
-        ValueError: if ``labels`` is a misc table with a multi-dimensional index
+        ValueError: if ``labels`` is a misc table,
+            but the misc table is not assigned to any database,
+            or its index is multi-dimensional,
+            or its index contains duplicates
         ValueError: ``dtype`` does not match type of ``labels``
 
     Example:

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -71,7 +71,7 @@ class Scheme(HeaderBase):
         >>> db['speaker'] = audformat.MiscTable(
         ...     pd.Index(['spk1', 'spk2'], name='speaker')
         ... )
-        >>> Scheme(labels='speaker', dtype='str')
+        >>> Scheme(str, labels='speaker')
         {dtype: str, labels: speaker}
 
     """

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -103,6 +103,9 @@ class Scheme(HeaderBase):
     ):
         super().__init__(description=description, meta=meta)
 
+        self._db = None
+        self._id = None
+
         if dtype is not None:
             if dtype in self._dtypes:
                 dtype = self._dtypes[dtype]
@@ -148,9 +151,6 @@ class Scheme(HeaderBase):
         r"""Minimum value"""
         self.maximum = maximum if self.is_numeric else None
         r"""Maximum value"""
-
-        self._db = None
-        self._id = None
 
     @property
     def is_numeric(self) -> bool:
@@ -270,6 +270,12 @@ class Scheme(HeaderBase):
             ValueError: if scheme does not define labels
             ValueError: if dtype of new labels does not match dtype of
                 scheme
+            ValueError: if ``labels`` is a misc table ID
+                and the scheme is already assigned to a database,
+                but the corresponding misc table is not part of the database,
+                or the given table ID is not a misc table,
+                or its index is multi-dimensional,
+                or its index contains duplicates
 
         Example:
             >>> speaker = Scheme(
@@ -303,14 +309,17 @@ class Scheme(HeaderBase):
             )
         self._check_labels(labels)
 
-        dtype_labels = self._dtype_from_labels(labels)
-        if dtype_labels != self.dtype:
-            raise ValueError(
-                "Data type of labels must not change: \n"
-                f"'{self.dtype}' \n"
-                f"!=\n"
-                f"'{dtype_labels}'"
-            )
+        if not isinstance(labels, str) or self._db is not None:
+            # Check change of data type
+            # for list, dict and assigned misc table
+            dtype_labels = self._dtype_from_labels(labels)
+            if dtype_labels != self.dtype:
+                raise ValueError(
+                    "Data type of labels must not change: \n"
+                    f"'{self.dtype}' \n"
+                    f"!=\n"
+                    f"'{dtype_labels}'"
+                )
 
         self.labels = labels
 
@@ -337,6 +346,39 @@ class Scheme(HeaderBase):
                 'Labels must be passed '
                 'as a dictionary, list or ID of a misc table.'
             )
+
+        if self._db is not None and isinstance(labels, str):
+
+            table_id = labels
+            if table_id not in self._db:
+                raise ValueError(
+                    f"The misc table '{table_id}' used as scheme labels "
+                    "needs to be assigned to the database."
+                )
+            if table_id not in self._db.misc_tables:
+                raise ValueError(
+                    f"The table '{table_id}' used as scheme labels "
+                    "needs to be a misc table."
+                )
+            if self._db[table_id].index.nlevels > 1:
+                raise ValueError(
+                    f"Index of misc table '{table_id}' used as scheme labels "
+                    'is only allowed to have a single level.'
+                )
+            if sum(self._db[table_id].index.duplicated()) > 0:
+                raise ValueError(
+                    f"Index of misc table '{table_id}' used as scheme labels "
+                    'is not allowed to contain duplicates.'
+                )
+            labels = list(self._db[table_id].index)
+            dtype_labels = self._dtype_from_labels(labels)
+            if self.dtype != dtype_labels:
+                raise ValueError(
+                    "Data type is set to "
+                    f"'{self.dtype}', "
+                    "but data type of labels in misc table is "
+                    f"'{dtype_labels}'."
+                )
 
     def _dtype_from_labels(
             self,
@@ -380,10 +422,7 @@ class Scheme(HeaderBase):
     ) -> typing.List:
         r"""Convert labels to actual labels as list."""
         if isinstance(labels, str):
-            if self._db is None or labels not in self._db:
-                labels = []
-            else:
-                labels = list(self._db[labels].index)
+            labels = list(self._db[labels].index)
         else:
             labels = list(labels)
         return labels

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -52,7 +52,8 @@ class Scheme(HeaderBase):
             or its index is multi-dimensional,
             or its index contains duplicates,
             or ``dtype`` does not match type of labels
-            from misc table
+            from misc table,
+            or ``dtype`` is set to ``bool``
 
     Example:
         >>> Scheme()
@@ -121,6 +122,11 @@ class Scheme(HeaderBase):
                 if dtype is None:
                     raise ValueError(
                         "'dtype' has to be provided "
+                        "when using a misc table as labels."
+                    )
+                if dtype == define.DataType.BOOL:
+                    raise ValueError(
+                        "'dtype' cannot be 'bool' "
                         "when using a misc table as labels."
                     )
             else:

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -19,7 +19,7 @@ class Scheme(HeaderBase):
     provided by a list,
     dictionary
     or a table ID of a :class:`audformat.MiscTable`,
-    for which the labels are given by the index.
+    where the values of the index are used as labels.
     A continuous range can be limited by a minimum and
     maximum value.
 

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -201,7 +201,7 @@ class Scheme(HeaderBase):
                 x = [''.join([random.choice(seq) for _ in range(str_len)])
                      for _ in range(n)]
         else:
-            labels = self._labels_to_list(self.labels)
+            labels = list(self._get_labels())
             x = [random.choice(labels) for _ in range(n)]
 
         if p_none is not None:
@@ -230,7 +230,7 @@ class Scheme(HeaderBase):
 
         """
         if self.labels is not None:
-            labels = self._labels_to_list(self.labels)
+            labels = list(self._get_labels())
             if len(labels) > 0 and isinstance(labels[0], int):
                 # allow nullable
                 labels = pd.array(labels, dtype='int64')
@@ -357,11 +357,24 @@ class Scheme(HeaderBase):
 
         return dtype
 
+    def _get_labels(
+            self,
+    ) -> typing.Union[typing.List, typing.Dict]:
+        r"""Return actual labels as list or dict."""
+        if isinstance(self.labels, str):
+            if self._db is None or self.labels not in self._db:
+                labels = {}
+            else:
+                labels = self._db[self.labels].df.to_dict('index')
+        else:
+            labels = self.labels
+        return labels
+
     def _labels_to_list(
             self,
             labels: typing.Union[dict, list, str],
     ) -> typing.List:
-        r"""Return list of labels."""
+        r"""Convert labels to actual labels as list."""
         if isinstance(labels, str):
             if self._db is None or labels not in self._db:
                 labels = []
@@ -383,7 +396,7 @@ class Scheme(HeaderBase):
         if item is not None and not pd.isna(item):
             if self.labels is not None:
                 if isinstance(self.labels, str):
-                    labels = self._labels_to_list(self.labels)
+                    labels = self._get_labels()
                 else:
                     labels = self.labels
                 return item in labels

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -16,15 +16,16 @@ class Scheme(HeaderBase):
     Allowed values for ``dtype`` are:
     ``'bool'``, ``'str'``, ``'int'``, ``'float'``, ``'time'``, and ``'date'``
     (see :class:`audformat.define.DataType`).
-    Values can be restricted to a set of labels provided by a
-    list or a dictionary.
+    Values can be restricted to a set of labels
+    provided by a list, dictionary or a :class:`audformat.MiscTable`,
+    for which the labels are given by the index.
     A continuous range can be limited by a minimum and
     maximum value.
 
     Args:
         dtype: if ``None`` derived from ``labels``, otherwise set to ``'str'``
-        labels: list or dictionary with valid labels,
-            or name of misc table containing labels as index
+        labels: list, dictionary or :class:`audformat.MiscTable`
+            with valid labels
         minimum: minimum value
         maximum: maximum value
         description: scheme description
@@ -35,6 +36,8 @@ class Scheme(HeaderBase):
         ValueError: if ``labels`` are not passed as list or dictionary
         ValueError: if ``labels`` are not of same data type
         ValueError: if ``labels`` is a misc table not assigned to any database
+        ValueError: if ``labels`` is a misc table contain duplicates
+        ValueError: if ``labels`` is a misc table with a multi-dimensional index
         ValueError: ``dtype`` does not match type of ``labels``
 
     Example:

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -51,7 +51,7 @@ class Scheme(HeaderBase):
             or the given table ID is not a misc table,
             or its index is multi-dimensional,
             or its index contains duplicates,
-            or ``dtype`` doe snot match type of labels
+            or ``dtype`` does not match type of labels
             from misc table
 
     Example:

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -331,7 +331,7 @@ class Scheme(HeaderBase):
         if not isinstance(labels, (dict, list, str)):
             raise ValueError(
                 'Labels must be passed '
-                'as a dictionary, list or ID of a misced table.'
+                'as a dictionary, list or ID of a misc table.'
             )
 
     def _dtype_from_labels(

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -407,7 +407,7 @@ class Scheme(HeaderBase):
             self,
             labels: typing.Union[dict, list, str] = None,
     ) -> typing.Dict:
-        r"""Return actual labels as list or dict."""
+        r"""Return actual labels as dict."""
         if labels is None:
             labels = self.labels
         if isinstance(labels, str):

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -65,7 +65,7 @@ class Scheme(HeaderBase):
         {dtype: int}
         >>> Scheme(float, minimum=0, maximum=1)
         {dtype: float, minimum: 0, maximum: 1}
-        >>> # Misc Table as Scheme
+        >>> # Use index of misc table as labels
         >>> import audformat
         >>> db = audformat.Database('mydb')
         >>> db.schemes['age'] = Scheme('int')

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -51,6 +51,21 @@ class Scheme(HeaderBase):
         {dtype: int}
         >>> Scheme(float, minimum=0, maximum=1)
         {dtype: float, minimum: 0, maximum: 1}
+        >>> # Misc Table as Scheme
+        >>> import audformat
+        >>> db = audformat.Database('mydb')
+        >>> db.schemes['age'] = Scheme('int')
+        >>> db['speaker'] = audformat.MiscTable(
+        ...     pd.Index(['spk1', 'spk2'], name='speaker')
+        ... )
+        >>> db['speaker']['age'] = audformat.Column(scheme_id='age')
+        >>> db['speaker']['age'].set([31, 46])
+        >>> Scheme(labels=db['speaker'])
+        dtype: str
+        labels:
+          levels: [speaker]
+          columns:
+            age: {scheme_id: age}
 
     """
     _dtypes = {

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -68,12 +68,9 @@ class Scheme(HeaderBase):
         >>> # Use index of misc table as labels
         >>> import audformat
         >>> db = audformat.Database('mydb')
-        >>> db.schemes['age'] = Scheme('int')
         >>> db['speaker'] = audformat.MiscTable(
         ...     pd.Index(['spk1', 'spk2'], name='speaker')
         ... )
-        >>> db['speaker']['age'] = audformat.Column(scheme_id='age')
-        >>> db['speaker']['age'].set([31, 46])
         >>> Scheme(labels='speaker', dtype='str')
         {dtype: str, labels: speaker}
 

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -302,48 +302,34 @@ class Scheme(HeaderBase):
 
     def _check_labels(
             self,
-            labels: typing.Union[dict, list, MiscTable],
+            labels: typing.Union[dict, list, str],
     ):
         r"""Raise label related errors."""
 
-        if not isinstance(labels, (dict, list, MiscTable)):
+        if not isinstance(labels, (dict, list, str)):
             raise ValueError(
                 'Labels must be passed '
-                'as a dictionary, list or misc table.'
+                'as a dictionary, list or ID of a misced table.'
             )
-        if isinstance(labels, MiscTable):
-            if labels.db is None:
-                raise ValueError(
-                    'The given table needs to be assigned '
-                    'to a database.'
-                )
-            if labels.index.nlevels > 1:
-                raise ValueError(
-                    'Index of misc table used for scheme labels '
-                    'is only allowed to have a single level.'
-                )
-            if sum(labels.index.duplicated()) > 0:
-                raise ValueError(
-                    'Index of misc table used for scheme labels '
-                    'is not allowed to contain duplicates.'
-                )
 
     def _dtype_from_labels(
             self,
-            labels: typing.Union[dict, list, MiscTable],
+            labels: typing.Union[dict, list, str],
     ) -> str:
         r"""Derive dtype from labels."""
 
-        labels = self._labels_to_list(labels)
-
-        if len(labels) > 0:
-            dtype = type(labels[0])
+        if isinstance(labels, str):
+            dtype = 'misc-table'
         else:
-            dtype = 'str'
-        if not all(isinstance(x, dtype) for x in labels):
-            raise ValueError(
-                'All labels must be of the same data type.'
-            )
+            labels = list(labels)
+            if len(labels) > 0:
+                dtype = type(labels[0])
+            else:
+                dtype = 'str'
+            if not all(isinstance(x, dtype) for x in labels):
+                raise ValueError(
+                    'All labels must be of the same data type.'
+                )
 
         if dtype in self._dtypes:
             dtype = self._dtypes[dtype]

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -320,9 +320,12 @@ def create_db(
         labels={1: 'a', 2: 'b', 3: 'c'}
     )
     db.schemes['label_map_str'] = Scheme(
-        labels={'label1': {'prop1': 1, 'prop2': 'a'},
-                'label2': {'prop1': 2, 'prop2': 'b'},
-                'label3': {'prop1': 3, 'prop2': 'c'}})
+        labels={
+            'label1': {'prop1': 1, 'prop2': 'a'},
+            'label2': {'prop1': 2, 'prop2': 'b'},
+            'label3': {'prop1': 3, 'prop2': 'c'},
+        }
+    )
     db.schemes['string'] = Scheme()
     db.schemes['time'] = Scheme(dtype=define.DataType.TIME)
 
@@ -369,9 +372,9 @@ def create_db(
         db.schemes['string'].draw(100, p_none=0.25)
     )
 
-    #######################
-    # Miscellaneous Table #
-    #######################
+    ##############
+    # Misc Table #
+    ##############
 
     db.schemes['age'] = Scheme(
         dtype=define.DataType.INTEGER,
@@ -391,5 +394,11 @@ def create_db(
     db['misc']['age'].set(db.schemes['age'].draw(len(index)))
     db['misc']['gender'] = Column(scheme_id='gender')
     db['misc']['gender'].set(db.schemes['gender'].draw(len(index)))
+
+    ############################
+    # Schemes from Misc Tables #
+    ############################
+
+    db.schemes['speaker'] = Scheme(labels=db['misc'])
 
     return db

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -386,7 +386,7 @@ def create_db(
     )
 
     index = pd.Index(
-        ['sp1', 'sp2', 'sp3'],
+        ['spk1', 'spk2', 'spk3'],
         name='speaker',
     )
     db['misc'] = MiscTable(index)

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -328,54 +328,6 @@ def create_db(
     )
     db.schemes['string'] = Scheme()
     db.schemes['time'] = Scheme(dtype=define.DataType.TIME)
-
-    ##########
-    # Splits #
-    ##########
-
-    db.splits['dev'] = Split(type=define.SplitType.DEVELOP)
-    db.splits['test'] = Split(type=define.SplitType.TEST)
-    db.splits['train'] = Split(type=define.SplitType.TRAIN)
-
-    ##########
-    # Tables #
-    ##########
-
-    add_table(
-        db,
-        'files',
-        define.IndexType.FILEWISE,
-        columns={
-            scheme: (scheme, 'gold') for scheme in db.schemes
-        },
-        num_files=100, p_none=0.25, split_id='train',
-        media_id='microphone'
-    )
-    db['files']['no_scheme'] = Column()
-    db['files']['no_scheme'].set(
-        db.schemes['string'].draw(100, p_none=0.25)
-    )
-
-    add_table(
-        db,
-        'segments',
-        define.IndexType.SEGMENTED,
-        columns={
-            scheme: (scheme, 'gold') for scheme in db.schemes
-        },
-        num_files=10, num_segments_per_file=10,
-        file_duration='60s', p_none=0.25, split_id='dev',
-        media_id='microphone',
-    )
-    db['segments']['no_scheme'] = Column()
-    db['segments']['no_scheme'].set(
-        db.schemes['string'].draw(100, p_none=0.25)
-    )
-
-    ##############
-    # Misc Table #
-    ##############
-
     db.schemes['age'] = Scheme(
         dtype=define.DataType.INTEGER,
         minimum=9,
@@ -384,6 +336,10 @@ def create_db(
     db.schemes['gender'] = Scheme(
         labels=['female', 'male'],
     )
+
+    ##############
+    # Misc Table #
+    ##############
 
     index = pd.Index(
         ['spk1', 'spk2', 'spk3'],
@@ -400,5 +356,49 @@ def create_db(
     ############################
 
     db.schemes['speaker'] = Scheme(labels='misc', dtype='str')
+
+    ##########
+    # Splits #
+    ##########
+
+    db.splits['dev'] = Split(type=define.SplitType.DEVELOP)
+    db.splits['test'] = Split(type=define.SplitType.TEST)
+    db.splits['train'] = Split(type=define.SplitType.TRAIN)
+
+    ##########
+    # Tables #
+    ##########
+
+    schemes = [s for s in db.schemes if s not in ['age', 'gender']]
+    add_table(
+        db,
+        'files',
+        define.IndexType.FILEWISE,
+        columns={
+            scheme: (scheme, 'gold') for scheme in schemes
+        },
+        num_files=100, p_none=0.25, split_id='train',
+        media_id='microphone'
+    )
+    db['files']['no_scheme'] = Column()
+    db['files']['no_scheme'].set(
+        db.schemes['string'].draw(100, p_none=0.25)
+    )
+
+    add_table(
+        db,
+        'segments',
+        define.IndexType.SEGMENTED,
+        columns={
+            scheme: (scheme, 'gold') for scheme in schemes
+        },
+        num_files=10, num_segments_per_file=10,
+        file_duration='60s', p_none=0.25, split_id='dev',
+        media_id='microphone',
+    )
+    db['segments']['no_scheme'] = Column()
+    db['segments']['no_scheme'].set(
+        db.schemes['string'].draw(100, p_none=0.25)
+    )
 
     return db

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -399,6 +399,6 @@ def create_db(
     # Schemes from Misc Tables #
     ############################
 
-    db.schemes['speaker'] = Scheme(labels=db['misc'])
+    db.schemes['speaker'] = Scheme(labels='misc', dtype='str')
 
     return db

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -328,14 +328,6 @@ def create_db(
     )
     db.schemes['string'] = Scheme()
     db.schemes['time'] = Scheme(dtype=define.DataType.TIME)
-    db.schemes['age'] = Scheme(
-        dtype=define.DataType.INTEGER,
-        minimum=9,
-        maximum=99,
-    )
-    db.schemes['gender'] = Scheme(
-        labels=['female', 'male'],
-    )
 
     ##############
     # Misc Table #
@@ -346,16 +338,16 @@ def create_db(
         name='speaker',
     )
     db['misc'] = MiscTable(index)
-    db['misc']['age'] = Column(scheme_id='age')
-    db['misc']['age'].set(db.schemes['age'].draw(len(index)))
-    db['misc']['gender'] = Column(scheme_id='gender')
-    db['misc']['gender'].set(db.schemes['gender'].draw(len(index)))
+    db['misc']['int'] = Column(scheme_id='int')
+    db['misc']['int'].set(db.schemes['int'].draw(len(index)))
+    db['misc']['label'] = Column(scheme_id='label')
+    db['misc']['label'].set(db.schemes['label'].draw(len(index)))
 
     ############################
     # Schemes from Misc Tables #
     ############################
 
-    db.schemes['speaker'] = Scheme(labels='misc', dtype='str')
+    db.schemes['label_map_misc'] = Scheme(labels='misc', dtype='str')
 
     ##########
     # Splits #
@@ -369,13 +361,12 @@ def create_db(
     # Tables #
     ##########
 
-    schemes = [s for s in db.schemes if s not in ['age', 'gender']]
     add_table(
         db,
         'files',
         define.IndexType.FILEWISE,
         columns={
-            scheme: (scheme, 'gold') for scheme in schemes
+            scheme: (scheme, 'gold') for scheme in db.schemes
         },
         num_files=100, p_none=0.25, split_id='train',
         media_id='microphone'
@@ -390,7 +381,7 @@ def create_db(
         'segments',
         define.IndexType.SEGMENTED,
         columns={
-            scheme: (scheme, 'gold') for scheme in schemes
+            scheme: (scheme, 'gold') for scheme in db.schemes
         },
         num_files=10, num_segments_per_file=10,
         file_duration='60s', p_none=0.25, split_id='dev',

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -334,8 +334,8 @@ def create_db(
     ##############
 
     index = pd.Index(
-        ['spk1', 'spk2', 'spk3'],
-        name='speaker',
+        ['label1', 'label2', 'label3'],
+        name='labels',
     )
     db['misc'] = MiscTable(index)
     db['misc']['int'] = Column(scheme_id='int')

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -161,7 +161,7 @@ def test_get_as_segmented():
         (pytest.DB['segments']['label_map_str'], 'prop2'),
         pytest.param(  # no mappings
             pytest.DB['files']['label'], 'label1',
-            # marks=pytest.mark.xfail(raises=ValueError),
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(  # no schemes
             pytest.DB['files']['no_scheme'], 'map',

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -159,7 +159,10 @@ def test_get_as_segmented():
         (pytest.DB['files']['label_map_int'], 'label_map_int'),
         (pytest.DB['files']['label_map_str'], 'prop1'),
         (pytest.DB['segments']['label_map_str'], 'prop2'),
-        (pytest.DB['files']['label'], 'label1'),
+        pytest.param(  # no mappings
+            pytest.DB['files']['label'], 'label1',
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
         pytest.param(  # no schemes
             pytest.DB['files']['no_scheme'], 'map',
             marks=pytest.mark.xfail(raises=ValueError),

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -159,6 +159,7 @@ def test_get_as_segmented():
         (pytest.DB['files']['label_map_int'], 'label_map_int'),
         (pytest.DB['files']['label_map_str'], 'prop1'),
         (pytest.DB['segments']['label_map_str'], 'prop2'),
+        (pytest.DB['files']['label'], 'label1'),
         pytest.param(  # no schemes
             pytest.DB['files']['no_scheme'], 'map',
             marks=pytest.mark.xfail(raises=ValueError),

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -161,7 +161,7 @@ def test_get_as_segmented():
         (pytest.DB['segments']['label_map_str'], 'prop2'),
         pytest.param(  # no mappings
             pytest.DB['files']['label'], 'label1',
-            marks=pytest.mark.xfail(raises=ValueError),
+            # marks=pytest.mark.xfail(raises=ValueError),
         ),
         pytest.param(  # no schemes
             pytest.DB['files']['no_scheme'], 'map',

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -37,8 +37,8 @@ def test_copy(table):
     [
         (
             pytest.DB['misc'],
-            'age',
-            pytest.DB['misc'].df['age'],
+            'int',
+            pytest.DB['misc'].df['int'],
         ),
     ]
 )

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -357,7 +357,7 @@ def test_replace_labels_misc_table():
     )
 
     # non-assigned scheme
-    scheme = audformat.Scheme(labels='misc', dtype='str')
+    scheme = audformat.Scheme('str', labels='misc')
     assert scheme.labels == 'misc'
     assert scheme._get_labels() == {}
 
@@ -384,6 +384,11 @@ def test_replace_labels_misc_table():
     assert scheme.labels == {'spk1': {}}
     assert scheme._get_labels() == {'spk1': {}}
     assert list(db['table']['columns'].get().values) == ['spk1', np.NaN]
+
+    # replace again with mis table
+    scheme.replace_labels('misc')
+    assert scheme.labels == 'misc'
+    assert scheme._get_labels() == {'spk1': {}, 'spk2': {}}
 
     # replace with list
     scheme.replace_labels(['spk1', 'spk2'])

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -360,7 +360,7 @@ def test_replace_labels_misc_table():
     # non-assigned scheme
     scheme = audformat.Scheme('str', labels='misc')
     assert scheme.labels == 'misc'
-    assert scheme._get_labels() == {}
+    assert scheme._labels_to_dict() == {}
 
     # replace with non-existing misc table scheme
     # and back again
@@ -370,7 +370,7 @@ def test_replace_labels_misc_table():
     # assigned scheme
     db.schemes['scheme'] = scheme
     assert scheme.labels == 'misc'
-    assert scheme._get_labels() == {'spk1': {}, 'spk2': {}}
+    assert scheme._labels_to_dict() == {'spk1': {}, 'spk2': {}}
 
     # use scheme
     db['table'] = audformat.Table(index=audformat.filewise_index(['f1', 'f2']))
@@ -383,23 +383,23 @@ def test_replace_labels_misc_table():
     )
     scheme.replace_labels('misc-new')
     assert scheme.labels == 'misc-new'
-    assert scheme._get_labels() == {'spk1': {}, 'spk2': {}, 'spk3': {}}
+    assert scheme._labels_to_dict() == {'spk1': {}, 'spk2': {}, 'spk3': {}}
 
     # replace with dictionary
     scheme.replace_labels({'spk1': {}})
     assert scheme.labels == {'spk1': {}}
-    assert scheme._get_labels() == {'spk1': {}}
+    assert scheme._labels_to_dict() == {'spk1': {}}
     assert list(db['table']['columns'].get().values) == ['spk1', np.NaN]
 
     # replace again with misc table
     scheme.replace_labels('misc')
     assert scheme.labels == 'misc'
-    assert scheme._get_labels() == {'spk1': {}, 'spk2': {}}
+    assert scheme._labels_to_dict() == {'spk1': {}, 'spk2': {}}
 
     # replace with list
     scheme.replace_labels(['spk1', 'spk2'])
     assert scheme.labels == ['spk1', 'spk2']
-    assert scheme._get_labels() == ['spk1', 'spk2']
+    assert scheme._labels_to_dict() == {'spk1': {}, 'spk2': {}}
 
     # replace with non-existing misc table scheme
     error_msg = (

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -37,6 +37,10 @@ def test_scheme_contains():
     # Misc table
     # assigned scheme
     assert 'spk1' in db.schemes['speaker']
+    # remove table
+    # db.drop_tables(['misc'])
+    db.misc_tables.pop('misc')
+    assert 'spk1' not in db.schemes['speaker']
     # unassigned scheme
     scheme = audformat.Scheme(labels='misc', dtype='str')
     assert 'spk1' not in scheme

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -53,9 +53,10 @@ def test_scheme_contains():
 @pytest.mark.parametrize(
     'dtype, values',
     [
-        (
+        pytest.param(  # bool not supported
             audformat.define.DataType.BOOL,
             [True, False],
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
             audformat.define.DataType.DATE,

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -47,6 +47,33 @@ def test_scheme_errors():
         scheme = audformat.Scheme(audformat.define.DataType.INTEGER)
         scheme.replace_labels(['a', 'b'])
 
+    # misc table not assigned to a database
+    table = audformat.MiscTable(pd.Index([], name='misc'))
+    error_msg = 'table needs to be assigned'
+    with pytest.raises(ValueError, match=error_msg):
+        audformat.Scheme(labels=table)
+
+    # misc table should only contain an one-dimensional index
+    db = pytest.DB
+    db['misc-multi-dim'] = audformat.MiscTable(
+        pd.MultiIndex.from_arrays(
+            [
+                [1, 2],
+                ['a', 'b'],
+            ],
+            names=['misc-1', 'misc-2'],
+        )
+    )
+    error_msg = 'allowed to have a single level'
+    with pytest.raises(ValueError, match=error_msg):
+        audformat.Scheme(labels=db['misc-multi-dim'])
+
+    # misc table should not contain duplicates
+    db['misc-duplicate'] = audformat.MiscTable(pd.Index([0, 0], name='misc'))
+    error_msg = 'not allowed to contain duplicates'
+    with pytest.raises(ValueError, match=error_msg):
+        audformat.Scheme(labels=db['misc-duplicate'])
+
 
 @pytest.mark.parametrize(
     'values, labels, new_labels, expected',

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -40,11 +40,11 @@ def test_scheme_contains():
 
     # Misc table
     # assigned scheme
-    assert 'spk1' in db.schemes['speaker']
+    assert 'spk1' in db.schemes['label_map_misc']
     # remove table
     # db.drop_tables(['misc'])
     db.misc_tables.pop('misc')
-    assert 'spk1' not in db.schemes['speaker']
+    assert 'spk1' not in db.schemes['label_map_misc']
     # unassigned scheme
     scheme = audformat.Scheme(labels='misc', dtype='str')
     assert 'spk1' not in scheme

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -9,14 +9,18 @@ def test_scheme_assign_values():
 
     db = audformat.testing.create_db(minimal=True)
     speakers = ['spk1', 'spk2', 'spk3']
+    ages = [33, 44, 55]
     index = pd.Index(speakers, name='speaker')
     db['misc'] = audformat.MiscTable(index)
+    db['misc']['age'] = audformat.Column()
+    db['misc']['age'].set(ages)
     db.schemes['scheme'] = audformat.Scheme(labels='misc', dtype='str')
     db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
     db['table']['speaker'] = audformat.Column(scheme_id='scheme')
     db['table']['speaker'].set(speakers)
 
     assert list(db['table']['speaker'].get()) == speakers
+    assert list(db['table']['speaker'].get(map='age')) == ages
 
 
 def test_scheme_contains():

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -5,7 +5,21 @@ import audformat
 import audformat.testing
 
 
-def test_scheme():
+def test_scheme_assign_values():
+
+    db = audformat.testing.create_db(minimal=True)
+    speakers = ['spk1', 'spk2', 'spk3']
+    index = pd.Index(speakers, name='speaker')
+    db['misc'] = audformat.MiscTable(index)
+    db.schemes['scheme'] = audformat.Scheme(labels='misc', dtype='str')
+    db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
+    db['table']['speaker'] = audformat.Column(scheme_id='scheme')
+    db['table']['speaker'].set(speakers)
+
+    assert list(db['table']['speaker'].get()) == speakers
+
+
+def test_scheme_contains():
 
     db = pytest.DB
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -22,6 +22,7 @@ def test_scheme_assign_values():
 
     assert list(db['table']['speaker'].get()) == speakers
     assert list(db['table']['speaker'].get(map='age')) == ages
+    assert list(db['table'].get(map={'speaker': 'age'})['age']) == ages
 
 
 def test_scheme_contains():

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -362,6 +362,11 @@ def test_replace_labels_misc_table():
     assert scheme.labels == 'misc'
     assert scheme._get_labels() == {}
 
+    # replace with non-existing misc table scheme
+    # and back again
+    scheme.replace_labels('misc-non-existing')
+    scheme.replace_labels('misc')
+
     # assigned scheme
     db.schemes['scheme'] = scheme
     assert scheme.labels == 'misc'
@@ -397,6 +402,9 @@ def test_replace_labels_misc_table():
     assert scheme._get_labels() == ['spk1', 'spk2']
 
     # replace with non-existing misc table scheme
-    scheme.replace_labels('misc-non-existing')
-    assert scheme.labels == 'misc-non-existing'
-    assert scheme._get_labels() == {}
+    error_msg = (
+        "The misc table 'misc-non-existing' used as scheme labels "
+        "needs to be assigned to the database."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        scheme.replace_labels('misc-non-existing')

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -90,7 +90,6 @@ def test_scheme_dtypes(dtype, values):
     db['table']['labels'] = audformat.Column(scheme_id='scheme')
     db['table']['labels'].set(values)
 
-    print(list(db['table']['labels'].get()))
     assert set(db['table']['labels'].get()) == set(values)
 
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -22,10 +22,10 @@ def test_scheme():
 
     # Misc table
     # assigned scheme
-    assert 'sp1' in db.schemes['speaker']
+    assert 'spk1' in db.schemes['speaker']
     # unassigned scheme
     scheme = audformat.Scheme(labels='misc', dtype='str')
-    assert 'sp1' not in scheme
+    assert 'spk1' not in scheme
 
 
 def test_scheme_errors():

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -20,6 +20,13 @@ def test_scheme():
     assert 'label1' in db.schemes['label_map_str']
     assert 1 in db.schemes['label_map_int']
 
+    # Misc table
+    # assigned scheme
+    assert 'sp1' in db.schemes['speaker']
+    # unassigned scheme
+    scheme = audformat.Scheme(labels='misc', dtype='str')
+    assert 'sp1' not in scheme
+
 
 def test_scheme_errors():
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -50,6 +50,49 @@ def test_scheme_contains():
     assert 'label1' not in scheme
 
 
+@pytest.mark.parametrize(
+    'dtype, values',
+    [
+        (
+            audformat.define.DataType.BOOL,
+            [True, False],
+        ),
+        (
+            audformat.define.DataType.DATE,
+            pd.to_datetime(['3/11/2000', '3/12/2000', '3/13/2000']),
+        ),
+        (
+            audformat.define.DataType.INTEGER,
+            [1, 2, 3],
+        ),
+        (
+            audformat.define.DataType.FLOAT,
+            [1.0, 2.0, 3.0],
+        ),
+        (
+            audformat.define.DataType.STRING,
+            ['a', 'b', 'c'],
+        ),
+        (
+            audformat.define.DataType.TIME,
+            pd.to_timedelta(['1s', '2s', '3s']),
+        ),
+    ]
+)
+def test_scheme_dtypes(dtype, values):
+    db = audformat.Database('test')
+    index = pd.Index(values, name='labels')
+    db['misc'] = audformat.MiscTable(index)
+    index = audformat.filewise_index([f'f{idx}' for idx in range(len(values))])
+    db.schemes['scheme'] = audformat.Scheme(dtype=dtype, labels='misc')
+    db['table'] = audformat.Table(index)
+    db['table']['labels'] = audformat.Column(scheme_id='scheme')
+    db['table']['labels'].set(values)
+
+    print(list(db['table']['labels'].get()))
+    assert set(db['table']['labels'].get()) == set(values)
+
+
 def test_scheme_errors():
 
     db = audformat.Database('test')

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -40,14 +40,14 @@ def test_scheme_contains():
 
     # Misc table
     # assigned scheme
-    assert 'spk1' in db.schemes['label_map_misc']
+    assert 'label1' in db.schemes['label_map_misc']
     # remove table
     # db.drop_tables(['misc'])
     db.misc_tables.pop('misc')
-    assert 'spk1' not in db.schemes['label_map_misc']
+    assert 'label1' not in db.schemes['label_map_misc']
     # unassigned scheme
     scheme = audformat.Scheme(labels='misc', dtype='str')
-    assert 'spk1' not in scheme
+    assert 'label1' not in scheme
 
 
 def test_scheme_errors():

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -386,7 +386,7 @@ def test_replace_labels_misc_table():
     assert scheme._get_labels() == {'spk1': {}}
     assert list(db['table']['columns'].get().values) == ['spk1', np.NaN]
 
-    # replace again with mis table
+    # replace again with misc table
     scheme.replace_labels('misc')
     assert scheme.labels == 'misc'
     assert scheme._get_labels() == {'spk1': {}, 'spk2': {}}


### PR DESCRIPTION
Add support for using `MiscTable` as a scheme with labels. This has no the big advantage that we can define schemes for entries in schemes.

~~Not sure if I overlooked something, but it seems relatively easy to add.~~

![image](https://user-images.githubusercontent.com/173624/177791681-1ec6a967-e289-4d68-afdb-f2b96123a595.png)

![image](https://user-images.githubusercontent.com/173624/177803946-1afe2dd0-b847-4229-bdc9-6383a95c0184.png)

I added the `speaker` scheme as example to `audformat.testing.create_db()`:

```python
import audformat.testing

audformat.testing.create_db()
```
results in

```yaml
name: unittest    
description: A database for unit testing.
source: internal
[...]
schemes:
[...]
  speaker:
    {dtype: str, labels: misc}
[...]
misc_tables:
  misc:
    levels: [speaker]
    columns:
      age: {scheme_id: age}
      gender: {scheme_id: gender}
```
