### PR TITLE
Add audformat.utils.intersect_misc()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -586,7 +586,6 @@ def intersect_misc(
     # index.intersection() does not preserve string dtype
     # for MultiIndex
     if isinstance(index, pd.MultiIndex):
-        obj = objs[0]
         dtypes = {
             name: dtype for name, dtype in zip(objs[0].names, objs[0].dtypes)
             if dtype == 'string'

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -428,26 +428,29 @@ def intersect(
             :ref:`table specifications <data-tables:Tables>`
 
     Example:
-        >>> index1 = filewise_index(['f1', 'f2', 'f3'])
-        >>> index2 = filewise_index(['f2', 'f3', 'f4'])
-        >>> intersect([index1, index2])
+        >>> intersect(
+        ...     [
+        ...         filewise_index(['f1', 'f2', 'f3']),
+        ...         filewise_index(['f2', 'f3', 'f4']),
+        ...     ]
+        ... )
         Index(['f2', 'f3'], dtype='string', name='file')
-        >>> index3 = segmented_index(
-        ...     ['f1', 'f2', 'f3', 'f4'],
-        ...     [0, 0, 0, 0],
-        ...     [1, 1, 1, 1],
+        >>> intersect(
+        ...     [
+        ...         segmented_index(['f1'], [0], [1]),
+        ...         segmented_index(['f1', 'f2'], [0, 1], [1, 2]),
+        ...     ]
         ... )
-        >>> index4 = segmented_index(
-        ...     ['f1', 'f2', 'f3'],
-        ...     [0, 0, 1],
-        ...     [1, 1, 2],
+        MultiIndex([('f1', '0 days', '0 days 00:00:01')],
+                   names=['file', 'start', 'end'])
+        >>> intersect(
+        ...     [
+        ...         filewise_index(['f1', 'f2']),
+        ...         segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
+        ...     ]
         ... )
-        >>> intersect([index3, index4])
         MultiIndex([('f1', '0 days', '0 days 00:00:01'),
                     ('f2', '0 days', '0 days 00:00:01')],
-                   names=['file', 'start', 'end'])
-        >>> intersect([index1, index2, index3, index4])
-        MultiIndex([('f2', '0 days', '0 days 00:00:01')],
                    names=['file', 'start', 'end'])
 
     """

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -413,6 +413,8 @@ def intersect(
 
     Index objects must be conform to
     :ref:`table specifications <data-tables:Tables>`.
+    Otherwise use
+    :func:`audformat.utils.intersect_misc`.
 
     If at least one object is segmented, the output is a segmented index.
 
@@ -497,21 +499,28 @@ def intersect_misc(
 ) -> pd.Index:
     r"""Intersect index objects.
 
-    Index objects must be conform to
+    Requires that levels and dtypes
+    of all objects match,
+    see :func:`audformat.utils.is_index_alike`.
+    Unlike :func:`audformat.utils.intersect`
+    index objects must not be conform to
     :ref:`table specifications <data-tables:Tables>`.
 
-    If at least one object is segmented, the output is a segmented index.
+    When intersecting
+    :class:`pd.Index`
+    objects with single-level
+    :class:`pd.MultiIndex`
+    objects the results will be a
+    :class:`pd.MultiIndex`.
 
     Args:
-        objs: index objects conform to
-            :ref:`table specifications <data-tables:Tables>`
+        objs: index objects
 
     Returns:
         intersection of index objects
 
     Raises:
-        ValueError: if one or more objects are not conform to
-            :ref:`table specifications <data-tables:Tables>`
+        ValueError: if level and dtypes of objects do not match
 
     Example:
         >>> intersect_misc(

--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -5,6 +5,7 @@ from audformat.core.utils import (
     hash,
     index_has_overlap,
     intersect,
+    intersect_misc,
     is_index_alike,
     iter_by_file,
     join_labels,

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -34,6 +34,11 @@ intersect
 
 .. autofunction:: intersect
 
+intersect_misc
+--------------
+
+.. autofunction:: intersect_misc
+
 is_index_alike
 --------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -893,6 +893,87 @@ def test_intersect(objs, expected):
     'objs, expected',
     [
         (
+            [],
+            pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([]),
+            ],
+            pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([]),
+                pd.Index([]),
+            ],
+            pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+                pd.Index([1, 2], name='idx'),
+            ],
+            pd.Index([1], name='idx'),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+                pd.Index([1, 2], dtype='Int64', name='idx'),
+            ],
+            pd.Index([1], dtype='Int64', name='idx'),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+                pd.MultiIndex.from_arrays([[1, 2]], names=['idx']),
+            ],
+            pd.MultiIndex.from_arrays([[1]], names=['idx']),
+        ),
+        (
+            [
+                pd.MultiIndex.from_arrays([[0, 1]], names=['idx']),
+                pd.MultiIndex.from_arrays([[1, 2]], names=['idx']),
+            ],
+            pd.MultiIndex.from_arrays([[1]], names=['idx']),
+        ),
+        (
+            [
+                pd.MultiIndex.from_arrays(
+                    [['a', 'b', 'c'], [0, 1, 2]],
+                    names=['idx1', 'idx2'],
+                ),
+                pd.MultiIndex.from_arrays(
+                    [['b', 'c'], [1, 3]],
+                    names=['idx1', 'idx2'],
+                ),
+            ],
+            pd.MultiIndex.from_arrays(
+                [['b'], [1]],
+                names=['idx1', 'idx2'],
+            ),
+        ),
+        pytest.param(
+            [
+                pd.Index([], name='idx1'),
+                pd.Index([], name='idx2'),
+            ],
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        )
+    ]
+)
+def test_intersect_misc(objs, expected):
+    pd.testing.assert_index_equal(
+        audformat.utils.intersect_misc(objs),
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    'objs, expected',
+    [
+        (
             [
                 pd.Index([]),
             ],


### PR DESCRIPTION
This adds `audformat.utils.intersect_misc()` to calculate the intersection between indices that are alike.

![image](https://user-images.githubusercontent.com/173624/180458237-c48e40bb-9179-4e5c-b693-0a3ea8ca3857.png)

![image](https://user-images.githubusercontent.com/173624/180457422-3e9b3ff1-2ab5-46ec-985e-8f4c50c21632.png)

I also updated the examples of `audformat.utils.intersect()` in the same fashion as we did for `audformat.utils.union()`:

![image](https://user-images.githubusercontent.com/173624/180457577-9613ce40-299a-4771-a4a0-c84f33e9c9e1.png)
