### PR TITLE
DOC: correct dtype handling in Table/Column.set()

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -270,7 +270,8 @@ class Column(HeaderBase):
         By default, all labels of the column are replaced,
         use ``index`` to set a subset.
         If columns is assigned to a :class:`Scheme`
-        values have to match its ``dtype``.
+        values will be automatically converted
+        to match its dtype.
 
         Examples are provided with the
         :ref:`table specifications <data-tables:Tables>`.
@@ -284,7 +285,8 @@ class Column(HeaderBase):
             RuntimeError: if column is not assign to a table
             ValueError: if trying to set values of a filewise column
                 using a segmented index
-            ValueError: if values do not match scheme
+            ValueError: if values cannot be converted
+                to match the schemes dtype
 
         """
         if self._table is None:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -423,10 +423,11 @@ class Base(HeaderBase):
     ):
         r"""Set labels.
 
-        By default, all labels of the table are replaced,
+        By default all labels of the table are replaced,
         use ``index`` to select a subset.
         If a column is assigned to a :class:`Scheme`
-        values have to match its ``dtype``.
+        values will be automatically converted
+        to match its dtype.
 
         Examples are provided with the
         :ref:`table specifications <data-tables:Tables>`.
@@ -436,7 +437,8 @@ class Base(HeaderBase):
             index: index
 
         Raises:
-            ValueError: if values do not match scheme
+            ValueError: if values cannot be converted
+                to match the schemes dtype
 
         """
         for idx, data in values.items():


### PR DESCRIPTION
Closes #138 

This updates the docstrings of `audformat.Table.set()` and `audformat.Column.set()` to mention that values, that do not match the schemes dtype are first tried to convert to the dtype and only raise an error if this is not possible.


**Table**

![image](https://user-images.githubusercontent.com/173624/180382227-8fc1530b-ec45-43ba-9212-984fa76c9dcb.png)

**Column**

![image](https://user-images.githubusercontent.com/173624/180382273-3cc0a02c-2303-4ff9-a048-f4c03963828e.png)
