### PR TITLE
Add helper function _assert_index_alike()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1629,8 +1629,13 @@ def _assert_index_alike(
         msg += f' Found different number of levels: {dims}.'
         raise ValueError(msg)
 
-    names = sorted(list(set([tuple(obj.names) if len(obj.names) > 1
-                             else obj.names[0] for obj in objs])))
+    names = set()
+    for obj in objs:
+        if len(obj.names) > 1:
+            names.add(tuple([str(name) for name in obj.names]))
+        else:
+            names.add(str(obj.names[0]))
+    names = sorted(list(names))
     if len(names) > 1:
         msg += f' Found different level names: {names}.'
         raise ValueError(msg)

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1632,30 +1632,30 @@ def _assert_index_alike(
     objs = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
     msg = 'Levels and dtypes of all objects must match.'
 
-    dims = sorted(list(set(obj.nlevels for obj in objs)))
+    dims = list(dict.fromkeys(obj.nlevels for obj in objs))
     if len(dims) > 1:
         msg += f' Found different number of levels: {dims}.'
         raise ValueError(msg)
 
-    names = set()
+    names = []
     for obj in objs:
         if len(obj.names) > 1:
-            names.add(tuple([name for name in obj.names]))
+            names.append(tuple([name for name in obj.names]))
         else:
-            names.add(obj.names[0])
-    names = sorted(list(names), key=lambda e: str(e))  # support None
+            names.append(obj.names[0])
+    names = list(dict.fromkeys(names))
     if len(names) > 1:
         msg += f' Found different level names: {names}.'
         raise ValueError(msg)
 
-    dtypes = set()
+    dtypes = []
     for obj in objs:
         if isinstance(obj, pd.MultiIndex):
             ds = [to_audformat_dtype(dtype) for dtype in obj.dtypes]
         else:
             ds = [to_audformat_dtype(obj.dtype)]
-        dtypes.add(tuple(ds) if len(ds) > 1 else ds[0])
-    dtypes = sorted(list(dtypes))
+        dtypes.append(tuple(ds) if len(ds) > 1 else ds[0])
+    dtypes = list(dict.fromkeys(dtypes))
     if len(dtypes) > 1:
         msg += f' Found different level dtypes: {dtypes}.'
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -12,13 +12,11 @@ import pandas as pd
 import audeer
 import audiofile
 
-import audformat.utils
 from audformat.core import define
 from audformat.core.common import to_audformat_dtype
 from audformat.core.database import Database
 from audformat.core.index import (
     filewise_index,
-    index_type,
     is_filewise_index,
     is_segmented_index,
     segmented_index,

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1640,10 +1640,10 @@ def _assert_index_alike(
     names = set()
     for obj in objs:
         if len(obj.names) > 1:
-            names.add(tuple([str(name) for name in obj.names]))
+            names.add(tuple([name for name in obj.names]))
         else:
-            names.add(str(obj.names[0]))
-    names = sorted(list(names))
+            names.add(obj.names[0])
+    names = sorted(list(names), key=lambda e: str(e))  # support None
     if len(names) > 1:
         msg += f' Found different level names: {names}.'
         raise ValueError(msg)

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1624,12 +1624,13 @@ def _assert_index_alike(
     objs = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
     msg = 'Levels and dtypes of all objects must match.'
 
-    dims = set(obj.nlevels for obj in objs)
+    dims = sorted(list(set(obj.nlevels for obj in objs)))
     if len(dims) > 1:
         msg += f' Found different number of levels: {dims}.'
         raise ValueError(msg)
 
-    names = set([tuple(obj.names) for obj in objs])
+    names = sorted(list(set([tuple(obj.names) if len(obj.names) > 1
+                             else obj.names[0] for obj in objs])))
     if len(names) > 1:
         msg += f' Found different level names: {names}.'
         raise ValueError(msg)
@@ -1640,7 +1641,8 @@ def _assert_index_alike(
             ds = [to_audformat_dtype(dtype) for dtype in obj.dtypes]
         else:
             ds = [to_audformat_dtype(obj.dtype)]
-        dtypes.add(tuple(ds))
+        dtypes.add(tuple(ds) if len(ds) > 1 else ds[0])
+    dtypes = sorted(list(dtypes))
     if len(dtypes) > 1:
         msg += f' Found different level dtypes: {dtypes}.'
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -169,6 +169,7 @@ def concat(
 
     objs = _maybe_convert_filewise_index(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
+    _assert_index_alike(objs)
 
     # the new index is a union of the individual objects
     index = union([obj.index for obj in objs])
@@ -548,8 +549,8 @@ def intersect(
         return _alike_index(objs[0])
 
     objs = _maybe_convert_filewise_index(objs)
-    _assert_index_alike(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
+    _assert_index_alike(objs)
 
     # sort objects by length
     objs = sorted(objs, key=lambda obj: len(obj))
@@ -1252,6 +1253,7 @@ def symmetric_difference(
 
     objs = _maybe_convert_filewise_index(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
+    _assert_index_alike(objs)
 
     index = union(objs)
     count = np.zeros(len(index))
@@ -1580,6 +1582,7 @@ def union(
 
     objs = _maybe_convert_filewise_index(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
+    _assert_index_alike(objs)
 
     # Combine all MultiIndex entries and drop duplicates afterwards,
     # faster than using index.union(),

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -168,7 +168,6 @@ def concat(
         return objs[0]
 
     objs = _maybe_convert_filewise_index(objs)
-    _assert_index_alike(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
 
     # the new index is a union of the individual objects
@@ -549,6 +548,7 @@ def intersect(
         return _alike_index(objs[0])
 
     objs = _maybe_convert_filewise_index(objs)
+    _assert_index_alike(objs)
     objs = _maybe_convert_single_level_multi_index(objs)
 
     # sort objects by length
@@ -1616,8 +1616,15 @@ def _alike_index(index: pd.Index) -> pd.Index:
 def _assert_index_alike(
         objs: typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]],
 ):
-    r"""Raise error if is_index_alike() returns ``False``."""
+    r"""Raise if index objects are not alike.
 
+    Args:
+        objs: objects
+
+    Raises:
+        ValueError: if index objects are not alike
+
+    """
     if is_index_alike(objs):
         return
 
@@ -1711,16 +1718,7 @@ def _maybe_convert_single_level_multi_index(
     Returns:
         list with possibly converted objects
 
-    Raises:
-        ValueError: if level and dtypes of objects do not match
-
     """
-    if not is_index_alike(objs):
-        raise ValueError(
-            'Levels and dtypes of all objects must match, '
-            'see audformat.utils.is_index_alike().'
-        )
-
     indices = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
     is_single_level = indices[0].nlevels == 1
     is_mix = len(set(isinstance(index, pd.MultiIndex)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1138,6 +1138,13 @@ def test_intersect(objs, expected):
         ),
         (
             [
+                pd.Index([1, 2, 3]),
+                pd.Index([10, 20], name='l'),
+            ],
+            "Found different level names: ['None', 'l']",
+        ),
+        (
+            [
                 pd.Index([1, 2, 3], name='l'),
                 pd.MultiIndex.from_arrays([[10, 20]], names=['l']),
             ],
@@ -1242,6 +1249,14 @@ def test_intersect(objs, expected):
             ],
             "Found different level dtypes: "
             "[('object', 'int'), ('object', 'object')]",
+        ),
+        (
+            [
+                pd.MultiIndex.from_arrays([[], []], names=['l1', 'l2']),
+                pd.MultiIndex.from_arrays([[], []]),
+            ],
+            "Found different level names: "
+            "[('None', 'None'), ('l1', 'l2')]",
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1127,7 +1127,7 @@ def test_intersect(objs, expected):
                 pd.Index([], name='l'),
                 pd.Index([], name='L'),
             ],
-            "Found different level names: ['L', 'l']",
+            "Found different level names: ['l', 'L']",
         ),
         (
             [
@@ -1176,18 +1176,17 @@ def test_intersect(objs, expected):
                 pd.Index([1, 2, 3], name='l'),
                 pd.MultiIndex.from_arrays([[10, 20]], names=['L']),
             ],
-            "Found different level names: ['L', 'l']",
+            "Found different level names: ['l', 'L']",
         ),
         (
             [
                 pd.Index(['a', 'b', 'c'], name='l'),
                 pd.MultiIndex.from_arrays([[10, 20]], names=['l']),
             ],
-            "Found different level dtypes: ['int', 'object']",
+            "Found different level dtypes: ['object', 'int']",
         ),
         (
             [
-                pd.Index([1, 2, 3], name='l'),
                 pd.MultiIndex.from_arrays(
                     [
                         [10],
@@ -1195,8 +1194,9 @@ def test_intersect(objs, expected):
                     ],
                     names=['l1', 'l2'],
                 ),
+                pd.Index([1, 2, 3], name='l'),
             ],
-            'Found different number of levels: [1, 2]',
+            'Found different number of levels: [2, 1]',
         ),
         (
             [
@@ -1235,7 +1235,7 @@ def test_intersect(objs, expected):
                 ),
             ],
             "Found different level dtypes: "
-            "[('int', 'object'), ('object', 'int')]",
+            "[('object', 'int'), ('int', 'object')]",
         ),
         (
             [
@@ -1283,7 +1283,7 @@ def test_intersect(objs, expected):
                 ),
             ],
             "Found different level names: "
-            "[('L1', 'L2'), ('l1', 'l2')]",
+            "[('l1', 'l2'), ('L1', 'L2')]",
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1138,10 +1138,17 @@ def test_intersect(objs, expected):
         ),
         (
             [
+                pd.Index([]),
+                pd.Index([], name='None')
+            ],
+            "Found different level names: [None, 'None']",
+        ),
+        (
+            [
                 pd.Index([1, 2, 3]),
                 pd.Index([10, 20], name='l'),
             ],
-            "Found different level names: ['None', 'l']",
+            "Found different level names: [None, 'l']",
         ),
         (
             [
@@ -1256,7 +1263,7 @@ def test_intersect(objs, expected):
                 pd.MultiIndex.from_arrays([[], []]),
             ],
             "Found different level names: "
-            "[('None', 'None'), ('l1', 'l2')]",
+            "[('l1', 'l2'), (None, None)]",
         ),
         (
             [


### PR DESCRIPTION
Adds helper function `utils._assert_index_alike()` which raises an `ValueError` if `is_index_alike()` fails.

### Examples:

```python
objs = [
    pd.Index([]),
    pd.MultiIndex.from_arrays([[], []]),
]
audformat.utils.union(objs)
```
```
Levels and dtypes of all objects must match. Found different number of levels: [1, 2].
```

```python
objs = [
    pd.MultiIndex.from_arrays([[], []], names=['idx1', 'idx2']),
    pd.MultiIndex.from_arrays([[], []]),
]
audformat.utils.union(objs)
```
```
Levels and dtypes of all objects must match. Found different level names: [('idx1', 'idx2'), (None, None)].
```

```python
objs = [
    pd.Index([], dtype='string'),
    pd.Index([]),
]
audformat.utils.union(objs)
```
```
Levels and dtypes of all objects must match. Found different level dtypes: ['object', 'str'].
```