### PR TITLE
TST: add additional tests for order to union()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2589,6 +2589,13 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
         ),
         (
             [
+                audformat.filewise_index(['f2', 'f1']),
+                audformat.filewise_index(['f1', 'f2']),
+            ],
+            audformat.filewise_index(['f2', 'f1']),
+        ),
+        (
+            [
                 audformat.filewise_index(['f1', 'f2']),
                 audformat.filewise_index(['f1', 'f2']),
                 audformat.filewise_index(['f2', 'f3']),
@@ -2750,6 +2757,13 @@ def test_to_filewise(output_folder, table_id, expected_file_names):
                 pd.Index([1, 2], dtype='Int64', name='idx'),
             ],
             pd.Index([0, 1, 2], dtype='Int64', name='idx'),
+        ),
+        (
+            [
+                pd.Index([1, 2], dtype='Int64', name='idx'),
+                pd.Index([0, 1], name='idx'),
+            ],
+            pd.Index([1, 2, 0], dtype='Int64', name='idx'),
         ),
         (
             [


### PR DESCRIPTION
This adds two additional tests:

* to check that the order of the index entries is given by the order of the input objs
* that the dtype of the output is independent of the order (in opposite to `intersect()` and `difference()`)