### PR TITLE
Add utils.set_index_dtypes()

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -267,43 +267,6 @@ def series_to_html(self):  # pragma: no cover
     return df.to_html()
 
 
-def set_index_dtype(
-        index: pd.Index,
-        dtypes: typing.Dict[str, str],
-) -> pd.Index:
-    r"""Set the dtypes of an index for the given levels."""
-    if len(dtypes) == 0:
-        return index
-
-    if isinstance(index, pd.MultiIndex):
-        # MultiIndex
-        if all([len(level) == 0 for level in index.levels]):
-            # set_levels() does not work
-            # in the case the levels are something like `[[], []]`,
-            # so we convert to a dataframe instead
-            df = index.to_frame()
-            for level, dtype in dtypes.items():
-                df[level] = df[level].astype(dtype)
-            index = pd.MultiIndex.from_frame(df)
-        else:
-            for level, dtype in dtypes.items():
-                # get_level_values() does not work
-                # for levels containing non-unique entries,
-                # hence we acces the data directly with
-                # index.levels[idx]
-                idx = index.names.index(level)
-                index = index.set_levels(
-                    index.levels[idx].astype(dtype),
-                    level=level,
-                )
-    else:
-        # Index
-        dtype = next(iter(dtypes.values()))
-        index = index.astype(dtype)
-
-    return index
-
-
 def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
     r"""Convert pandas to audformat dtype."""
     if pd.api.types.is_bool_dtype(dtype):

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -363,7 +363,7 @@ def segmented_index(
             define.IndexField.START,
             define.IndexField.END,
         ])
-    index = utils.set_index_dtype(index, {define.IndexField.FILE: 'string'})
+    index = utils.set_index_dtypes(index, {define.IndexField.FILE: 'string'})
     assert_index(index)
 
     return index

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from audformat.core import define
-from audformat.core.common import set_index_dtype
+from audformat.core import utils
 from audformat.core.typing import (
     Files,
     Timestamps,
@@ -363,7 +363,7 @@ def segmented_index(
             define.IndexField.START,
             define.IndexField.END,
         ])
-    index = set_index_dtype(index, {define.IndexField.FILE: 'string'})
+    index = utils.set_index_dtype(index, {define.IndexField.FILE: 'string'})
     assert_index(index)
 
     return index

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -478,7 +478,7 @@ class Base(HeaderBase):
             if column.scheme_id is not None:
                 dtypes[column_id] = schemes[column.scheme_id].to_pandas_dtype()
             else:
-                dtypes[column_id] = 'str'
+                dtypes[column_id] = object
 
         # replace dtype with converter for dates or timestamps
         dtypes_wo_converters = {}
@@ -509,7 +509,7 @@ class Base(HeaderBase):
                 level: dtype for level, dtype in dtypes.items()
                 if level in converters
             }
-            df.index = utils.set_index_dtype(df.index, converter_dtypes)
+            df.index = utils.set_index_dtypes(df.index, converter_dtypes)
             # fix columns
             for column_id in columns:
                 if column_id in converters:
@@ -689,7 +689,7 @@ class MiscTable(Base):
                 level: 'Int64' for level, dtype in zip(levels, dtypes)
                 if pd.api.types.is_integer_dtype(dtype)
             }
-            index = utils.set_index_dtype(index, int_dtypes)
+            index = utils.set_index_dtypes(index, int_dtypes)
 
             if not all(levels) or len(levels) > len(set(levels)):
                 raise ValueError(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -13,7 +13,6 @@ from audformat.core.column import Column
 from audformat.core.common import (
     HeaderBase,
     HeaderDict,
-    set_index_dtype,
     to_audformat_dtype,
     to_pandas_dtype,
 )
@@ -510,7 +509,7 @@ class Base(HeaderBase):
                 level: dtype for level, dtype in dtypes.items()
                 if level in converters
             }
-            df.index = set_index_dtype(df.index, converter_dtypes)
+            df.index = utils.set_index_dtype(df.index, converter_dtypes)
             # fix columns
             for column_id in columns:
                 if column_id in converters:
