### PR TITLE
Forbid nesting of misc tables as scheme labels

### DIFF
--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -386,6 +386,16 @@ class Scheme(common.HeaderBase):
                     f"The table '{table_id}' used as scheme labels "
                     "needs to be a misc table."
                 )
+            for column in self._db.misc_tables[table_id].columns.values():
+                if isinstance(self._db.schemes[column.scheme_id].labels, str):
+                    raise ValueError(
+                        f"The misc table "
+                        f"'{table_id}' "
+                        f"cannot be used as scheme labels "
+                        f"when one of its columns is "
+                        f"assigned to a scheme that "
+                        f"uses labels from a misc table."
+                    )
             if self._db[table_id].index.nlevels > 1:
                 raise ValueError(
                     f"Index of misc table '{table_id}' used as scheme labels "

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -302,8 +302,9 @@ class Scheme(common.HeaderBase):
                 or the given table ID is not a misc table,
                 or its index is multi-dimensional,
                 or its index contains duplicates,
-                or the misc table has a column that is already assigned to
-                a scheme with labels from another misc table
+                or the misc table has a column
+                that is already assigned to a scheme
+                with labels from another misc table
 
         Example:
             >>> speaker = Scheme(

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -61,7 +61,9 @@ class Scheme(common.HeaderBase):
             or its index contains duplicates,
             or ``dtype`` does not match type of labels
             from misc table,
-            or ``dtype`` is set to ``bool``
+            or ``dtype`` is set to ``bool``,
+            or the misc table has a column that is already assigned to
+            a scheme with labels from another misc table
 
     Example:
         >>> Scheme()
@@ -298,7 +300,9 @@ class Scheme(common.HeaderBase):
                 but the corresponding misc table is not part of the database,
                 or the given table ID is not a misc table,
                 or its index is multi-dimensional,
-                or its index contains duplicates
+                or its index contains duplicates,
+                or the misc table has a column that is already assigned to
+                a scheme with labels from another misc table
 
         Example:
             >>> speaker = Scheme(
@@ -387,15 +391,17 @@ class Scheme(common.HeaderBase):
                     "needs to be a misc table."
                 )
             for column in self._db.misc_tables[table_id].columns.values():
-                if isinstance(self._db.schemes[column.scheme_id].labels, str):
-                    raise ValueError(
-                        f"The misc table "
-                        f"'{table_id}' "
-                        f"cannot be used as scheme labels "
-                        f"when one of its columns is "
-                        f"assigned to a scheme that "
-                        f"uses labels from a misc table."
-                    )
+                if column.scheme_id is not None:
+                    scheme = self._db.schemes[column.scheme_id]
+                    if isinstance(scheme.labels, str):
+                        raise ValueError(
+                            f"The misc table "
+                            f"'{table_id}' "
+                            f"cannot be used as scheme labels "
+                            f"when one of its columns is "
+                            f"assigned to a scheme that "
+                            f"uses labels from a misc table."
+                        )
             if self._db[table_id].index.nlevels > 1:
                 raise ValueError(
                     f"Index of misc table '{table_id}' used as scheme labels "

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -62,8 +62,9 @@ class Scheme(common.HeaderBase):
             or ``dtype`` does not match type of labels
             from misc table,
             or ``dtype`` is set to ``bool``,
-            or the misc table has a column that is already assigned to
-            a scheme with labels from another misc table
+            or the misc table has a column
+            that is already assigned to a scheme
+            with labels from another misc table
 
     Example:
         >>> Scheme()

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -393,7 +393,7 @@ class Scheme(common.HeaderBase):
             for column in self._db.misc_tables[table_id].columns.values():
                 if column.scheme_id is not None:
                     scheme = self._db.schemes[column.scheme_id]
-                    if isinstance(scheme.labels, str):
+                    if scheme.uses_table:
                         raise ValueError(
                             f"The misc table "
                             f"'{table_id}' "

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -137,10 +137,21 @@ class Base(HeaderBase):
             BadIdError: if a column with a ``scheme_id`` or ``rater_id`` is
                 added that does not exist
             ValueError: if column ID is not different from level names
+            ValueError: if the column is linked to a
+                :class:`audformat.Scheme`
+                that is using labels from a
+                :class:`audformat.MiscTable`,
+                but the table the columns is assigned to
+                is already used in this or another
+                :class:`audformat.Scheme`
 
         """
 
-        if column.scheme_id is not None and self.db is not None:
+        if (
+                column.scheme_id is not None
+                and self.db is not None
+                and column.scheme_id in self.db.schemes
+        ):
 
             # check if scheme uses
             # labels from a table

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -137,13 +137,10 @@ class Base(HeaderBase):
             BadIdError: if a column with a ``scheme_id`` or ``rater_id`` is
                 added that does not exist
             ValueError: if column ID is not different from level names
-            ValueError: if the column is linked to a
-                :class:`audformat.Scheme`
-                that is using labels from a
-                :class:`audformat.MiscTable`,
-                but the table the columns is assigned to
-                is already used in this or another
-                :class:`audformat.Scheme`
+            ValueError: if the column is linked to a scheme
+                that is using labels from a misc table,
+                but the misc table the column is assigned to
+                is already used by the same or another scheme
 
         """
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -139,6 +139,39 @@ class Base(HeaderBase):
             ValueError: if column ID is not different from level names
 
         """
+
+        if column.scheme_id is not None and self.db is not None:
+
+            # check if scheme uses
+            # labels from a table
+            labels = self.db.schemes[column.scheme_id].labels
+            if isinstance(labels, str):
+
+                # check if scheme uses
+                # labels from this table
+                if self._id == labels:
+                    raise ValueError(
+                        f"Scheme "
+                        f"'{column.scheme_id}' "
+                        f"uses misc table "
+                        f"'{self._id}' "
+                        f"as labels and cannot be used "
+                        f"with columns of the same table."
+                    )
+
+                # check if this table
+                # is already used with a scheme
+                for scheme_id, scheme in self.db.schemes.items():
+                    if self._id == scheme.labels:
+                        raise ValueError(
+                            f"Since the misc table "
+                            f"'{self._id}' "
+                            f"is used as labels in scheme "
+                            f"'{scheme_id}' "
+                            f"its columns cannot used with a scheme "
+                            f"that also uses labels from a misc table."
+                        )
+
         self.columns[column_id] = column
         return column
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -176,7 +176,7 @@ class Base(HeaderBase):
                             f"'{self._id}' "
                             f"is used as labels in scheme "
                             f"'{scheme_id}' "
-                            f"its columns cannot used with a scheme "
+                            f"its columns cannot be used with a scheme "
                             f"that also uses labels from a misc table."
                         )
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -152,12 +152,12 @@ class Base(HeaderBase):
 
             # check if scheme uses
             # labels from a table
-            labels = self.db.schemes[column.scheme_id].labels
-            if isinstance(labels, str):
+            scheme = self.db.schemes[column.scheme_id]
+            if scheme.uses_table:
 
                 # check if scheme uses
                 # labels from this table
-                if self._id == labels:
+                if self._id == scheme.labels:
                     raise ValueError(
                         f"Scheme "
                         f"'{column.scheme_id}' "
@@ -169,8 +169,8 @@ class Base(HeaderBase):
 
                 # check if this table
                 # is already used with a scheme
-                for scheme_id, scheme in self.db.schemes.items():
-                    if self._id == scheme.labels:
+                for scheme_id in self.db.schemes:
+                    if self._id == self.db.schemes[scheme_id].labels:
                         raise ValueError(
                             f"Since the misc table "
                             f"'{self._id}' "

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -226,7 +226,7 @@ def test_scheme_errors():
     error_msg = (
         "Since the misc table 'misc2' "
         "is used as labels in scheme 'scheme2' "
-        "its columns cannot used with a scheme "
+        "its columns cannot be used with a scheme "
         "that also uses labels from a misc table."
     )
     with pytest.raises(ValueError, match=error_msg):

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -478,3 +478,15 @@ def test_replace_labels_misc_table():
     )
     with pytest.raises(ValueError, match=error_msg):
         scheme.replace_labels('misc-non-existing')
+
+    # replace labels with a misc table that
+    # has a column that already links a misc table
+    scheme.replace_labels('labels')
+    db['labels-new']['column'] = audformat.Column(scheme_id='scheme')
+    error_msg = (
+        "The misc table 'labels-new' cannot be used as scheme labels "
+        "when one of its columns is assigned to a scheme "
+        "that uses labels from a misc table."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        scheme.replace_labels('labels-new')


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/258 

In https://github.com/audeering/audformat/issues/258 we decided that a `MiscTable` that is used in a scheme cannot have columns that are linked to a scheme, which is also using labels from a `MiscTable`.

1. A `Scheme` is created with labels from a `MiscTable`, but already has a column that links to another scheme with labels from a `MiscTable`:

   ![image](https://user-images.githubusercontent.com/10383417/182636103-5066c5e1-9b9b-4ffa-a1b5-73c34c9a057f.png)

2. Same as 1. but `MiscTable` is assigned via `Scheme.replace_labels()`:

   ![image](https://user-images.githubusercontent.com/10383417/182636482-499b6e47-0037-4898-b482-eb7fca3b4002.png)

3. We add a `Column` to a `MiscTable` that we link to a `Scheme` that is using labels either from the same or another table

    ![image](https://user-images.githubusercontent.com/10383417/182637536-33359630-0a76-474f-99b3-3599dc791ced.png)
