### PR TITLE
Implement MiscTable.__add__()

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -813,6 +813,51 @@ class MiscTable(Base):
         file other
         f1   f2     True
              f3    False
+        >>> index_ex = pd.MultiIndex.from_tuples(
+        ...   [
+        ...     ('f4', 'f1'),
+        ...   ],
+        ...   names=['file', 'other'],
+        ... )
+        >>> index_ex = utils.set_index_dtypes(index_ex, 'string')
+        >>> table_ex = table.extend_index(
+        ...     index_ex,
+        ...     inplace=False,
+        ... )
+        >>> table_ex.get()
+                    match
+        file other
+        f1   f2      True
+             f3     False
+        f2   f3      True
+        f4   f1       NaN
+        >>> table_ex.set(
+        ...     {'match': True},
+        ...     index=index_ex,
+        ... )
+        >>> table_ex.get()
+                    match
+        file other
+        f1   f2      True
+             f3     False
+        f2   f3      True
+        f4   f1      True
+        >>> table_str = MiscTable(index)
+        >>> table_str['strings'] = Column()
+        >>> table_str.set({'strings': ['a', 'b', 'c']})
+        >>> (table + table_str).get()
+                    match strings
+        file other
+        f1   f2      True       a
+             f3     False       b
+        f2   f3      True       c
+        >>> (table_ex + table_str).get()
+                    match strings
+        file other
+        f1   f2      True       a
+             f3     False       b
+        f2   f3      True       c
+        f4   f1      True     NaN
 
     """
     def __init__(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -66,7 +66,11 @@ class Base(HeaderBase):
 
         The new table contains index and columns of both tables.
         Missing values will be set to ``NaN``.
-        If at least one table is segmented, the output has a segmented index.
+
+        If table is conform to
+        :ref:`table specifications <data-tables:Tables>`
+        and at least one table is segmented,
+        the output has a segmented index.
 
         Columns with the same identifier are combined to a single column.
         This requires that:
@@ -79,7 +83,7 @@ class Base(HeaderBase):
         as well as,
         references to schemes and raters are discarded.
         If you intend to keep them,
-        use :meth:`audformat.Table.update`.
+        use ``update()``.
 
         Args:
             other: the other table

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -813,15 +813,15 @@ class MiscTable(Base):
         file other
         f1   f2     True
              f3    False
-        >>> index_ex = pd.MultiIndex.from_tuples(
+        >>> index_new = pd.MultiIndex.from_tuples(
         ...   [
         ...     ('f4', 'f1'),
         ...   ],
         ...   names=['file', 'other'],
         ... )
-        >>> index_ex = utils.set_index_dtypes(index_ex, 'string')
+        >>> index_new = utils.set_index_dtypes(index_new, 'string')
         >>> table_ex = table.extend_index(
-        ...     index_ex,
+        ...     index_new,
         ...     inplace=False,
         ... )
         >>> table_ex.get()
@@ -833,7 +833,7 @@ class MiscTable(Base):
         f4   f1       NaN
         >>> table_ex.set(
         ...     {'match': True},
-        ...     index=index_ex,
+        ...     index=index_new,
         ... )
         >>> table_ex.get()
                     match
@@ -983,9 +983,9 @@ class Table(Base):
         f1   0 days NaT      0
         f2   0 days NaT      1
         f3   0 days NaT      2
-        >>> index_ex = filewise_index('f4')
+        >>> index_new = filewise_index('f4')
         >>> table_ex = table.extend_index(
-        ...     index_ex,
+        ...     index_new,
         ...     inplace=False,
         ... )
         >>> table_ex.get()
@@ -997,7 +997,7 @@ class Table(Base):
         f4      NaN
         >>> table_ex.set(
         ...     {'values': 3},
-        ...     index=index_ex,
+        ...     index=index_new,
         ... )
         >>> table_ex.get()
              values

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -91,6 +91,7 @@ class Base(HeaderBase):
         Raises:
             ValueError: if columns with the same name have different dtypes
             ValueError: if values in the same position do not match
+            ValueError: if level and dtypes of indices do not match
 
         """
         df = utils.concat([self.df, other.df])


### PR DESCRIPTION
Implement `__add()__` for `MiscTable` by moving to `Base`.

![image](https://user-images.githubusercontent.com/10383417/181721395-e9b8dca2-a8e2-4fea-838d-242da266fbfa.png)

Extends the docstring example of `MiscTable` by:

![image](https://user-images.githubusercontent.com/10383417/181735249-54b83020-8e00-4053-b305-1d79f77c84c2.png)

and renames `index_ex` to `index_new` in docstring example of `Table`:

![image](https://user-images.githubusercontent.com/10383417/181735328-ca244df5-eefb-486e-927a-45149acbfb81.png)


