### PR TITLE
WIP: audformat.utils.union() supports all indices

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1206,9 +1206,8 @@ def union(
 ) -> pd.Index:
     r"""Create union of index objects.
 
-    Filewise indices will be first converted to segmented indeces
-    if a segmented index is given as well.
-
+    Filewise indices will be converted to segmented indeces
+    if any segmented index is present.
     If ``objs`` is an empty list,
     an empty filewise index is returned.
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1228,16 +1228,6 @@ def union(
         ...     ]
         ... )
         Index(['f1', 'f2', 'f3', 'f4'], dtype='object', name='file')
-        >>> index3 = segmented_index(
-        ...     ['f1', 'f2', 'f3', 'f4'],
-        ...     [0, 0, 0, 0],
-        ...     [1, 1, 1, 1],
-        ... )
-        >>> index4 = segmented_index(
-        ...     ['f1', 'f2', 'f3'],
-        ...     [0, 0, 1],
-        ...     [1, 1, 2],
-        ... )
         >>> union(
         ...     [
         ...         segmented_index(['f2'], [0], [1]),

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1209,7 +1209,7 @@ def union(
     Filewise indices will be converted to segmented indeces
     if any segmented index is present.
     If ``objs`` is an empty list,
-    an empty filewise index is returned.
+    an empty :class:`pandas.Index`` object is returned.
 
     Args:
         objs: index objects
@@ -1221,9 +1221,12 @@ def union(
         ValueError: if level and dtypes of objects do not match
 
     Example:
-        >>> index1 = filewise_index(['f1', 'f2', 'f3'])
-        >>> index2 = filewise_index(['f2', 'f3', 'f4'])
-        >>> union([index1, index2])
+        >>> union(
+        ...     [
+        ...         filewise_index(['f1', 'f2', 'f3']),
+        ...         filewise_index(['f2', 'f3', 'f4']),
+        ...     ]
+        ... )
         Index(['f1', 'f2', 'f3', 'f4'], dtype='object', name='file')
         >>> index3 = segmented_index(
         ...     ['f1', 'f2', 'f3', 'f4'],
@@ -1235,24 +1238,51 @@ def union(
         ...     [0, 0, 1],
         ...     [1, 1, 2],
         ... )
-        >>> union([index3, index4])
-        MultiIndex([('f1', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f2', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f4', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:01', '0 days 00:00:02')],
-                   names=['file', 'start', 'end'])
-        >>> union([index1, index2, index3, index4])
-        MultiIndex([('f1', '0 days 00:00:00',               NaT),
-                    ('f2', '0 days 00:00:00',               NaT),
-                    ('f3', '0 days 00:00:00',               NaT),
-                    ('f4', '0 days 00:00:00',               NaT),
+        >>> union(
+        ...     [
+        ...         segmented_index(['f2'], [0], [1]),
+        ...         segmented_index(['f1', 'f2'], [0, 1], [1, 2]),
+        ...     ]
+        ... )
+        MultiIndex([('f2', '0 days 00:00:00', '0 days 00:00:01'),
                     ('f1', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f2', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f4', '0 days 00:00:00', '0 days 00:00:01'),
-                    ('f3', '0 days 00:00:01', '0 days 00:00:02')],
+                    ('f2', '0 days 00:00:01', '0 days 00:00:02')],
                    names=['file', 'start', 'end'])
+        >>> union(
+        ...     [
+        ...         filewise_index(['f1', 'f2']),
+        ...         segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+        ...     ]
+        ... )
+        MultiIndex([('f1', '0 days',               NaT),
+                    ('f2', '0 days',               NaT),
+                    ('f1', '0 days', '0 days 00:00:01'),
+                    ('f2', '0 days', '0 days 00:00:01')],
+                   names=['file', 'start', 'end'])
+        >>> union(
+        ...     [
+        ...         pd.Index([0, 1], name='idx'),
+        ...         pd.Index([1, 2], dtype='Int64', name='idx'),
+        ...     ]
+        ... )
+        Index([0, 1, 2], dtype='Int64', name='idx')
+        >>> union(
+        ...     [
+        ...         pd.MultiIndex.from_arrays(
+        ...             [['a', 'b', 'c'], [0, 1, 2]],
+        ...             names=['idx1', 'idx2'],
+        ...         ),
+        ...         pd.MultiIndex.from_arrays(
+        ...             [['b', 'c'], [1, 3]],
+        ...             names=['idx1', 'idx2'],
+        ...         ),
+        ...    ]
+        ... )
+        MultiIndex([('a', 0),
+                    ('b', 1),
+                    ('c', 2),
+                    ('c', 3)],
+                   names=['idx1', 'idx2'])
         >>> union(
         ...     [
         ...         pd.Index(['spk1'], name='speaker'),
@@ -1263,7 +1293,7 @@ def union(
 
     """
     if not objs:
-        return filewise_index()
+        return pd.Index([])
 
     objs = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1213,15 +1213,10 @@ def union(
     an empty filewise index is returned.
 
     Args:
-        objs: index objects conform to
-            :ref:`table specifications <data-tables:Tables>`
+        objs: index objects
 
     Returns:
         union of index objects
-
-    Raises:
-        ValueError: if one or more objects are not conform to
-            :ref:`table specifications <data-tables:Tables>`
 
     Example:
         >>> index1 = filewise_index(['f1', 'f2', 'f3'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1981,6 +1981,59 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 [pd.NaT, pd.NaT, 1, 1, pd.NaT],
             ),
         ),
+        # Non audformat conform indices
+        (
+            [
+                pd.Index([]),
+            ],
+            pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([]),
+                pd.Index([]),
+            ],
+            pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+                pd.Index([1, 2], name='idx'),
+            ],
+            pd.Index([0, 1, 2], name='idx'),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+                pd.Index([1, 2], dtype='Int64', name='idx'),
+            ],
+            pd.Index([0, 1, 2], dtype='Int64', name='idx'),
+        ),
+        (
+            [
+                pd.MultiIndex.from_arrays(
+                    [['a', 'b', 'c'], [0, 1, 2]],
+                    names=['idx1', 'idx2'],
+                ),
+                pd.MultiIndex.from_arrays(
+                    [['b', 'c'], [1, 3]],
+                    names=['idx1', 'idx2'],
+                ),
+            ],
+            pd.MultiIndex.from_arrays(
+                [['a', 'b', 'c', 'c'], [0, 1, 2, 3]],
+                names=['idx1', 'idx2'],
+            ),
+        ),
+        pytest.param(
+            [
+                pd.Index([], name='idx1'),
+                pd.Index([], name='idx2'),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        )
+
     ]
 )
 def test_union(objs, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1823,7 +1823,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
     [
         (
             [],
-            audformat.filewise_index(),
+            pd.Index([]),
         ),
         (
             [


### PR DESCRIPTION
Expands `audformat.utils.union()` to handle not only filewise or segmented indices, but all others as well.
This will be helpful to concat two misc tables.

This means `audformat.utils.union()` no longer raises a `ValueError` if an index is provided that is not conform to `audformat`.
If any segmented index is present, all filewise indices are still converted to segmented indices before combining them with all other indices.

![image](https://user-images.githubusercontent.com/173624/180399357-ee155050-976a-44c2-bfbe-16078fba3508.png)
