### PR TITLE
Scheme.__contains__: convert to float for max-min-checking

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -453,6 +453,7 @@ class Scheme(common.HeaderBase):
                 labels = self._labels_to_dict()
                 return item in labels
             if self.is_numeric:
+                item = float(item)
                 if self.minimum and not item >= self.minimum:
                     return False
                 if self.maximum and not item <= self.maximum:

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import numpy as np
 import pandas as pd
@@ -320,6 +322,19 @@ def test_set_invalid_values():
 
     db = pytest.DB
     num = len(db['files'])
+
+    # Values that do match scheme are converted if possible
+    table = db['files'].copy()  # use copy as we change values here
+    # string -> float
+    table['float'].set(['-1.0'] * num)
+    error_msg = re.escape("could not convert string to float: 'a'")
+    with pytest.raises(ValueError, match=error_msg):
+        table['float'].set('a')
+    # float -> string
+    table['string'].set(1.0)
+    error_msg = re.escape('Some value(s) do not match scheme')
+    with pytest.raises(ValueError, match=error_msg):
+        db['files']['label'].set(1.0)
 
     with pytest.raises(ValueError):
         db['files']['float'].set(-2.0)


### PR DESCRIPTION
In `audformat.Column/Table.set()` we state that we raise an `ValueError` if the data values cannot be converted to the dtype of the scheme. This was not correct if the scheme uses a min, max range and a string was provided that could be converted to float/int.

In that case it was raising a `IndexError` instead of doing the conversion first before checking min, max range.

I fixed it here, by ensuring that we convert always to float before doing the min, max check.