### PR TITLE
Fix string dtype backward compatibility for PKL

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -623,20 +623,6 @@ class Base(HeaderBase):
                     dtype = dtypes[column_id]
                     df[column_id] = df[column_id].astype(dtype)
 
-        # Older versions of audformat stored columns
-        # assigned to a string scheme as 'object',
-        # so we need to convert those to 'string'
-        for column_id, column in self.columns.items():
-            if (
-                column.scheme_id is not None
-                and (
-                    self.db.schemes[column.scheme_id].dtype
-                    == define.DataType.STRING
-                )
-                and df[column_id].dtype == 'object'
-            ):
-                df[column_id] = df[column_id].astype('string', copy=False)
-
         self._df = df
 
     def _load_pickled(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -24,6 +24,7 @@ from audformat.core.errors import (
 from audformat.core.index import (
     filewise_index,
     index_type,
+    is_filewise_index,
     is_segmented_index,
 )
 from audformat.core.media import Media
@@ -622,6 +623,20 @@ class Base(HeaderBase):
                     dtype = dtypes[column_id]
                     df[column_id] = df[column_id].astype(dtype)
 
+        # Older versions of audformat stored columns
+        # assigned to a string scheme as 'object',
+        # so we need to convert those to 'string'
+        for column_id, column in self.columns.items():
+            if (
+                column.scheme_id is not None
+                and (
+                    self.db.schemes[column.scheme_id].dtype
+                    == define.DataType.STRING
+                )
+                and df[column_id].dtype == 'object'
+            ):
+                df[column_id] = df[column_id].astype('string', copy=False)
+
         self._df = df
 
     def _load_pickled(self, path: str):
@@ -648,6 +663,20 @@ class Base(HeaderBase):
                 and df[column_id].dtype == 'object'
             ):
                 df[column_id] = df[column_id].astype('string', copy=False)
+        # Fix index entries as well
+        if (
+                (
+                    is_filewise_index(df.index)
+                    and df.index.dtype == 'object'
+                ) or (
+                    is_segmented_index(df.index)
+                    and df.index.dtypes[define.IndexField.FILE] == 'object'
+                )
+        ):
+            df.index = utils.set_index_dtypes(
+                df.index,
+                {define.IndexField.FILE: 'string'},
+            )
 
         self._df = df
 


### PR DESCRIPTION
This fixes dtypes of filewise and segmented index entries stored in PKL files in cache with `dtype == 'object'`.

We had indeed forgotten to convert the index columns as well.
