### PR TITLE
WIP: Ensures Table.files returns correct dtype

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -932,6 +932,8 @@ class Table(Base):
         else:
             index = self.df.index.get_level_values(define.IndexField.FILE)
             index.name = define.IndexField.FILE
+            if index.dtype != define.DataType.STRING:
+                index = utils.set_index_dtypes(index, define.DataType.STRING)
             return index
 
     @property


### PR DESCRIPTION
This fixes the problem that loading a databses might fail as we get a mixture of dtypes for `db.files`.

I don't know yet, why this was not covered by tests before, and I also don't know yet why we get the problem in the first place.