### PR TITLE
DOC: add links to usage section in API docs

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -156,7 +156,8 @@ class Column(HeaderBase):
             index: index conform to
                 :ref:`table specifications <data-tables:Tables>`
             copy: return a copy of the labels
-            map: map scheme or scheme field to column values.
+            map: :ref:`map scheme or scheme field to column values
+                <map-scheme-labels>`.
                 For example if your column holds speaker IDs and is
                 assigned to a scheme that contains a dict mapping
                 speaker IDs to age entries, ``map='age'``

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -47,6 +47,10 @@ class Database(HeaderBase):
     In addition, it links to a number of tables
     listing files and labels.
 
+    For a start
+    see how to :ref:`create a database <create-a-database>`
+    and inspect the :ref:`example of the emodb database <emodb-example>`.
+
     Args:
         name: name of database
         source: data source (e.g. link to website)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -620,7 +620,8 @@ class Database(HeaderBase):
     ) -> 'Database':
         r"""Update database with other database(s).
 
-        In order to update a database, *license* and *usage* have to match.
+        In order to :ref:`update a database <update-a-database>`,
+        *license* and *usage* have to match.
         *Media*, *raters*, *schemes* and *splits* that are not part of
         the database yet are added. Other fields will be updated by
         applying the following rules:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -65,7 +65,8 @@ class Base(HeaderBase):
     def __add__(self, other: typing.Self) -> typing.Self:
         r"""Create new table by combining two tables.
 
-        The new table contains index and columns of both tables.
+        The new :ref:`combined table <combine-tables>`
+        contains index and columns of both tables.
         Missing values will be set to ``NaN``.
 
         If table is conform to
@@ -1309,7 +1310,9 @@ class Table(Base):
     ) -> Table:
         r"""Update table with other table(s).
 
-        Table which calls ``update()`` must be assigned to a database.
+        Table which calls ``update()``
+        to :ref:`combine tables <combine-tables>`
+        must be assigned to a database.
         For all tables media and split must match.
 
         Columns that are not yet part of the table will be added and

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -339,7 +339,8 @@ class Base(HeaderBase):
         use ``index`` to get a subset.
 
         Examples are provided with the
-        :ref:`table specifications <data-tables:Tables>`.
+        :ref:`table specifications <data-tables:Tables>`,
+        and for ``map`` in :ref:`map-scheme-labels`.
 
         Args:
             index: index
@@ -1199,7 +1200,8 @@ class Table(Base):
             index: index conform to
                 :ref:`table specifications <data-tables:Tables>`
             copy: return a copy of the labels
-            map: map scheme or scheme fields to column values.
+            map: :ref:`map scheme or scheme fields to column values
+                <map-scheme-labels>`.
                 For example if your table holds a column ``speaker`` with
                 speaker IDs, which is assigned to a scheme that contains a
                 dict mapping speaker IDs to age and gender entries,

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -1,3 +1,5 @@
+.. _combine-tables:
+
 Combine tables
 ==============
 

--- a/docs/create-database.rst
+++ b/docs/create-database.rst
@@ -1,3 +1,5 @@
+.. _create-a-database:
+
 Create a database
 =================
 

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -1,3 +1,5 @@
+.. _emodb-example:
+
 Emodb example
 =============
 

--- a/docs/update-database.rst
+++ b/docs/update-database.rst
@@ -1,3 +1,5 @@
+.. _update-a-database:
+
 Update a database
 =================
 


### PR DESCRIPTION
Closes #81 

This adds links to

* https://audeering.github.io/audformat/map-scheme.html for `Table.get()` and `Column.get()`
![image](https://user-images.githubusercontent.com/173624/181743839-afb62505-ff34-4983-877a-eaa58f579694.png)
![image](https://user-images.githubusercontent.com/173624/181744072-3e1ede1f-8ddc-4b59-b635-3d9234ae950a.png)
* https://audeering.github.io/audformat/combine-tables.html to `Table.__add__()` and `Table.update()`
![image](https://user-images.githubusercontent.com/173624/181742672-29408e82-2df9-464d-9815-f93f63b43056.png)
![image](https://user-images.githubusercontent.com/173624/181743334-d5c8dfb8-b85a-4869-bdca-c913d3f4c23d.png)
* https://audeering.github.io/audformat/update-database.html to `Database.update()` 
![image](https://user-images.githubusercontent.com/173624/181742085-13eda2b7-dd95-469c-ab88-4847904dde76.png)
* https://audeering.github.io/audformat/create-database.html and https://audeering.github.io/audformat/emodb-example.html to `Database`
![image](https://user-images.githubusercontent.com/173624/181739546-46371320-1cf5-47c0-a7b3-a5173fba7e3d.png)


