### PR TITLE
TST: ensure utils.union() is associative

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2436,3 +2436,19 @@ def test_union(objs, expected):
         audformat.utils.union(objs),
         expected,
     )
+    # Ensure A ∪ (B ∪ C) == (A ∪ B) ∪ C
+    if len(objs) > 2:
+        pd.testing.assert_index_equal(
+            audformat.utils.union(
+                [
+                    objs[0],
+                    audformat.utils.union(objs[1:]),
+                ]
+            ),
+            audformat.utils.union(
+                [
+                    audformat.utils.union(objs[:-1]),
+                    objs[-1],
+                ]
+            ),
+        )


### PR DESCRIPTION
As with `audformat.utils.intersect()` we should ensure that `audformat.utils.union()` is associative, namely Ensure A ∪ (B ∪ C) == (A ∪ B) ∪ C.