### PR TITLE
Combine union() and union_misc() to single function

### DIFF
--- a/audformat/utils/__init__.py
+++ b/audformat/utils/__init__.py
@@ -18,5 +18,4 @@ from audformat.core.utils import (
     to_filewise_index,
     to_segmented_index,
     union,
-    union_misc,
 )

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -98,8 +98,3 @@ union
 -----
 
 .. autofunction:: union
-
-union_misc
-----------
-
-.. autofunction:: union_misc

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1939,10 +1939,12 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
 @pytest.mark.parametrize(
     'objs, expected',
     [
+        # empty
         (
             [],
-            audformat.filewise_index(),
+            pd.Index([]),
         ),
+        # conform to audformat
         (
             [
                 audformat.filewise_index(),
@@ -2099,22 +2101,7 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 [pd.NaT, pd.NaT, 1, 1, pd.NaT],
             ),
         ),
-    ]
-)
-def test_union(objs, expected):
-    pd.testing.assert_index_equal(
-        audformat.utils.union(objs),
-        expected,
-    )
-
-
-@pytest.mark.parametrize(
-    'objs, expected',
-    [
-        (
-            [],
-            pd.Index([]),
-        ),
+        # other
         (
             [
                 pd.Index([]),
@@ -2179,11 +2166,11 @@ def test_union(objs, expected):
             ],
             None,
             marks=pytest.mark.xfail(raises=ValueError),
-        )
+        ),
     ]
 )
-def test_union_misc(objs, expected):
+def test_union(objs, expected):
     pd.testing.assert_index_equal(
-        audformat.utils.union_misc(objs),
+        audformat.utils.union(objs),
         expected,
     )


### PR DESCRIPTION
Applies #221 to implement a single `union()` function.

![image](https://user-images.githubusercontent.com/10383417/180724224-3971e59b-8984-4dc5-9174-5edb191a5fbc.png)

![image](https://user-images.githubusercontent.com/10383417/180724266-32a4b155-6094-41eb-b107-bebb57eb4bca.png)
