### PR TITLE
Add a code comment for dtype argument in Schemes

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -75,6 +75,10 @@ class Scheme(HeaderBase):
         {dtype: str, labels: speaker}
 
     """
+    # Mapping for dtype input argument,
+    # e.g. to allow `str` besides `'str'`.
+    # This behavior is only for convinience
+    # and not mentioned in the docstring
     _dtypes = {
         'bool': define.DataType.BOOL,
         bool: define.DataType.BOOL,

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -77,7 +77,7 @@ class Scheme(HeaderBase):
     """
     # Mapping for dtype input argument,
     # e.g. to allow `str` besides `'str'`.
-    # This behavior is only for convinience
+    # This behavior is only for convenience
     # and not mentioned in the docstring
     _dtypes = {
         'bool': define.DataType.BOOL,


### PR DESCRIPTION
Closes #206 

This adds a comment to highlight that the `_dtypes` variable in the code allows to support more than the documented input types for the `dtype` argument of `audformat.Schemes`