### PR TITLE
Fix: change type hint of argument dtype in Scheme to str

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -71,7 +71,7 @@ class Scheme(common.HeaderBase):
         labels: [a, b, c]
         >>> Scheme(define.DataType.INTEGER)
         {dtype: int}
-        >>> Scheme(float, minimum=0, maximum=1)
+        >>> Scheme('float', minimum=0, maximum=1)
         {dtype: float, minimum: 0, maximum: 1}
         >>> # Use index of misc table as labels
         >>> import audformat
@@ -105,7 +105,7 @@ class Scheme(common.HeaderBase):
 
     def __init__(
             self,
-            dtype: typing.Union[typing.Type, define.DataType] = None,
+            dtype: str = None,
             *,
             labels: typing.Union[dict, list, str] = None,
             minimum: typing.Union[int, float] = None,


### PR DESCRIPTION
Closes #269 

![image](https://user-images.githubusercontent.com/10383417/182598004-93192a4e-0b0a-4098-b5db-9f691b239be6.png)
