### PR TITLE
TST: require flake8<5.0.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,6 @@
 audiofile >=1.1.0
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus


### PR DESCRIPTION
Fix tests by requireing `flake8<5.0.0` until https://github.com/tholo/pytest-flake8/issues/87 is fixed.