### PR TITLE
Fix: utils.set_index_dtypes() for timedelta

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1164,6 +1164,7 @@ def set_index_dtypes(
                     index = index.set_levels(
                         index.levels[idx].astype(dtype),
                         level=level,
+                        verify_integrity=False,
                     )
     else:
         # Index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1145,7 +1145,13 @@ def set_index_dtypes(
             # so we convert to a dataframe instead
             df = index.to_frame()
             for level, dtype in dtypes.items():
-                df[level] = df[level].astype(dtype)
+                if dtype != df[level].dtype:
+                    if pd.api.types.is_timedelta64_dtype(dtype):
+                        # avoid: TypeError: Cannot cast DatetimeArray
+                        # to dtype timedelta64[ns]
+                        df[level] = pd.to_timedelta(list(df[level]))
+                    else:
+                        df[level] = df[level].astype(dtype)
             index = pd.MultiIndex.from_frame(df)
         else:
             for level, dtype in dtypes.items():
@@ -1154,14 +1160,16 @@ def set_index_dtypes(
                 # hence we access the data directly with
                 # index.levels[idx]
                 idx = index.names.index(level)
-                index = index.set_levels(
-                    index.levels[idx].astype(dtype),
-                    level=level,
-                )
+                if dtype != index.levels[idx].dtype:
+                    index = index.set_levels(
+                        index.levels[idx].astype(dtype),
+                        level=level,
+                    )
     else:
         # Index
         dtype = next(iter(dtypes.values()))
-        index = index.astype(dtype)
+        if dtype != index.dtype:
+            index = index.astype(dtype)
 
     return index
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1848,13 +1848,14 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
         (
             pd.MultiIndex.from_arrays(
                 [
+                    ['f1', 'f2'],
                     [0, 1],
                     [pd.NaT, pd.NaT],
                 ],
-                names=['idx', 'time'],
+                names=['file', 'start', 'end'],
             ),
-            {'time': 'timedelta64[ns]'},
-            None,
+            {'end': 'timedelta64[ns]'},
+            audformat.segmented_index(['f1', 'f2'], [0, 1]),
         ),
         pytest.param(
             pd.MultiIndex.from_arrays(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1854,7 +1854,11 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
                 ],
                 names=['file', 'start', 'end'],
             ),
-            {'end': 'timedelta64[ns]'},
+            {
+                'file': 'string',
+                'start': 'timedelta64[ns]',
+                'end': 'timedelta64[ns]',
+            },
             audformat.segmented_index(['f1', 'f2'], [0, 1]),
         ),
         pytest.param(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1849,7 +1849,7 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
             pd.MultiIndex.from_arrays(
                 [
                     ['f1', 'f2'],
-                    [0, 1],
+                    [0, int(1e9)],
                     [pd.NaT, pd.NaT],
                 ],
                 names=['file', 'start', 'end'],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1845,6 +1845,17 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
                 names=['idx', 'date'],
             ),
         ),
+        (
+            pd.MultiIndex.from_arrays(
+                [
+                    [0, 1],
+                    [pd.NaT, pd.NaT],
+                ],
+                names=['idx', 'time'],
+            ),
+            {'time': 'timedelta64[ns]'},
+            None,
+        ),
         pytest.param(
             pd.MultiIndex.from_arrays(
                 [


### PR DESCRIPTION
Closes #230 

Fix conversion to `timedelta64[ns]` for a level in a `MultiIndex` that contains `NaT` entries.