### PR TITLE
Use list comprehension in audformat.utils.intersect()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -470,6 +470,14 @@ def intersect(
     the result is a
     :class:`pandas.Index`.
 
+    The order of the resulting index
+    depends on the order of ``objs``.
+    If you require :func:`audformat.utils.intersect`
+    to be commutative_,
+    you have to sort its output.
+
+    .. _commutative: https://en.wikipedia.org/wiki/Commutative_property
+
     Args:
         objs: index objects
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -572,6 +572,8 @@ def intersect(
 
     # Ensure we have order of first object
     index = objs[0].intersection(index)
+    if isinstance(index, pd.MultiIndex):
+        index = set_index_dtypes(index, objs[0].dtypes.to_dict())
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -553,13 +553,12 @@ def intersect(
     # sort objects by length
     objs = sorted(objs, key=lambda obj: len(obj))
     # start from shortest index
-    index = set(objs[0])
+    index = list(objs[0])
     for obj in objs[1:]:
-        index = index.intersection(set(obj))
+        index = [idx for idx in index if idx in obj]
         if len(index) == 0:
             # break early if no more intersection is possible
             break
-    index = sorted(list((index)))
     index = _alike_index(obj, index)
 
     return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -472,6 +472,8 @@ def intersect(
 
     The order of the resulting index
     depends on the order of ``objs``.
+    The dtype of the resulting index
+    is identical to the dtype of the first object.
     If you require :func:`audformat.utils.intersect`
     to be commutative_,
     you have to sort its output.

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1605,7 +1605,7 @@ def _alike_index(
         data: typing.Sequence = [],
 ) -> pd.Index:
     if isinstance(index, pd.MultiIndex):
-        return audformat.utils.set_index_dtypes(
+        return set_index_dtypes(
             pd.MultiIndex.from_tuples(data, names=list(index.names)),
             index.dtypes.to_dict(),
         )

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -558,14 +558,20 @@ def intersect(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
+    # sort objects by length
+    objs_sorted = sorted(objs, key=lambda obj: len(obj))
     # start from first object
-    index = list(objs[0])
-    for obj in objs[1:]:
+    index = list(objs_sorted[0])
+    for obj in objs_sorted[1:]:
         index = [idx for idx in index if idx in obj]
         if len(index) == 0:
             # break early if no more intersection is possible
             break
+
     index = _alike_index(objs[0], index)
+
+    # Ensure we have order of first object
+    index = objs[0].intersection(index)
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -560,11 +560,7 @@ def intersect(
 
     # start from first object
     index = list(objs[0])
-    nlevels = objs[0].nlevels
     for obj in objs[1:]:
-        if nlevels > 1:
-            # for multi-level indices we are faster using set()
-            obj = set(obj)
         index = [idx for idx in index if idx in obj]
         if len(index) == 0:
             # break early if no more intersection is possible

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -560,12 +560,16 @@ def intersect(
 
     # start from first object
     index = list(objs[0])
+    nlevels = objs[0].nlevels
     for obj in objs[1:]:
+        if nlevels > 1:
+            # for multi-level indices we are faster using set()
+            obj = set(obj)
         index = [idx for idx in index if idx in obj]
         if len(index) == 0:
             # break early if no more intersection is possible
             break
-    index = _alike_index(obj, index)
+    index = _alike_index(objs[0], index)
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -550,9 +550,7 @@ def intersect(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    # sort objects by length
-    objs = sorted(objs, key=lambda obj: len(obj))
-    # start from shortest index
+    # start from first object
     index = list(objs[0])
     for obj in objs[1:]:
         index = [idx for idx in index if idx in obj]

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -562,7 +562,12 @@ def intersect(
 
     # sort objects by length
     objs_sorted = sorted(objs, key=lambda obj: len(obj))
-    # start from first object
+
+    # return if the shortest obj has no entries
+    if len(objs_sorted[0]) == 0:
+        return _alike_index(objs[0])
+
+    # start from shortest object
     index = list(objs_sorted[0])
     for obj in objs_sorted[1:]:
         index = [idx for idx in index if idx in obj]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -876,6 +876,13 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
+                audformat.filewise_index(['f3', 'f2', 'f1']),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(['f2', 'f1']),
+        ),
+        (
+            [
                 audformat.filewise_index(['f1', 'f2']),
                 audformat.filewise_index(['f1', 'f2']),
                 audformat.filewise_index('f3'),
@@ -1083,11 +1090,10 @@ def test_index_has_overlap(obj, expected):
     ]
 )
 def test_intersect(objs, expected):
-    for permuted_objs in itertools.permutations(objs):
-        pd.testing.assert_index_equal(
-            audformat.utils.intersect(permuted_objs),
-            expected,
-        )
+    pd.testing.assert_index_equal(
+        audformat.utils.intersect(objs),
+        expected,
+    )
     # Ensure A ∩ (B ∩ C) == (A ∩ B) ∩ C
     if len(objs) > 2:
         pd.testing.assert_index_equal(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1044,10 +1044,17 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
+                pd.Index([1, 2, 3], name='idx'),
                 pd.Index([1, np.nan], dtype='Int64', name='idx'),
-                pd.Index([1, 2, 3], dtype='Int64', name='idx'),
             ],
             pd.Index([1], dtype='Int64', name='idx'),
+        ),
+        (
+            [
+                pd.Index([1, np.nan], dtype='Int64', name='idx'),
+                pd.Index([1, 2, 3], name='idx'),
+            ],
+            pd.Index([1], dtype='int64', name='idx'),
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1084,10 +1084,10 @@ def test_index_has_overlap(obj, expected):
 )
 def test_intersect(objs, expected):
     for permuted_objs in itertools.permutations(objs):
-        index = audformat.utils.intersect(permuted_objs)
-        if len(index) > 0:
-            index = index.sort_values()
-        pd.testing.assert_index_equal(index, expected)
+        pd.testing.assert_index_equal(
+            audformat.utils.intersect(permuted_objs),
+            expected,
+        )
     # Ensure A ∩ (B ∩ C) == (A ∩ B) ∩ C
     if len(objs) > 2:
         pd.testing.assert_index_equal(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1038,7 +1038,7 @@ def test_index_has_overlap(obj, expected):
         (
             [
                 pd.Index([1, np.nan], dtype='Int64', name='idx'),
-                pd.Index([1, 2, 3], name='idx'),
+                pd.Index([1, 2, 3], dtype='Int64', name='idx'),
             ],
             pd.Index([1], dtype='Int64', name='idx'),
         ),
@@ -1084,10 +1084,10 @@ def test_index_has_overlap(obj, expected):
 )
 def test_intersect(objs, expected):
     for permuted_objs in itertools.permutations(objs):
-        pd.testing.assert_index_equal(
-            audformat.utils.intersect(permuted_objs),
-            expected,
-        )
+        index = audformat.utils.intersect(permuted_objs)
+        if len(index) > 0:
+            index = index.sort_values()
+        pd.testing.assert_index_equal(index, expected)
     # Ensure A ∩ (B ∩ C) == (A ∩ B) ∩ C
     if len(objs) > 2:
         pd.testing.assert_index_equal(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1047,14 +1047,14 @@ def test_index_has_overlap(obj, expected):
                 pd.Index([1, 2, 3], name='idx'),
                 pd.Index([1, np.nan], dtype='Int64', name='idx'),
             ],
-            pd.Index([1], dtype='Int64', name='idx'),
+            pd.Int64Index([1], dtype='int64', name='idx')
         ),
         (
             [
                 pd.Index([1, np.nan], dtype='Int64', name='idx'),
                 pd.Index([1, 2, 3], name='idx'),
             ],
-            pd.Index([1], dtype='int64', name='idx'),
+            pd.Index([1], dtype='Int64', name='idx'),
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1047,7 +1047,7 @@ def test_index_has_overlap(obj, expected):
                 pd.Index([1, 2, 3], name='idx'),
                 pd.Index([1, np.nan], dtype='Int64', name='idx'),
             ],
-            pd.Int64Index([1], dtype='int64', name='idx')
+            pd.Index([1], dtype='int64', name='idx')
         ),
         (
             [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1058,6 +1058,13 @@ def test_index_has_overlap(obj, expected):
         ),
         (
             [
+                pd.Index([1, np.nan], dtype='Int64', name='idx'),
+                pd.Index([np.nan, 2, 3], dtype='Int64', name='idx'),
+            ],
+            pd.Index([np.nan], dtype='Int64', name='idx'),
+        ),
+        (
+            [
                 pd.Index([0, 1], name='idx'),
                 pd.MultiIndex.from_arrays([[1, 2]], names=['idx']),
             ],


### PR DESCRIPTION
Addresses half of https://github.com/audeering/audformat/issues/245

This implements `audformat.utils.intersect()` by converting indices to lists before checking for intersections,
and creating a new index at the end of the operation.
It also suggest to not sort the objects, in order to allow the test proposed in https://github.com/audeering/audformat/pull/254 to pass and preserve original index orders (output is no longer commutative then).

I benchmarked the current code using `list()` against the implementation of the master. The code for the benchmark is given below.


**Results for last obj of same size as first object**

| Table type | Index samples | v0.14.3 | master | list+sort | list-sort | pull request |
| --- | --- | --- | --- | --- | --- | --- |
| filewise | (100000, 500000, 100000) | 0.16 s | 0.19 s  | 0.14 s | 0.16 s | 0.16 s |
| filewise | (100000, 500000, 10000) | 0.12 s | 0.12 s  | 0.07 s | 0.14 s | 0.07 s |
| segmented | (100000, 500000, 100000) | 6.04 s | 14.51 s | 2.81 s | 3.17 s | 2.71 s |
| segmented | (100000, 500000, 10000) | 5.14 s | 12.91 s | 0.24 s | 3.04 s | 0.27 s |

![image](https://user-images.githubusercontent.com/173624/182303889-afcb4d6d-7c3e-40ca-89b5-70f0ed82c3af.png)

---

Code for benchmark:

```python
import audformat
import numpy as np
import pandas as pd
import random
import time


random.seed(0)
samples = 100000


def main():
    nsamples = 100000
    repetitions = 10

    for description, samples in [
            (
                'same length',
                [nsamples, 5 * nsamples, nsamples],
            ),
            (
                '1/10 length',
                [nsamples, 5 * nsamples, int(nsamples / 10)],
            ),
    ]:  
        for index in [filewise, segmented]:
            times = []
            for _ in range(repetitions):
                objs = index(samples)
                times.append(measure(objs))
            print(
                f'Execution time {index.__name__} {description}: '
                f'{np.mean(times):.2f}s'
            )


def measure(objs):
    start = time.time()
    _ = audformat.utils.intersect(objs)
    end = time.time()
    return end - start


def filewise(samples):
    index1 = audformat.filewise_index([f"f{n}" for n in range(samples[0])])
    index2 = audformat.filewise_index([f"f{n}" for n in range(samples[1])])
    idx = [n for n in range(len(index2))]
    index3 = index2[random.sample(idx, k=samples[2])]
    return [index1, index2, index3]


def segmented(samples):
    index1 = audformat.segmented_index(
        [f"f{n}" for n in range(samples[0])],
        random.choices([0, 1, 2, 3], k=samples[0]),
        random.choices([4, 5, 6, pd.NaT], k=samples[0]),
    )
    index2 = audformat.segmented_index(
        [f"f{n}" for n in range(samples[1])],
        random.choices([0, 1, 2, 3], k=samples[1]),
        random.choices([4, 5, 6, pd.NaT], k=samples[1]),
    )
    idx = [n for n in range(len(index2))]
    index3 = index2[random.sample(idx, k=samples[2])]
    return [index1, index2, index3]


if __name__ == '__main__':
    main()
```