### PR TITLE
Implement [drop,extend,pick]_index for MiscTable

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -313,15 +313,24 @@ class Base(HeaderBase):
                 index, fill_values=fill_values, inplace=True,
             )
 
-        input_type = index_type(index)
-        if self.type != input_type:
-            raise ValueError(
-                f'Cannot extend a '
-                f'{self.type} '
-                f'table with a '
-                f'{input_type} '
-                f'index.'
-            )
+        if hasattr(self, 'type'):
+            input_type = index_type(index)
+            if self.type != input_type:
+                raise ValueError(
+                    f'Cannot extend a '
+                    f'{self.type} '
+                    f'table with a '
+                    f'{input_type} '
+                    f'index.'
+                )
+        else:
+            if not utils.is_index_alike([self.index, index]):
+                # TODO: add utils.assert_index_alike()
+                raise ValueError(
+                    'Levels and dtypes of all objects must match, '
+                    'see audformat.utils.is_index_alike().'
+                )
+
         new_index = self.df.index.union(index)
         self._df = self.df.reindex(new_index)
         if fill_values is not None:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -269,7 +269,7 @@ class Base(HeaderBase):
 
         _assert_table_index(self, index, 'extend')
 
-        new_index = self.df.index.union(index)
+        new_index = utils.union([self.df.index, index])
         self._df = self.df.reindex(new_index)
         if fill_values is not None:
             if isinstance(fill_values, dict):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # allow typing without string
+
 import copy
 import os
 import pickle
@@ -70,7 +72,7 @@ class Base(HeaderBase):
 
     def __eq__(
             self,
-            other: 'Base',
+            other: Base,
     ) -> bool:
         if self.dump() != other.dump():
             return False
@@ -152,7 +154,7 @@ class Base(HeaderBase):
         if self.split_id is not None and self.db is not None:
             return self.db.splits[self.split_id]
 
-    def copy(self) -> 'Base':
+    def copy(self) -> typing.Self:
         r"""Copy table.
 
         Return:
@@ -180,7 +182,7 @@ class Base(HeaderBase):
             column_ids: typing.Union[str, typing.Sequence[str]],
             *,
             inplace: bool = False,
-    ) -> 'Table':
+    ) -> typing.Self:
         r"""Drop columns by ID.
 
         Args:
@@ -210,7 +212,7 @@ class Base(HeaderBase):
             index: pd.Index,
             *,
             inplace: bool = False,
-    ) -> 'Base':
+    ) -> typing.Self:
         r"""Drop rows from index.
 
         Args:
@@ -243,8 +245,8 @@ class Base(HeaderBase):
                 typing.Dict[str, typing.Any]
             ] = None,
             inplace: bool = False,
-    ) -> 'Base':
-        r"""Extend table by new rows.
+    ) -> typing.Self:
+        r"""Extend table with new rows.
 
         Args:
             index: index object
@@ -424,7 +426,7 @@ class Base(HeaderBase):
             column_ids: typing.Union[str, typing.Sequence[str]],
             *,
             inplace: bool = False,
-    ) -> 'Base':
+    ) -> typing.Self:
         r"""Pick columns by ID.
 
         All other columns will be dropped.
@@ -450,7 +452,7 @@ class Base(HeaderBase):
             index: pd.Index,
             *,
             inplace: bool = False,
-    ) -> 'Base':
+    ) -> typing.Self:
         r"""Pick rows from index.
 
         Args:
@@ -824,15 +826,6 @@ class MiscTable(Base):
             meta=meta,
         )
 
-    def copy(self) -> 'MiscTable':
-        r"""Copy table.
-
-        Return:
-            new table object
-
-        """
-        return super().copy()
-
     def _get_by_index(self, index: pd.Index) -> (pd.DataFrame, bool):
         return self.df.loc[index], False
 
@@ -1073,15 +1066,6 @@ class Table(Base):
                 define.IndexField.START
             )
 
-    def copy(self) -> 'Table':
-        r"""Copy table.
-
-        Return:
-            new table object
-
-        """
-        return super().copy()
-
     def drop_files(
             self,
             files: typing.Union[
@@ -1091,7 +1075,7 @@ class Table(Base):
             ],
             *,
             inplace: bool = False,
-    ) -> 'Table':
+    ) -> Table:
         r"""Drop files.
 
         Remove rows with a reference to listed or matching files.
@@ -1221,7 +1205,7 @@ class Table(Base):
             ],
             *,
             inplace: bool = False,