@@ -690,7 +689,7 @@ class MiscTable(Base):
                 level: 'Int64' for level, dtype in zip(levels, dtypes)
                 if pd.api.types.is_integer_dtype(dtype)
             }
-            index = set_index_dtype(index, int_dtypes)
+            index = utils.set_index_dtype(index, int_dtypes)
 
             if not all(levels) or len(levels) > len(set(levels)):
                 raise ValueError(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -478,7 +478,7 @@ class Base(HeaderBase):
             if column.scheme_id is not None:
                 dtypes[column_id] = schemes[column.scheme_id].to_pandas_dtype()
             else:
-                dtypes[column_id] = object
+                dtypes[column_id] = 'object'
 
         # replace dtype with converter for dates or timestamps
         dtypes_wo_converters = {}

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -507,7 +507,7 @@ class Base(HeaderBase):
             # fix index
             converter_dtypes = {
                 level: dtype for level, dtype in dtypes.items()
-                if level in converters
+                if level in converters and level in levels
             }
             df.index = utils.set_index_dtypes(df.index, converter_dtypes)
             # fix columns

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -631,13 +631,14 @@ class MiscTable(Base):
         ...   ],
         ...   names=['file', 'other'],
         ... )
+        >>> index = utils.set_index_dtypes(index, 'string')
         >>> table = MiscTable(
         ...     index,
         ...     split_id=define.SplitType.TEST,
         ... )
         >>> table['match'] = Column()
         >>> table
-        levels: {file: object, other: object}
+        levels: {file: str, other: str}
         split_id: test
         columns:
           match: {}

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -999,7 +999,7 @@ def set_index_dtypes(
             typing.Dict[str, str],
         ],
 ) -> pd.Index:
