### PR TITLE
DOC: mention that utils.union() is not commutative

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1501,6 +1501,14 @@ def union(
     the result is a
     :class:`pandas.Index`.
 
+    The order of the resulting index
+    depends on the order of ``objs``.
+    If you require :func:`audformat.utils.union`
+    to be commutative_,
+    you have to sort its output.
+
+    .. _commutative: https://en.wikipedia.org/wiki/Commutative_property
+
     Args:
         objs: index objects
 


### PR DESCRIPTION
Closes #240 

This adds a section to the docstring of `audformat.utils.union()` stating that the output order depends on the input order
and that the result needs to be sorted if it should behave A ∪ B == B ∪ A.

![image](https://user-images.githubusercontent.com/173624/181714224-42b2e93f-ecbd-4cff-9db7-74fc452af803.png)