-    ) -> 'Table':
+    ) -> Table:
         r"""Pick files.
 
         Keep only rows with a reference to listed files or matching files.
@@ -1254,7 +1238,7 @@ class Table(Base):
             others: typing.Union['Table', typing.Sequence['Table']],
             *,
             overwrite: bool = False,
-    ) -> 'Table':
+    ) -> Table:
         r"""Update table with other table(s).
 
         Table which calls ``update()`` must be assigned to a database.

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -959,7 +959,7 @@ class Table(Base):
             meta=meta,
         )
 
-    def __add__(self, other: 'Table') -> 'Table':
+    def __add__(self, other: Table) -> Table:
         r"""Create new table by combining two tables.
 
         The new table contains index and columns of both tables.
@@ -1235,7 +1235,7 @@ class Table(Base):
 
     def update(
             self,
-            others: typing.Union['Table', typing.Sequence['Table']],
+            others: typing.Union[Table, typing.Sequence[Table]],
             *,
             overwrite: bool = False,
     ) -> Table:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -471,7 +471,7 @@ class Base(HeaderBase):
 
         _assert_table_index(self, index, 'pick rows from')
 
-        new_index = self.df.index.intersection(index)
+        new_index = utils.intersect([self.df.index, index])
         self._df = self.df.reindex(new_index)
 
         return self

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -227,7 +227,7 @@ class Base(HeaderBase):
         if not inplace:
             return self.copy().drop_index(index, inplace=True)
 
-        _assert_table_index(self, index, 'drop from')
+        _assert_table_index(self, index, 'drop rows from')
 
         new_index = self.df.index.difference(index)
         self._df = self.df.reindex(new_index)
@@ -467,7 +467,7 @@ class Base(HeaderBase):
         if not inplace:
             return self.copy().pick_index(index, inplace=True)
 
-        _assert_table_index(self, index, 'pick from')
+        _assert_table_index(self, index, 'pick rows from')
 
         new_index = self.df.index.intersection(index)
         self._df = self.df.reindex(new_index)

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1488,7 +1488,7 @@ def _assert_table_index(
         raise ValueError(
             f'Cannot '
             f'{operation} '
-            f'table if levels and dtypes of index do not match.\n'
+            f'table if input index and table index are not alike.\n'
             f'Expected index:\n'
             f'\t{want}'
             f'\nbut yours is:\n'

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -231,7 +231,7 @@ class Base(HeaderBase):
 
         _assert_table_index(self, index, 'drop rows from')
 
-        new_index = self.df.index.difference(index)
+        new_index = utils.symmetric_difference([self.index, index])
         self._df = self.df.reindex(new_index)
 
         return self

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -615,13 +615,13 @@ def test_drop_and_pick_index():
 
     index = pytest.DB['segments'].index[:5]
     with pytest.raises(
-            ValueError,
-            match='Levels and dtypes of all objects must match',
+        ValueError,
+        match='Cannot drop',
     ):
         pytest.DB[table_id].drop_index(index).get()
     with pytest.raises(
-            ValueError,
-            match='Levels and dtypes of all objects must match',
+        ValueError,
+        match='Cannot pick',
     ):
         pytest.DB[table_id].pick_index(index).get()
 
@@ -637,8 +637,8 @@ def test_extend_index():
     db['misc'].extend_index(pd.Index([], name='idx'))
     assert db['misc'].get().empty
     with pytest.raises(
-            ValueError,
-            match='Levels and dtypes of all objects must match',
+        ValueError,
+        match='Cannot extend',
     ):
         db['misc'].extend_index(pd.Index([], name='other'))
 

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -671,6 +671,22 @@ def test_extend_index():
         np.array(['a', 'a', 'b']),
     )
 
+    # extend with MultIndex
+
+    # TODO: uncomment when https://github.com/audeering/audformat/issues/227
+    #  is solved
+
+    # index = pd.MultiIndex.from_arrays([['1', '4']], names=['idx'])
+    # db['misc'].extend_index(
+    #     index,
+    #     fill_values='b',
+    #     inplace=True,
+    # )
+    # np.testing.assert_equal(
+    #     db['misc']['columns'].get().values,
+    #     np.array(['a', 'a', 'b', 'b']),
+    # )
+
     db.drop_tables('misc')
 
 

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -604,18 +604,26 @@ def test_dtype_multiindex_single_level(
     assert db_new['misc'].index.dtype == expected_pandas_dtype
 
 
-@pytest.mark.parametrize(
-    'table, column, expected',
-    [
-        (
-            pytest.DB['misc'],
-            'int',
-            pytest.DB['misc'].df['int'],
-        ),
-    ]
-)
-def test_get_column(table, column, expected):
-    pd.testing.assert_series_equal(table[column].get(), expected)
+def test_drop_and_pick_index():
+
+    table_id = 'misc'
+    index = pytest.DB[table_id].index[:5]
+    df_pick = pytest.DB[table_id].pick_index(index).get()
+    index = pytest.DB[table_id].index[5:]
+    df_drop = pytest.DB[table_id].drop_index(index).get()
+    pd.testing.assert_frame_equal(df_pick, df_drop)
+
+    index = pytest.DB['segments'].index[:5]
+    with pytest.raises(
+            ValueError,
+            match='Levels and dtypes of all objects must match',
+    ):
+        pytest.DB[table_id].drop_index(index).get()
+    with pytest.raises(
+            ValueError,
+            match='Levels and dtypes of all objects must match',
+    ):
+        pytest.DB[table_id].pick_index(index).get()
 
 
 def test_extend_index():
@@ -661,6 +669,20 @@ def test_extend_index():
     )
 
     db.drop_tables('misc')
+
+
+@pytest.mark.parametrize(
+    'table, column, expected',
+    [
+        (
+            pytest.DB['misc'],
+            'int',
+            pytest.DB['misc'].df['int'],
+        ),
+    ]
+)
+def test_get_column(table, column, expected):
+    pd.testing.assert_series_equal(table[column].get(), expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -607,13 +607,16 @@ def test_dtype_multiindex_single_level(
 def test_drop_and_pick_index():
 
     table_id = 'misc'
-    index = pytest.DB[table_id].index[:5]
+
+    index = pytest.DB[table_id].index[:2]
     df_pick = pytest.DB[table_id].pick_index(index).get()
-    index = pytest.DB[table_id].index[5:]
+    index = pytest.DB[table_id].index[2:]
     df_drop = pytest.DB[table_id].drop_index(index).get()
+
+    assert len(df_pick) == len(df_drop) == 2
     pd.testing.assert_frame_equal(df_pick, df_drop)
 
-    index = pytest.DB['segments'].index[:5]
+    index = pytest.DB['segments'].index[:2]
     with pytest.raises(
         ValueError,
         match='Cannot drop',

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -520,10 +520,13 @@ def test_drop_and_pick_columns(inplace):
 def test_drop_and_pick_index():
 
     for table in ['files', 'segments']:
+
         index = pytest.DB[table].index[:5]
         df_pick = pytest.DB[table].pick_index(index).get()
         index = pytest.DB[table].index[5:]
         df_drop = pytest.DB[table].drop_index(index).get()
+
+        assert len(df_pick) == len(df_drop) == 5
         pd.testing.assert_frame_equal(df_pick, df_drop)
 
     index = pytest.DB['segments'].index[:5]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -529,12 +529,12 @@ def test_drop_and_pick_index():
     index = pytest.DB['segments'].index[:5]
     with pytest.raises(
         ValueError,
-        match='Cannot drop'
+        match='Cannot drop rows'
     ):
         pytest.DB['files'].drop_index(index).get()
     with pytest.raises(
         ValueError,
-        match='Cannot pick',
+        match='Cannot pick rows',
     ):
         pytest.DB['files'].pick_index(index).get()
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -527,9 +527,15 @@ def test_drop_and_pick_index():
         pd.testing.assert_frame_equal(df_pick, df_drop)
 
     index = pytest.DB['segments'].index[:5]
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match='Cannot drop'
+    ):
         pytest.DB['files'].drop_index(index).get()
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match='Cannot pick',
+    ):
         pytest.DB['files'].pick_index(index).get()
 
 
@@ -653,7 +659,10 @@ def test_extend_index():
     db['table'] = audformat.Table()
     db['table'].extend_index(audformat.filewise_index())
     assert db['table'].get().empty
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match='Cannot extend',
+    ):
         db['table'].extend_index(
             audformat.segmented_index(
                 files=['1.wav', '2.wav'],

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -517,6 +517,22 @@ def test_drop_and_pick_columns(inplace):
         assert 'string' in db['files'].columns
 
 
+def test_drop_and_pick_index():
+
+    for table in ['files', 'segments']:
+        index = pytest.DB[table].index[:5]
+        df_pick = pytest.DB[table].pick_index(index).get()
+        index = pytest.DB[table].index[5:]
+        df_drop = pytest.DB[table].drop_index(index).get()
+        pd.testing.assert_frame_equal(df_pick, df_drop)
+
+    index = pytest.DB['segments'].index[:5]
+    with pytest.raises(ValueError):
+        pytest.DB['files'].drop_index(index).get()
+    with pytest.raises(ValueError):
+        pytest.DB['files'].pick_index(index).get()
+
+
 @pytest.mark.parametrize(
     'files',
     [
@@ -541,54 +557,6 @@ def test_drop_files(files, table):
     elif isinstance(files, str):
         files = [files]
     assert len(table.files.intersection(files)) == 0
-
-
-@pytest.mark.parametrize(
-    'files',
-    [
-        pytest.DB.files,
-        pytest.DB.files[0],
-        [pytest.DB.files[0], 'does-not-exist.wav'],
-        lambda x: '1' in x,
-    ]
-)
-@pytest.mark.parametrize(
-    'table',
-    [
-        pytest.DB['files'],
-        pytest.DB['segments'],
-    ]
-)
-def test_pick_files(files, table):
-
-    table = table.pick_files(files, inplace=False)
-    if callable(files):
-        files = table.files[table.files.to_series().apply(files)]
-        seen = set()
-        seen_add = seen.add
-        files = [x for x in files if not (x in seen or seen_add(x))]
-    elif isinstance(files, str):
-        files = [files]
-    pd.testing.assert_index_equal(
-        table.files.unique(),
-        audformat.filewise_index(files).intersection(table.files),
-    )
-
-
-def test_and_pick_index():
-
-    for table in ['files', 'segments']:
-        index = pytest.DB[table].index[:5]
-        df_pick = pytest.DB[table].pick_index(index).get()
-        index = pytest.DB[table].index[5:]
-        df_drop = pytest.DB[table].drop_index(index).get()
-        pd.testing.assert_frame_equal(df_pick, df_drop)
-
-    index = pytest.DB['segments'].index[:5]
-    with pytest.raises(ValueError):
-        pytest.DB['files'].drop_index(index).get()
-    with pytest.raises(ValueError):
-        pytest.DB['files'].pick_index(index).get()
 
 
 def test_empty():
@@ -947,6 +915,38 @@ def test_map(table, map):
         if column not in mapped_columns:
             expected.drop(columns=column, inplace=True)
     pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    'files',
+    [
+        pytest.DB.files,
+        pytest.DB.files[0],
+        [pytest.DB.files[0], 'does-not-exist.wav'],
+        lambda x: '1' in x,
+    ]
+)
+@pytest.mark.parametrize(
+    'table',
+    [
+        pytest.DB['files'],
+        pytest.DB['segments'],
+    ]
+)
+def test_pick_files(files, table):
+
+    table = table.pick_files(files, inplace=False)
+    if callable(files):
+        files = table.files[table.files.to_series().apply(files)]
+        seen = set()
+        seen_add = seen.add
+        files = [x for x in files if not (x in seen or seen_add(x))]
+    elif isinstance(files, str):
+        files = [files]
+    pd.testing.assert_index_equal(
+        table.files.unique(),
+        audformat.filewise_index(files).intersection(table.files),
+    )
 
 
 @pytest.mark.parametrize('num_files,num_segments_per_file,values', [

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -710,8 +710,7 @@ def test_extend_index():
         db['table']['columns'].get().values,
         np.array(['a', 'a']),
     )
-    index = pd.Index(['1.wav', '3.wav'],
-                     name=audformat.define.IndexField.FILE)
+    index = audformat.filewise_index(['1.wav', '3.wav'])
     db['table'].extend_index(
         index,
         fill_values='b',


### PR DESCRIPTION
Moves `drop_index()`, `extend_index()` and `pick_index()` from `table.Table` to `table.Base` and adapts the code that it works for `Table` and `MiscTable`.

![image](https://user-images.githubusercontent.com/10383417/180790152-9558e13a-eb36-41ec-830d-660529acdc7b.png)

![image](https://user-images.githubusercontent.com/10383417/180790087-e29adf7c-f7d3-4c74-bf3e-089519e730d2.png)

![image](https://user-images.githubusercontent.com/10383417/180790239-a87e73d3-613e-4a25-a136-3d2fc11a1c59.png)

Here are two examples for the error message if input `index` does not match the index of the table:

```python
db = audformat.testing.create_db()
db['misc'].drop_index(db['segments'].index)
```
```
Cannot drop rows from table if input index and table index are not alike.
Expected index:
	file              string
	start    timedelta64[ns]
	end      timedelta64[ns]
but yours is:
	labels    string
```

```python
db = audformat.testing.create_db()
db['segments'].extend_index(db['files'].index)
```
```
Cannot extend a segmented table with a filewise index.
```