### PR TITLE
DOC: extend emodb example with misc table

### DIFF
--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -123,7 +123,6 @@ to the emotion table.
 .. jupyter-execute::
 
     import audformat
-    import audiofile as af
     import pandas as pd
 
     # Prepare functions for getting information from file names


### PR DESCRIPTION
This uses a misc table for the `speaker` scheme in the emodb example.
This allows us to use schemes for the column entries and it's also nice to have an example for the usage of a misc table as scheme.

![image](https://user-images.githubusercontent.com/173624/182550250-f0c92364-34f6-4c45-b8f2-74b10782db7e.png)

[...]

![image](https://user-images.githubusercontent.com/173624/182550306-8eb61120-3601-463e-be33-5372a9290349.png)

[...]

![image](https://user-images.githubusercontent.com/173624/182550402-72c54e68-0367-4481-9677-0384f1590c86.png)

[...]

![image](https://user-images.githubusercontent.com/173624/182550476-912d3e88-520b-4e24-aa16-a08531f5b099.png)
