### PR TITLE
Fix: intersect() returns empty index for single object

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -12,6 +12,7 @@ import pandas as pd
 import audeer
 import audiofile
 
+import audformat.utils
 from audformat.core import define
 from audformat.core.common import to_audformat_dtype
 from audformat.core.database import Database
@@ -1596,9 +1597,12 @@ def _alike_index(index: pd.Index) -> pd.Index:
     elif is_segmented_index(index):
         return segmented_index()
     elif isinstance(index, pd.MultiIndex):
-        return pd.MultiIndex.from_arrays(
-            [[]] * index.nlevels,
-            names=index.names,
+        return audformat.utils.set_index_dtypes(
+            pd.MultiIndex.from_arrays(
+                [[]] * index.nlevels,
+                names=index.names,
+            ),
+            index.dtypes.to_dict(),
         )
     else:
         return pd.Index(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -483,6 +483,12 @@ def intersect(
     Example:
         >>> intersect(
         ...     [
+        ...         pd.Index([1, 2, 3], name='idx'),
+        ...     ]
+        ... )
+        Index([], dtype='object', name='idx')
+        >>> intersect(
+        ...     [
         ...         pd.Index([1, np.nan], dtype='Int64', name='idx'),
         ...         pd.Index([1, 2, 3], name='idx'),
         ...     ]
@@ -538,7 +544,17 @@ def intersect(
         return pd.Index([])
 
     if len(objs) == 1:
-        return objs[0]
+        if is_filewise_index(objs[0]):
+            return filewise_index()
+        elif is_segmented_index(objs[0]):
+            return segmented_index()
+        elif isinstance(objs[0], pd.MultiIndex):
+            return pd.MultiIndex.from_arrays(
+                [[]] * objs[0].nlevels,
+                names=objs[0].names,
+            )
+        else:
+            return pd.Index([], name=objs[0].name)
 
     objs = _maybe_convert_filewise_index(objs)
     objs = _maybe_convert_single_level_multi_index(objs)

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -486,7 +486,7 @@ def intersect(
         ...         pd.Index([1, 2, 3], name='idx'),
         ...     ]
         ... )
-        Index([], dtype='object', name='idx')
+        Int64Index([], dtype='int64', name='idx')
         >>> intersect(
         ...     [
         ...         pd.Index([1, np.nan], dtype='Int64', name='idx'),
@@ -544,17 +544,7 @@ def intersect(
         return pd.Index([])
 
     if len(objs) == 1:
-        if is_filewise_index(objs[0]):
-            return filewise_index()
-        elif is_segmented_index(objs[0]):
-            return segmented_index()
-        elif isinstance(objs[0], pd.MultiIndex):
-            return pd.MultiIndex.from_arrays(
-                [[]] * objs[0].nlevels,
-                names=objs[0].names,
-            )
-        else:
-            return pd.Index([], name=objs[0].name)
+        return _alike_index(objs[0])
 
     objs = _maybe_convert_filewise_index(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
@@ -1597,6 +1587,25 @@ def union(
     index = index.drop_duplicates()
 
     return index
+
+
+def _alike_index(index: pd.Index) -> pd.Index:
+    r"""Return empty index with same levels and dtypes."""
+    if is_filewise_index(index):
+        return filewise_index()
+    elif is_segmented_index(index):
+        return segmented_index()
+    elif isinstance(index, pd.MultiIndex):
+        return pd.MultiIndex.from_arrays(
+            [[]] * index.nlevels,
+            names=index.names,
+        )
+    else:
+        return pd.Index(
+            [],
+            dtype=index.dtype,
+            name=index.name,
+        )
 
 
 def _is_same_dtype(d1, d2) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -847,6 +847,12 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(),
+        ),
+        (
+            [
                 audformat.filewise_index(),
                 audformat.filewise_index(),
             ],
@@ -878,6 +884,12 @@ def test_index_has_overlap(obj, expected):
         (
             [
                 audformat.segmented_index(),
+            ],
+            audformat.segmented_index(),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2']),
             ],
             audformat.segmented_index(),
         ),
@@ -983,6 +995,24 @@ def test_index_has_overlap(obj, expected):
                 pd.Index([]),
             ],
             pd.Index([]),
+        ),
+        (
+            [
+                pd.Index([0, 1], name='idx'),
+            ],
+            pd.Index([], name='idx'),
+        ),
+        (
+            [
+                pd.MultiIndex.from_arrays(
+                    [[0, 1], [2, 3]],
+                    names=['idx1', 'idx2'],
+                ),
+            ],
+            pd.MultiIndex.from_arrays(
+                [[], []],
+                names=['idx1', 'idx2'],
+            ),
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1000,7 +1000,7 @@ def test_index_has_overlap(obj, expected):
             [
                 pd.Index([0, 1], name='idx'),
             ],
-            pd.Index([], name='idx'),
+            pd.Index([], dtype='int64', name='idx'),
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1005,13 +1005,19 @@ def test_index_has_overlap(obj, expected):
         (
             [
                 pd.MultiIndex.from_arrays(
-                    [[0, 1], [2, 3]],
+                    [[0, 1], ['a', 'b']],
                     names=['idx1', 'idx2'],
                 ),
             ],
-            pd.MultiIndex.from_arrays(
-                [[], []],
-                names=['idx1', 'idx2'],
+            audformat.utils.set_index_dtypes(
+                pd.MultiIndex.from_arrays(
+                    [[], []],
+                    names=['idx1', 'idx2'],
+                ),
+                {
+                    'idx1': 'int',
+                    'idx2': 'object',
+                },
             ),
         ),
         (


### PR DESCRIPTION
Closes #238 

Adds one more docstring example:

![image](https://user-images.githubusercontent.com/10383417/181494434-9b7ace9d-ff56-45e7-b025-76fbb9b67394.png)
