### PR TITLE
TST: [pick|extend|drop]_index() should preserve order

### DIFF
--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -937,6 +937,37 @@ def test_drop_and_pick_index():
         pytest.DB[table_id].pick_index(index).get()
 
 
+def test_drop_extend_and_pick_index_order():
+
+    # Ensure order of index is preserved.
+    index = pd.Index([4, 3, 2, 1], name='idx')
+    table = audformat.MiscTable(index)
+    # pick
+    new_table = table.pick_index(
+        pd.Index([1, 2], name='idx')
+    )
+    pd.testing.assert_index_equal(
+        new_table.index,
+        pd.Index([2, 1], dtype='Int64', name='idx'),
+    )
+    # extend
+    new_table = table.extend_index(
+        pd.Index([5], name='idx')
+    )
+    pd.testing.assert_index_equal(
+        new_table.index,
+        pd.Index([4, 3, 2, 1, 5], dtype='Int64', name='idx'),
+    )
+    # drop
+    new_table = table.drop_index(
+        pd.Index([1, 2], name='idx')
+    )
+    pd.testing.assert_index_equal(
+        new_table.index,
+        pd.Index([4, 3], dtype='Int64', name='idx'),
+    )
+
+
 def test_extend_index():
 
     db = audformat.testing.create_db(minimal=True)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -547,6 +547,29 @@ def test_drop_and_pick_index():
         pytest.DB['files'].pick_index(index).get()
 
 
+def test_drop_and_pick_index_order():
+
+    # Ensure order of index is preserved.
+    # This is affected by utils.intersect()
+    # and utils.symmetric_difference()
+    index = audformat.filewise_index(['f4', 'f3', 'f2', 'f1'])
+    table = audformat.Table(index)
+    new_table = table.pick_index(
+        audformat.filewise_index(['f1', 'f2'])
+    )
+    assert pd.testing.assert_index_equal(
+        new_table.index,
+        audformat.filewise_index(['f2', 'f1']),
+    )
+    new_table = table.drop_index(
+        audformat.filewise_index(['f1', 'f2'])
+    )
+    assert pd.testing.assert_index_equal(
+        new_table.index,
+        audformat.filewise_index(['f4', 'f3']),
+    )
+
+
 @pytest.mark.parametrize(
     'files',
     [

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -557,14 +557,14 @@ def test_drop_and_pick_index_order():
     new_table = table.pick_index(
         audformat.filewise_index(['f1', 'f2'])
     )
-    assert pd.testing.assert_index_equal(
+    pd.testing.assert_index_equal(
         new_table.index,
         audformat.filewise_index(['f2', 'f1']),
     )
     new_table = table.drop_index(
         audformat.filewise_index(['f1', 'f2'])
     )
-    assert pd.testing.assert_index_equal(
+    pd.testing.assert_index_equal(
         new_table.index,
         audformat.filewise_index(['f4', 'f3']),
     )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -547,13 +547,12 @@ def test_drop_and_pick_index():
         pytest.DB['files'].pick_index(index).get()
 
 
-def test_drop_and_pick_index_order():
+def test_drop_extend_and_pick_index_order():
 
     # Ensure order of index is preserved.
-    # This is affected by utils.intersect()
-    # and utils.symmetric_difference()
     index = audformat.filewise_index(['f4', 'f3', 'f2', 'f1'])
     table = audformat.Table(index)
+    # pick
     new_table = table.pick_index(
         audformat.filewise_index(['f1', 'f2'])
     )
@@ -561,6 +560,15 @@ def test_drop_and_pick_index_order():
         new_table.index,
         audformat.filewise_index(['f2', 'f1']),
     )
+    # extend
+    new_table = table.extend_index(
+        audformat.filewise_index('f5')
+    )
+    pd.testing.assert_index_equal(
+        new_table.index,
+        audformat.filewise_index(['f4', 'f3', 'f2', 'f1', 'f5']),
+    )
+    # drop
     new_table = table.drop_index(
         audformat.filewise_index(['f1', 'f2'])
     )


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/248

This adds tests preserving the order of the original table index by `drop_index()`, `extend_index()` and `pick_index()`
for `audformat.Table` and `audformat.MiscTable`.