### PR TITLE
Ensure that column ID is differnt from index level names

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -557,7 +557,7 @@ class Base(HeaderBase):
             raise ValueError(
                 f"Cannot add column with ID "
                 f"'{column_id}' "
-                f"when there is already an "
+                f"when there is an "
                 f"index level with same name. "
                 f"Level names are: "
                 f"{levels}."

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -90,6 +90,7 @@ class Base(HeaderBase):
         Raises:
             BadIdError: if a column with a ``scheme_id`` or ``rater_id`` is
                 added that does not exist
+            ValueError: if column ID is not different from level names
 
         """
         self.columns[column_id] = column
@@ -547,6 +548,21 @@ class Base(HeaderBase):
 
     def _set_column(self, column_id: str, column: Column) -> Column:
 
+        levels = (
+            self.index.names
+            if isinstance(self.index, pd.MultiIndex)
+            else [self.index.name]
+        )
+        if column_id in levels:
+            raise ValueError(
+                f"Cannot add column with ID "
+                f"'{column_id}' "
+                f"when there is already an "
+                f"index level with same name. "
+                f"Level names are: "
+                f"{levels}."
+            )
+
         if column.scheme_id is not None and \
                 column.scheme_id not in self.db.schemes:
             raise BadIdError('column', column.scheme_id, self.db.schemes)
@@ -579,6 +595,9 @@ class MiscTable(Base):
     To fill a table with labels,
     add one or more :class:`audformat.Column`
     and use :meth:`audformat.MiscTable.set` to set the values.
+    When adding a column,
+    the column ID must be different
+    from the index level names.
 
     Args:
         index: table index with non-empty and unique level names
@@ -699,6 +718,13 @@ class Table(Base):
     To fill a table with labels,
     add one or more :class:`audformat.Column`
     and use :meth:`audformat.Table.set` to set the values.
+    When adding a column,
+    the column ID must be different
+    from the index level names,
+    which are ``'file'``
+    in case of a ``filewise`` table
+    and ``'file'``, ``'start'`` and ``'end'``
+    in case of ``segmented`` table.
 
     Args:
         index: index conform to

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -631,3 +631,32 @@ def test_get_column(table, column, expected):
 )
 def test_level_names(index):
     audformat.MiscTable(index)
+
+
+@pytest.mark.parametrize(
+    'index, columns',
+    [
+        (
+            pd.Index([], name='idx'),
+            ['column'],
+        ),
+        (
+            pd.MultiIndex([[], []], [[], []], names=['idx1', 'idx2']),
+            ['column'],
+        ),
+        pytest.param(
+            pd.Index([], name='idx'),
+            ['idx'],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            pd.MultiIndex([[], []], [[], []], names=['idx1', 'idx2']),
+            ['column', 'idx2'],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_level_and_column_names(index, columns):
+    misc = audformat.MiscTable(index)
+    for column in columns:
+        misc[column] = audformat.Column()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -650,25 +650,25 @@ def test_exceptions():
 
     # level and column names must be unique
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='index level with same name'):
         db['table'] = audformat.Table(
             audformat.filewise_index(),
         )
         db['table'][audformat.define.IndexField.FILE] = audformat.Column()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='index level with same name'):
         db['table'] = audformat.Table(
             audformat.segmented_index(),
         )
         db['table'][audformat.define.IndexField.FILE] = audformat.Column()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='index level with same name'):
         db['table'] = audformat.Table(
             audformat.segmented_index(),
         )
         db['table'][audformat.define.IndexField.START] = audformat.Column()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match='index level with same name'):
         db['table'] = audformat.Table(
             audformat.segmented_index(),
         )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -648,6 +648,32 @@ def test_exceptions():
         )
         db['table']['column'] = audformat.Column(rater_id='invalid')
 
+    # level and column names must be unique
+
+    with pytest.raises(ValueError):
+        db['table'] = audformat.Table(
+            audformat.filewise_index(),
+        )
+        db['table'][audformat.define.IndexField.FILE] = audformat.Column()
+
+    with pytest.raises(ValueError):
+        db['table'] = audformat.Table(
+            audformat.segmented_index(),
+        )
+        db['table'][audformat.define.IndexField.FILE] = audformat.Column()
+
+    with pytest.raises(ValueError):
+        db['table'] = audformat.Table(
+            audformat.segmented_index(),
+        )
+        db['table'][audformat.define.IndexField.START] = audformat.Column()
+
+    with pytest.raises(ValueError):
+        db['table'] = audformat.Table(
+            audformat.segmented_index(),
+        )
+        db['table'][audformat.define.IndexField.END] = audformat.Column()
+
 
 def test_extend_index():
 


### PR DESCRIPTION
Closes #209 

![image](https://user-images.githubusercontent.com/10383417/180172148-8698520c-1bb1-4872-92a3-582e397c6b88.png)

![image](https://user-images.githubusercontent.com/10383417/180171878-04fee0f6-a1bf-4ead-8552-fc22252edab7.png)

![image](https://user-images.githubusercontent.com/10383417/180171935-dd4b282e-8b03-49c0-a58a-152a7e69a228.png)

### Example

```python
import audformat

index = pd.Index([1, 2, 3], name='name')
misc = audformat.MiscTable(index)
misc[index.name] = audformat.Column()
```
```
ValueError: Cannot add column with ID 'name' when there is already an index level with same name. Level names are: ['name'].
```
