### PR TITLE
Fix: utils.intersect() properly handles NaT

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -490,8 +490,8 @@ def intersect(
     Example:
         >>> intersect(
         ...     [
-        ...         pd.Index([0, 1], name='idx'),
-        ...         pd.Index([1, 2], dtype='Int64', name='idx'),
+        ...         pd.Index([1, np.nan], dtype='Int64', name='idx'),
+        ...         pd.Index([1, 2, 3], name='idx'),
         ...     ]
         ... )
         Index([1], dtype='Int64', name='idx')
@@ -529,7 +529,7 @@ def intersect(
         ...         segmented_index(['f1', 'f2'], [0, 1], [1, 2]),
         ...     ]
         ... )
-        MultiIndex([('f1', '0 days 00:00:00', '0 days 00:00:01')],
+        MultiIndex([('f1', '0 days', '0 days 00:00:01')],
                    names=['file', 'start', 'end'])
         >>> intersect(
         ...     [
@@ -568,11 +568,12 @@ def intersect(
 
         objs = _convert_single_level_multi_index(objs)
 
-        index = union(objs)
-        mask = np.ones(len(index), dtype=bool)
-        # sort objects by length to check short indices first
+        # sort objects by length
         objs = sorted(objs, key=lambda obj: len(obj))
-        for obj in objs:
+        # start from shortest index
+        index = objs[0]
+        mask = np.ones(len(index), dtype=bool)
+        for obj in objs[1:]:
             mask &= index.isin(obj)
             if not mask.any():
                 # break early if no more intersection is possible

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -570,8 +570,13 @@ def intersect(
 
         index = union(objs)
         mask = np.ones(len(index), dtype=bool)
+        # sort objects by length to check short indices first
+        objs = sorted(objs, key=lambda obj: len(obj))
         for obj in objs:
             mask &= index.isin(obj)
+            if not mask.any():
+                # break early if no more intersection is possible
+                break
         index = index[mask]
 
     return index

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import itertools
 from io import StringIO
 import os
 import shutil
@@ -1037,15 +1038,11 @@ def test_index_has_overlap(obj, expected):
     ]
 )
 def test_intersect(objs, expected):
-    pd.testing.assert_index_equal(
-        audformat.utils.intersect(objs),
-        expected,
-    )
-    objs = list(reversed(objs))
-    pd.testing.assert_index_equal(
-        audformat.utils.intersect(objs),
-        expected,
-    )
+    for permuted_objs in itertools.permutations(objs):
+        pd.testing.assert_index_equal(
+            audformat.utils.intersect(permuted_objs),
+            expected,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -992,8 +992,8 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
-                pd.Index([0, 1], name='idx'),
-                pd.Index([1, 2], dtype='Int64', name='idx'),
+                pd.Index([1, np.nan], dtype='Int64', name='idx'),
+                pd.Index([1, 2, 3], name='idx'),
             ],
             pd.Index([1], dtype='Int64', name='idx'),
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -940,6 +940,13 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
+                audformat.segmented_index('f1'),
+                audformat.segmented_index('f1', 0, 1),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
                 audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
                 audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
                 audformat.filewise_index(['f1', 'f2']),
@@ -1030,6 +1037,11 @@ def test_index_has_overlap(obj, expected):
     ]
 )
 def test_intersect(objs, expected):
+    pd.testing.assert_index_equal(
+        audformat.utils.intersect(objs),
+        expected,
+    )
+    objs = list(reversed(objs))
     pd.testing.assert_index_equal(
         audformat.utils.intersect(objs),
         expected,


### PR DESCRIPTION
Closes #233 

Instead of calling `index.intersect()` we use `index.isin()` to create a mask that we apply on the union of all index objects. This works with `NaT` and also preserves the `dtype`, which simplifies the code.