### PR TITLE
Fix and speedup utils.symmetric_difference()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1274,22 +1274,11 @@ def symmetric_difference(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    def intersect2(obj1, obj2):
-        return [o for o in obj1 if o in obj2]
-
-    def union2(obj1, obj2):
-        if len(obj1) > len(obj2):
-            return obj1 + [o for o in obj2 if o not in obj1]
-        else:
-            return [o for o in obj1 if o not in obj2] + obj2
-
     index = list(objs[0])
     for obj in objs[1:]:
-        obj = list(obj)
-        index = [
-            idx for idx in union2(index, obj)
-            if idx not in intersect2(index, obj)
-        ]
+        index += list(obj)
+        counting = collections.Counter(index)
+        index = [idx for idx, count in counting.items() if count == 1]
 
     index = _alike_index(objs[0], index)
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1274,13 +1274,24 @@ def symmetric_difference(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    index = objs[0]
+    def intersect2(obj1, obj2):
+        return [o for o in obj1 if o in obj2]
+
+    def union2(obj1, obj2):
+        if len(obj1) > len(obj2):
+            return obj1 + [o for o in obj2 if o not in obj1]
+        else:
+            return [o for o in obj1 if o not in obj2] + obj2
+
+    index = list(objs[0])
     for obj in objs[1:]:
+        obj = list(obj)
         index = [
-            idx for idx in union([index, obj])
-            if idx not in intersect([index, obj])
+            idx for idx in union2(index, obj)
+            if idx not in intersect2(index, obj)
         ]
-        index = _alike_index(objs[0], index)
+
+    index = _alike_index(objs[0], index)
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1274,10 +1274,13 @@ def symmetric_difference(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    index = audeer.flatten_list([list(obj) for obj in objs])
-    counting = collections.Counter(index)
-    index = [idx for idx, count in counting.items() if count == 1]
-    index = _alike_index(objs[0], index)
+    index = objs[0]
+    for obj in objs[1:]:
+        index = [
+            idx for idx in union([index, obj])
+            if idx not in intersect([index, obj])
+        ]
+        index = _alike_index(objs[0], index)
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1196,7 +1196,7 @@ def symmetric_difference(
     depends on the order of ``objs``.
     The dtype of the resulting index
     is identical to the dtype of the first object.
-    If you require :func:`audformat.utils.intersect`
+    If you require :func:`audformat.utils.symmetric_difference`
     to be commutative_,
     you have to sort its output.
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1,3 +1,4 @@
+import collections
 import errno
 import os
 import re
@@ -1209,7 +1210,7 @@ def symmetric_difference(
         Int64Index([1, 2, 3], dtype='int64', name='idx')
         >>> symmetric_difference(
         ...     [
-        ...         pd.Index([0, 1], name='idx'),
+        ...         pd.Index([0, 1], dtype='Int64', name='idx'),
         ...         pd.Index([1, 2], dtype='Int64', name='idx'),
         ...     ]
         ... )
@@ -1273,11 +1274,10 @@ def symmetric_difference(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    index = union(objs)
-    count = np.zeros(len(index))
-    for obj in objs:
-        count += index.isin(obj)
-    index = index[count == 1]
+    index = audeer.flatten_list([list(obj) for obj in objs])
+    counting = collections.Counter(index)
+    index = [idx for idx, count in counting.items() if count == 1]
+    index = _alike_index(objs[0], index)
 
     return index
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1192,6 +1192,16 @@ def symmetric_difference(
     the result is a
     :class:`pandas.Index`.
 
+    The order of the resulting index
+    depends on the order of ``objs``.
+    The dtype of the resulting index
+    is identical to the dtype of the first object.
+    If you require :func:`audformat.utils.intersect`
+    to be commutative_,
+    you have to sort its output.
+
+    .. _commutative: https://en.wikipedia.org/wiki/Commutative_property
+
     Args:
         objs: index objects
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2411,6 +2411,20 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
         ),
         (
             [
+                pd.Index([0, 1], dtype='int64', name='idx'),
+                pd.Index([1, 2], dtype='Int64', name='idx'),
+            ],
+            pd.Index([0, 2], dtype='int64', name='idx'),
+        ),
+        (
+            [
+                pd.Index([1, 2], dtype='Int64', name='idx'),
+                pd.Index([0, 1], dtype='int64', name='idx'),
+            ],
+            pd.Index([2, 0], dtype='Int64', name='idx'),
+        ),
+        (
+            [
                 pd.Index([0, 1], name='idx'),
                 pd.MultiIndex.from_arrays([[1, 2]], names=['idx']),
             ],
@@ -2454,12 +2468,6 @@ def test_symmetric_difference(objs, expected):
         audformat.utils.symmetric_difference(objs),
         expected,
     )
-    expected = expected.sortlevel()[0]
-    for permuted_objs in itertools.permutations(objs):
-        pd.testing.assert_index_equal(
-            audformat.utils.symmetric_difference(permuted_objs).sortlevel()[0],
-            expected,
-        )
     # Ensure (A Δ B) Δ C = A Δ (B Δ C)
     if len(objs) > 2:
         pd.testing.assert_index_equal(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2251,7 +2251,15 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
                 audformat.filewise_index(['f1', 'f2']),
                 audformat.filewise_index(['f2', 'f3']),
             ],
-            audformat.filewise_index('f3'),
+            audformat.filewise_index(['f2', 'f3']),
+        ),
+        (
+            [
+                audformat.filewise_index(['f2', 'f3']),
+                audformat.filewise_index(['f1', 'f2']),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(['f3', 'f2']),
         ),
         (
             [
@@ -2294,7 +2302,7 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
                 audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
                 audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
             ],
-            audformat.segmented_index('f3', 0, 1),
+            audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
         ),
         (
             [
@@ -2302,11 +2310,7 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
                 audformat.segmented_index(['f2', 'f1'], [0, 0], [1, 1]),
                 audformat.segmented_index(['f2', 'f3'], [1, 1], [2, 2]),
             ],
-            audformat.segmented_index(
-                ['f2', 'f3'],
-                [1, 1],
-                [2, 2],
-            ),
+            audformat.segmented_index(['f2', 'f3'], [1, 1], [2, 2]),
         ),
         (
             [
@@ -2333,6 +2337,18 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
             [
                 audformat.segmented_index(['f1', 'f2'], [0, 0], [1, 1]),
                 audformat.segmented_index(['f2', 'f3'], [0, 0], [1, 1]),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.segmented_index(
+                ['f1', 'f3', 'f1', 'f2'],
+                [0, 0, 0, 0],
+                [1, 1, pd.NaT, pd.NaT],
+            ),
+        ),
+        (
+            [
+                audformat.segmented_index(['f1', 'f2'], [0, 0], [1, pd.NaT]),
+                audformat.segmented_index(['f2', 'f3'], [0, 0], [pd.NaT, 1]),
                 audformat.filewise_index(['f1', 'f2']),
             ],
             audformat.segmented_index(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2388,7 +2388,7 @@ def test_to_segmented_index(obj, allow_nat, files_duration, root, expected):
         ),
         (
             [
-                pd.Index([0, 1], name='idx'),
+                pd.Index([0, 1], dtype='Int64', name='idx'),
                 pd.Index([1, 2], dtype='Int64', name='idx'),
             ],
             pd.Index([0, 2], dtype='Int64', name='idx'),


### PR DESCRIPTION
Closes #245

This fixes the results and tests for `audformat.utils.symmetric_difference()` for more than two objects,
and speeds up the implementation by basing it on `list` and `collections.Counter`.
It has the same speed as using `set`, but has the advantage of preserving the order.

**Benchmark results (code below)**

| Table type | Index samples | v0.14.3 | master | pull request |
| --- | --- | --- | --- | --- | 
| filewise | (100000, 500000, 100000) | - | 0.54 s  | 0.41 s |
| filewise | (100000, 500000, 10000) | - | 0.41 s  | 0.36 s |
| segmented | (100000, 500000, 100000) | - | 22.39 s | 8.55 s |
| segmented | (100000, 500000, 10000) | - | 19.74 s | 8.03 s |

![image](https://user-images.githubusercontent.com/173624/182375756-93e0c9b0-17cb-4218-9969-90e459466ddd.png)

---

Code for benchmark:

```python
import audformat
import numpy as np
import pandas as pd
import random
import time


random.seed(0)
samples = 100000


def main():
    nsamples = 100000
    repetitions = 10

    for description, samples in [
            (
                'same length',
                [nsamples, 5 * nsamples, nsamples],
            ),
            (
                '1/10 length',
                [nsamples, 5 * nsamples, int(nsamples / 10)],
            ),
    ]:  
        for index in [filewise, segmented]:
            times = []
            for _ in range(repetitions):
                objs = index(samples)
                times.append(measure(objs))
            print(
                f'Execution time {index.__name__} {description}: '
                f'{np.mean(times):.2f}s'
            )


def measure(objs):
    start = time.time()
    _ = audformat.utils.symmeric_difference(objs)
    end = time.time()
    return end - start


def filewise(samples):
    index1 = audformat.filewise_index([f"f{n}" for n in range(samples[0])])
    index2 = audformat.filewise_index([f"f{n}" for n in range(samples[1])])
    idx = [n for n in range(len(index2))]
    index3 = index2[random.sample(idx, k=samples[2])]
    return [index1, index2, index3]


def segmented(samples):
    index1 = audformat.segmented_index(
        [f"f{n}" for n in range(samples[0])],
        random.choices([0, 1, 2, 3], k=samples[0]),
        random.choices([4, 5, 6, pd.NaT], k=samples[0]),
    )
    index2 = audformat.segmented_index(
        [f"f{n}" for n in range(samples[1])],
        random.choices([0, 1, 2, 3], k=samples[1]),
        random.choices([4, 5, 6, pd.NaT], k=samples[1]),
    )
    idx = [n for n in range(len(index2))]
    index3 = index2[random.sample(idx, k=samples[2])]
    return [index1, index2, index3]


if __name__ == '__main__':
    main()
```