### PR TITLE
Add audformat.define.DataType.OBJECT

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -6,7 +6,10 @@ import numpy as np
 import pandas as pd
 
 from audformat.core import define
-from audformat.core.common import HeaderBase
+from audformat.core.common import (
+    HeaderBase,
+    to_pandas_dtype,
+)
 from audformat.core.index import (
     index_type,
     is_scalar,
@@ -301,6 +304,9 @@ class Column(HeaderBase):
         if self.scheme_id is not None:
             scheme = self._table._db.schemes[self.scheme_id]
             assert_values(values, scheme)
+            dtype = scheme.to_pandas_dtype()
+        else:
+            dtype = df[column_id].dtype
 
         if hasattr(self._table, 'type') and \
                 self._table.type != index_type(index):
@@ -322,7 +328,7 @@ class Column(HeaderBase):
             df.loc[index, column_id] = pd.Series(
                 values,
                 index=index,
-                dtype=df[column_id].dtype,
+                dtype=dtype,
             )
 
     def __eq__(

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -6,10 +6,7 @@ import numpy as np
 import pandas as pd
 
 from audformat.core import define
-from audformat.core.common import (
-    HeaderBase,
-    to_pandas_dtype,
-)
+from audformat.core.common import HeaderBase
 from audformat.core.index import (
     index_type,
     is_scalar,

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -6,8 +6,6 @@ from collections import OrderedDict
 
 import pandas as pd
 
-import audeer
-
 from audformat import define
 from audformat.core.errors import (
     BadKeyError,

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -310,9 +310,13 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
         return define.DataType.INTEGER
     elif pd.api.types.is_timedelta64_dtype(dtype):
         return define.DataType.TIME
-    else:
-        # default to str
+    # We cannot use pd.api.types.is_string_dtype()
+    # as it returns `True` for list, object, etc.
+    elif dtype in [str, 'str', 'string']:
         return define.DataType.STRING
+    else:
+        # default to object
+        return define.DataType.OBJECT
 
 
 def to_pandas_dtype(dtype: str) -> str:
@@ -325,6 +329,8 @@ def to_pandas_dtype(dtype: str) -> str:
         return 'float'
     elif dtype == define.DataType.INTEGER:
         return 'Int64'
+    elif dtype == define.DataType.OBJECT:
+        return 'object'
     elif dtype == define.DataType.STRING:
         return 'str'
     elif dtype == define.DataType.TIME:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -96,7 +96,8 @@ class Database(HeaderBase):
         ...     scheme_id='emotion',
         ...     rater_id='rater',
         ... )
-        >>> db['misc-table'] = MiscTable(pd.Index([], name='idx'))
+        >>> index = pd.Index([], dtype='string', name='idx')
+        >>> db['misc-table'] = MiscTable(index)
         >>> db['misc-table']['column'] = Column(scheme_id='match')
         >>> db
         name: mydb

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -20,6 +20,7 @@ class DataType(DefineBase):
     DATE = 'date'
     INTEGER = 'int'
     FLOAT = 'float'
+    OBJECT = 'object'
     STRING = 'str'
     TIME = 'time'
 

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from audformat.core import define
+from audformat.core.common import set_index_dtype
 from audformat.core.typing import (
     Files,
     Timestamps,
@@ -169,14 +170,18 @@ def filewise_index(
 
     Example:
         >>> filewise_index(['a.wav', 'b.wav'])
-        Index(['a.wav', 'b.wav'], dtype='object', name='file')
+        Index(['a.wav', 'b.wav'], dtype='string', name='file')
 
     """
     if files is None:
         files = []
 
     files = to_array(files)
-    index = pd.Index(files, name=define.IndexField.FILE)
+    index = pd.Index(
+        files,
+        name=define.IndexField.FILE,
+        dtype='string',
+    )
     assert_index(index)
 
     return index
@@ -358,6 +363,7 @@ def segmented_index(
             define.IndexField.START,
             define.IndexField.END,
         ])
+    index = set_index_dtype(index, {define.IndexField.FILE: 'string'})
     assert_index(index)
 
     return index

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -15,7 +15,13 @@ class Scheme(common.HeaderBase):
     r"""A scheme defines valid values of an annotation.
 
     Allowed values for ``dtype`` are:
-    ``'bool'``, ``'str'``, ``'int'``, ``'float'``, ``'time'``, and ``'date'``
+    ``'bool'``,
+    ``'int'``,
+    ``'float'``,
+    ``'object'``,
+    ``'str'``,
+    ``'time'``,
+    and ``'date'``
     (see :class:`audformat.define.DataType`).
     Values can be restricted to a set of labels
     provided by a list,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -530,6 +530,20 @@ class Base(HeaderBase):
         except pickle.UnpicklingError:
             df = pd.read_pickle(path, compression='xz')
 
+        # Older versions of audformat stored columns
+        # assigned to a string scheme as 'object',
+        # so we need to convert those to 'string'
+        for column_id, column in self.columns.items():
+            if (
+                column.scheme_id is not None
+                and (
+                    self.db.schemes[column.scheme_id].dtype
+                    == define.DataType.STRING
+                )
+                and df[column_id].dtype == 'object'
+            ):
+                df[column_id] = df[column_id].astype('string', copy=False)
+
         self._df = df
 
     def _save_csv(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -624,7 +624,7 @@ class MiscTable(Base):
         ... )
         >>> table['match'] = Column()
         >>> table
-        levels: {file: str, other: str}
+        levels: {file: object, other: object}
         split_id: test
         columns:
           match: {}

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -336,6 +336,7 @@ def create_db(
     index = pd.Index(
         ['label1', 'label2', 'label3'],
         name='labels',
+        dtype='string',
     )
     db['misc'] = MiscTable(index)
     db['misc']['int'] = Column(scheme_id='int')

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -40,7 +40,7 @@ import audformat
         ),
         (
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
     ]
 )
@@ -68,6 +68,9 @@ def test_to_audformat_dtype(dtype, expected):
             audformat.define.DataType.INTEGER,
             'Int64',
         ),
+        (
+            audformat.define.DataType.OBJECT,
+            'object',
         (
             audformat.define.DataType.STRING,
             'str',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -31,7 +31,7 @@ import audformat
             audformat.define.DataType.INTEGER,
         ),
         (
-            'str',
+            'string',
             audformat.define.DataType.STRING,
         ),
         (
@@ -71,9 +71,10 @@ def test_to_audformat_dtype(dtype, expected):
         (
             audformat.define.DataType.OBJECT,
             'object',
+        ),
         (
             audformat.define.DataType.STRING,
-            'str',
+            'string',
         ),
         (
             audformat.define.DataType.TIME,

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -76,6 +76,12 @@ def test_copy(table):
         (
             [],
             str,
+            'object',
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            'string',
             'string',
             audformat.define.DataType.STRING,
         ),
@@ -177,7 +183,7 @@ def test_dtype_column(
             [],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             pd.DatetimeIndex,
@@ -219,6 +225,13 @@ def test_dtype_column(
             [],
             str,
             'object',
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            pd.Index,
+            [],
+            'string',
+            'string',
             audformat.define.DataType.STRING,
         ),
         (
@@ -275,7 +288,7 @@ def test_dtype_column(
             ['0'],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             pd.TimedeltaIndex,
@@ -284,12 +297,12 @@ def test_dtype_column(
             'timedelta64[ns]',
             audformat.define.DataType.TIME,
         ),
-        (  # list as index -> converted to str
+        (
             pd.Index,
             [[0]],
             'object',
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
     ]
 )
@@ -360,6 +373,12 @@ def test_dtype_index(
             [],
             str,
             'object',
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            'string',
+            'string',
             audformat.define.DataType.STRING,
         ),
         (
@@ -408,7 +427,7 @@ def test_dtype_index(
             ['0'],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             [0],
@@ -490,6 +509,12 @@ def test_dtype_multiindex(
             [],
             str,
             'object',
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            'string',
+            'string',
             audformat.define.DataType.STRING,
         ),
         (
@@ -538,7 +563,7 @@ def test_dtype_multiindex(
             ['0'],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             [0],

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -41,7 +41,7 @@ def test_copy(table):
             [],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             [],
@@ -76,7 +76,7 @@ def test_copy(table):
         (
             [],
             str,
-            'object',
+            'string',
             audformat.define.DataType.STRING,
         ),
         (
@@ -125,7 +125,7 @@ def test_copy(table):
             ['0'],
             None,
             'object',
-            audformat.define.DataType.STRING,
+            audformat.define.DataType.OBJECT,
         ),
         (
             [0],

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -705,7 +705,7 @@ def test_load_old_pickle(tmpdir):
     db_root = tmpdir.join('db')
     db.save(db_root, storage_format='pkl')
 
-    # Change scheme to dtype to string and store header again
+    # Change scheme dtype to string and store header again
     db.schemes['column'] = audformat.Scheme(audformat.define.DataType.STRING)
     db.save(db_root, header_only=True)
 

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -11,7 +11,7 @@ def test_scheme_assign_values():
     db = audformat.testing.create_db(minimal=True)
     speakers = ['spk1', 'spk2', 'spk3']
     ages = [33, 44, 55]
-    index = pd.Index(speakers, name='speaker')
+    index = pd.Index(speakers, name='speaker', dtype='string')
     db['misc'] = audformat.MiscTable(index)
     db['misc']['age'] = audformat.Column()
     db['misc']['age'].set(ages)
@@ -84,7 +84,8 @@ def test_scheme_contains():
 )
 def test_scheme_dtypes(dtype, values):
     db = audformat.Database('test')
-    index = pd.Index(values, name='labels')
+    pandas_dtype = audformat.core.common.to_pandas_dtype(dtype)
+    index = pd.Index(values, name='labels', dtype=pandas_dtype)
     db['misc'] = audformat.MiscTable(index)
     index = audformat.filewise_index([f'f{idx}' for idx in range(len(values))])
     db.schemes['scheme'] = audformat.Scheme(dtype=dtype, labels='misc')
@@ -113,7 +114,8 @@ def test_scheme_errors():
     # unknown type
     error_msg = (
         "Bad value 'bad', "
-        "expected one of \\['bool', 'date', 'float', 'int', 'str', 'time'\\]"
+        "expected one of "
+        "\\['bool', 'date', 'float', 'int', 'object', 'str', 'time'\\]"
     )
     with pytest.raises(ValueError, match=error_msg):
         audformat.Scheme('bad')
@@ -354,7 +356,7 @@ def test_replace_labels_misc_table():
 
     db = audformat.testing.create_db(minimal=True)
     db['misc'] = audformat.MiscTable(
-        pd.Index(['spk1', 'spk2'], name='speaker')
+        pd.Index(['spk1', 'spk2'], name='speaker', dtype='string')
     )
 
     # non-assigned scheme
@@ -379,7 +381,7 @@ def test_replace_labels_misc_table():
 
     # replace with new misc table scheme
     db['misc-new'] = audformat.MiscTable(
-        pd.Index(['spk1', 'spk2', 'spk3'], name='speaker')
+        pd.Index(['spk1', 'spk2', 'spk3'], name='speaker', dtype='string')
     )
     scheme.replace_labels('misc-new')
     assert scheme.labels == 'misc-new'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1365,10 +1365,7 @@ def test_map_language(language, expected):
 f1
 f2
 f3'''),
-        pd.Index(
-            ['f1', 'f2', 'f3'],
-            name='file',
-        ),
+        audformat.filewise_index(['f1', 'f2', 'f3']),
     ),
     (
         StringIO('''file,value
@@ -1430,13 +1427,10 @@ f2,00:00:03,2.0'''),
 f1,00:00:00,00:00:01
 f1,00:00:01,00:00:02
 f2,00:00:02,00:00:03'''),
-        pd.MultiIndex.from_arrays(
-            [
-                ['f1', 'f1', 'f2'],
-                pd.to_timedelta(['0s', '1s', '2s']),
-                pd.to_timedelta(['1s', '2s', '3s']),
-            ],
-            names=['file', 'start', 'end'],
+        audformat.segmented_index(
+            ['f1', 'f1', 'f2'],
+            ['0s', '1s', '2s'],
+            ['1s', '2s', '3s'],
         ),
     ),
     (


### PR DESCRIPTION
Closes #210
Closes #211 

This adds the audformat dtype `audformat.define.DataType.OBJECT` and switches the use-case for `audformat.define.DataType.STRING` to objects that use the `string` dtype in `pandas`.

![image](https://user-images.githubusercontent.com/173624/180196779-696b56fc-3363-4a33-99fb-0f9e9e159f27.png)

![image](https://user-images.githubusercontent.com/173624/180196878-e366175a-1f96-418a-824f-63ef1bfa8e7b.png)

---

We should maybe thinking about moving `audformat.core.common.set_index_dtype()` to the public API as there is no easy way for a user to set the dtype when creating a `MultiIndex`, at least none that I'm aware of.

This means currently we use `'object'` dtype in our example for the `MiscTable` definition:

![image](https://user-images.githubusercontent.com/173624/180197493-eea5fa8b-a807-4487-b249-a5b0eea11ff4.png)