### PR TITLE
Implement update() for MiscTable

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -268,7 +268,7 @@ class Base(HeaderBase):
             new object if ``inplace=False``, otherwise ``self``
 
         Raises:
-            ValueError: if level and dtypes of table indices do not match
+            ValueError: if level and dtypes of index does not match table index
 
         """
         if not inplace:
@@ -304,7 +304,7 @@ class Base(HeaderBase):
             new object if ``inplace=False``, otherwise ``self``
 
         Raises:
-            ValueError: if level and dtypes of table indices do not match
+            ValueError: if level and dtypes of index does not match table index
 
         """
         if not inplace:
@@ -509,7 +509,7 @@ class Base(HeaderBase):
             new object if ``inplace=False``, otherwise ``self``
 
         Raises:
-            ValueError: if level and dtypes of table indices do not match
+            ValueError: if level and dtypes of index does not match table index
 
         """
         if not inplace:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -635,7 +635,7 @@ class Base(HeaderBase):
             ValueError: if a missing scheme or rater cannot be copied
                 because a different object with the same ID exists
             ValueError: if values in same position overlap
-            ValueError: if index is not conform to table index
+            ValueError: if level and dtypes of table indices do not match
 
         """
         if self.db is None:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1426,8 +1426,7 @@ def test_type():
 def test_update(table, overwrite, others):
     df = table.get()
     table.update(others, overwrite=overwrite)
-    if isinstance(others, audformat.Table):
-        others = [others]
+    others = audeer.to_list(others)
     df = audformat.utils.concat(
         [df] + [other.df for other in others],
         overwrite=overwrite,


### PR DESCRIPTION
Implements `update()` for `MiscTable` by moving the method to `Base`

![image](https://user-images.githubusercontent.com/10383417/181767380-a927d226-629d-4cb1-8086-34ea9dfa67ab.png)

In addition changes the description of errors in `drop_index()`, `pick_index()` and `extend_index()` to:

![image](https://user-images.githubusercontent.com/10383417/181768420-baa31710-84cc-4cd2-950d-6271b7b23327.png)