-    r"""Set the dtypes of an index for the given levels.
+    r"""Set the dtypes of an index for the given level names.
 
     Args:
         index: index object

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1015,27 +1015,27 @@ def set_index_dtypes(
         index with new dtypes
 
     Examples:
-        >>> idx1 = pd.Index(['a', 'b'])
-        >>> idx1
+        >>> index1 = pd.Index(['a', 'b'])
+        >>> index1
         Index(['a', 'b'], dtype='object')
-        >>> idx2 = set_index_dtypes(idx1, 'string')
-        >>> idx2
+        >>> index2 = set_index_dtypes(index1, 'string')
+        >>> index2
         Index(['a', 'b'], dtype='string')
-        >>> idx3 = pd.MultiIndex.from_arrays(
+        >>> index3 = pd.MultiIndex.from_arrays(
         ...     [['a', 'b'], [1, 2]],
         ...     names=['level1', 'level2'],
         ... )
-        >>> idx3.dtypes
+        >>> index3.dtypes
         level1    object
         level2     int64
         dtype: object
-        >>> idx4 = set_index_dtypes(idx3, {'level2': 'float'})
-        >>> idx4.dtypes
+        >>> index4 = set_index_dtypes(index3, {'level2': 'float'})
+        >>> index4.dtypes
         level1    object
         level2   float64
         dtype: object
-        >>> idx5 = set_index_dtypes(idx3, 'string')
-        >>> idx5.dtypes
+        >>> index5 = set_index_dtypes(index3, 'string')
+        >>> index5.dtypes
         level1    string
         level2    string
         dtype: object

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1007,6 +1007,9 @@ def set_index_dtypes(
             If a single dtype is given,
             it will be applied to all levels
 
+    Raises:
+        ValueError: if level names are not unique
+
     Returns:
         index with new dtypes
 
@@ -1039,8 +1042,25 @@ def set_index_dtypes(
     """
     levels = index.names if isinstance(index, pd.MultiIndex) else [index.name]
 
+    if len(set(levels)) != len(levels):
+        raise ValueError(
+            f'Got index with levels '
+            f'{levels}, '
+            f'but names must be unique.'
+        )
+
     if not isinstance(dtypes, dict):
         dtypes = {level: dtypes for level in levels}
+
+    for name in dtypes:
+        if name not in levels:
+            raise ValueError(
+                f"A level with name "
+                f"'{name}' "
+                f"does not exist. "
+                f"Must be on one of "
+                f"{levels}."
+            )
 
     if len(dtypes) == 0:
         return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1009,6 +1009,7 @@ def set_index_dtypes(
 
     Raises:
         ValueError: if level names are not unique
+        ValueError: if level does not exist
 
     Returns:
         index with new dtypes

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1059,7 +1059,7 @@ def set_index_dtypes(
                 f"A level with name "
                 f"'{name}' "
                 f"does not exist. "
-                f"Must be on one of "
+                f"Level names are: "
                 f"{levels}."
             )
 

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -14,6 +14,7 @@ from audformat.core.utils import (
     map_language,
     read_csv,
     replace_file_extension,
+    set_index_dtype,
     to_filewise_index,
     to_segmented_index,
     union,

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -14,7 +14,7 @@ from audformat.core.utils import (
     map_language,
     read_csv,
     replace_file_extension,
-    set_index_dtype,
+    set_index_dtypes,
     to_filewise_index,
     to_segmented_index,
     union,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -79,6 +79,11 @@ replace_file_extension
 
 .. autofunction:: replace_file_extension
 
+set_index_dtypes
+----------------
+
+.. autofunction:: set_index_dtypes
+
 to_filewise_index
 -----------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1659,6 +1659,12 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
+        pytest.param(
+            pd.Index([0], name='idx'),
+            {'bad': 'string'},
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_set_index_dtypes(index, dtypes, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1549,6 +1549,124 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
 
 
 @pytest.mark.parametrize(
+    'index, dtypes, expected',
+    [
+        (
+            pd.Index([]),
+            'string',
+            pd.Index([], dtype='string'),
+        ),
+        (
+            pd.Index([]),
+            {},
+            pd.Index([]),
+        ),
+        (
+            pd.Index(['a', 'b']),
+            'string',
+            pd.Index(['a', 'b'], dtype='string'),
+        ),
+        (
+            pd.Index(['a', 'b'], dtype='string'),
+            'string',
+            pd.Index(['a', 'b'], dtype='string'),
+        ),
+        (
+            pd.Index(['a', 'b'], name='idx'),
+            {'idx': 'string'},
+            pd.Index(['a', 'b'], name='idx', dtype='string'),
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [2, 3],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+            'str',
+            pd.MultiIndex.from_arrays(
+                [
+                    ['0', '1'],
+                    ['2', '3'],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [2, 3],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+            {
+                'idx2': 'str',
+                'idx1': 'str',
+            },
+            pd.MultiIndex.from_arrays(
+                [
+                    ['0', '1'],
+                    ['2', '3'],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [2, 3],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+            {
+                'idx2': 'str',
+            },
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    ['2', '3'],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+        ),
+        pytest.param(
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [2, 3],
+                ],
+                names=['idx', 'idx'],
+            ),
+            'str',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [2, 3],
+                ],
+                names=['idx1', 'idx2'],
+            ),
+            {
+                'idx1': 'string',
+                'bad': 'string',
+            },
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_set_index_dtypes(index, dtypes, expected):
+    index = audformat.utils.set_index_dtypes(index, dtypes)
+    pd.testing.assert_index_equal(index, expected)
+
+
+@pytest.mark.parametrize(
     'obj, allow_nat, files_duration, root, expected',
     [
         # empty


### PR DESCRIPTION
Closes #217 

Moves `common.set_index_type()` to `utils.set_index_types()` and makes it part of public API. Adds option to specify single `dtype` and raises an error if level names are not unique or level name does not exist.

![image](https://user-images.githubusercontent.com/10383417/180429806-15d6dded-fe5c-4692-9396-53ae9d51201c.png)

Uses function in docstring example of `MiscTable`:

![image](https://user-images.githubusercontent.com/10383417/180418133-f0989e9f-4439-4e27-952d-dd09eb045f68.png)
