### PR TITLE
Extend audformat.utils.concat() to support misc objects

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -76,6 +76,14 @@ def concat(
         dtype: Int64
         >>> concat(
         ...     [
+        ...         pd.Series([0], index=pd.Index([0]), name='col1'),
+        ...         pd.Series([1], index=pd.Index([0]), name='col2'),
+        ...     ]
+        ... )
+           col1  col2
+        0     0     1
+        >>> concat(
+        ...     [
         ...         pd.Series(
         ...             [0., 1.],
         ...             index=pd.Index(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -41,7 +41,7 @@ def concat(
     of all objects match,
     see :func:`audformat.utils.is_index_alike`.
 
-    The new object contains index and columns of both objects.
+    The new object contains index and columns of all objects.
     Missing values will be set to ``NaN``.
 
     Columns with the same identifier are combined to a single column.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,12 @@ from audformat import define
         (
             [],
             False,
-            pd.Series([], audformat.filewise_index(), dtype='object'),
+            pd.Series([], pd.Index([]), dtype='object'),
+        ),
+        (
+            [pd.Series([], pd.Index([]), dtype='object')],
+            False,
+            pd.Series([], pd.Index([]), dtype='object')
         ),
         (
             [pd.Series([], audformat.filewise_index(), dtype='object')],
@@ -48,11 +53,11 @@ from audformat import define
         ),
         (
             [
-                pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
-                pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
+                pd.Series([1., 2.], pd.Index(['f1', 'f2'])),
+                pd.Series([1., 2.], pd.Index(['f1', 'f2'])),
             ],
             False,
-            pd.Series([1., 2.], audformat.filewise_index(['f1', 'f2'])),
+            pd.Series([1., 2.], pd.Index(['f1', 'f2'])),
         ),
         (
             [
@@ -77,6 +82,34 @@ from audformat import define
             ],
             False,
             pd.Series([1., 2.], audformat.segmented_index(['f1', 'f2'])),
+        ),
+        (
+            [
+                pd.Series([1.], pd.Index(['f1'])),
+                pd.Series(
+                    [2.],
+                    pd.MultiIndex.from_arrays([['f2']]),
+                ),
+            ],
+            False,
+            pd.Series(
+                [1., 2.],
+                pd.MultiIndex.from_arrays([['f1', 'f2']]),
+            ),
+        ),
+        (
+            [
+                pd.Series([1.], pd.Index(['f1'], name='idx')),
+                pd.Series(
+                    [2.],
+                    pd.MultiIndex.from_arrays([['f2']], names=['idx']),
+                ),
+            ],
+            False,
+            pd.Series(
+                [1., 2.],
+                pd.MultiIndex.from_arrays([['f1', 'f2']], names=['idx']),
+            ),
         ),
         # combine values in same location
         (
@@ -458,11 +491,60 @@ from audformat import define
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
+        pytest.param(
+            [
+                pd.Series(
+                    [1.],
+                    pd.Index(['f1'], name='idx', dtype='string'),
+                ),
+                pd.Series(  # default dtype is object
+                    [2.],
+                    pd.MultiIndex.from_arrays([['f1']], names=['idx']),
+                ),
+            ],
+            False,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
         # error: values do not match
         pytest.param(
             [
                 pd.Series([1.], audformat.filewise_index('f1')),
                 pd.Series([2.], audformat.filewise_index('f1')),
+            ],
+            False,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [
+                pd.Series([1.], pd.Index(['f1'], name='idx')),
+                pd.Series(
+                    [2.],
+                    pd.MultiIndex.from_arrays([['f1']], names=['idx']),
+                ),
+            ],
+            False,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        # error: index names do not match
+        pytest.param(
+            [
+                pd.Series([], index=pd.Index([], name='idx1')),
+                pd.Series([], index=pd.Index([], name='idx2')),
+            ],
+            False,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            [
+                pd.Series([1.], pd.Index(['f1'], name='idx1')),
+                pd.Series(
+                    [2.],
+                    pd.MultiIndex.from_arrays([['f2']], names=['idx2']),
+                ),
             ],
             False,
             None,


### PR DESCRIPTION
Closes #221 

This extends `audformat.utils.concat()` to support objects with an arbitrary index.

![image](https://user-images.githubusercontent.com/173624/180795142-7c45dc02-ddc1-490a-a46b-c39a01fca3d1.png)

![image](https://user-images.githubusercontent.com/173624/180759163-2aebb5a5-a4a1-4d98-a632-7a6bd1c6fea4.png)

![image](https://user-images.githubusercontent.com/173624/180756160-3bf6d9a5-ba65-44c7-966c-65b8a1918669.png)

---

Requires #223 to be merged first.