### PR TITLE
DOC: include methods/attributes from HeaderBase

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,6 +19,7 @@ Column
 
 .. autoclass:: Column
     :members:
+    :inherited-members:
 
 filewise_index
 --------------
@@ -35,6 +36,7 @@ Database
 
 .. autoclass:: Database
     :members:
+    :inherited-members:
     :special-members:
 
 index_type
@@ -57,13 +59,14 @@ Media
 
 .. autoclass:: Media
     :members:
+    :inherited-members:
 
 MiscTable
 ---------
 
 .. autoclass:: MiscTable
     :members:
-    :inherited-members: HeaderBase
+    :inherited-members:
     :special-members: __add__, __getitem__, __setitem__
 
 Rater
@@ -71,12 +74,14 @@ Rater
 
 .. autoclass:: Rater
     :members:
+    :inherited-members:
 
 Scheme
 ------
 
 .. autoclass:: Scheme
     :members:
+    :inherited-members:
 
 Split
 -----
@@ -86,6 +91,7 @@ Usually one of :class:`define.SplitType`.
 
 .. autoclass:: Split
     :members:
+    :inherited-members:
 
 Table
 -----
@@ -102,5 +108,5 @@ There are two types of tables:
 
 .. autoclass:: Table
     :members:
-    :inherited-members: HeaderBase
+    :inherited-members:
     :special-members: __add__, __getitem__, __setitem__


### PR DESCRIPTION
Closes #186 

This includes documentation for all methods and attributes from `HeaderBase`, which are:
* `description`
* `meta`
* `dump()`
* `to_dict()`
* `from_dict()`

I thought `from_dict()` and `to_dict()` might also be interesting as this would be another way to create the object.
If we decide that we don't want to support this we can still hide them by one of the following methods:
* make them private, e.g. `_from_dict()`
* remove docstring in definition in `HeaderBase`