### PR TITLE
Join schemes in Database.update()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -755,6 +755,9 @@ class Database(HeaderBase):
                     self_labels = self.schemes[scheme_id].labels
 
                     # join labels from misc tables
+                    # by combining the index of all tables,
+                    # columns values will be updated
+                    # later when the tables are joined
                     if (
                         isinstance(other_labels, str)
                         or isinstance(self_labels, str)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -756,7 +756,7 @@ class Database(HeaderBase):
 
                     # join labels from misc tables
                     # by combining the index of all tables,
-                    # columns values will be updated
+                    # column values will be updated
                     # later when the tables are joined
                     if (
                         isinstance(other_labels, str)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -626,8 +626,11 @@ class Database(HeaderBase):
 
         In order to :ref:`update a database <update-a-database>`,
         *license* and *usage* have to match.
+        Labels and values of *schemes*
+        with the same ID are combined.
         *Media*, *raters*, *schemes* and *splits* that are not part of
-        the database yet are added. Other fields will be updated by
+        the database yet are added.
+        Other fields will be updated by
         applying the following rules:
 
         ============= =====================================
@@ -657,6 +660,8 @@ class Database(HeaderBase):
             ValueError: if database has different license or usage
             ValueError: if different media, rater, scheme or split with
                 same ID is found
+            ValueError: if schemes cannot be combined,
+                e.g. labels have different dtype
             ValueError: if tables cannot be combined
                 (e.g. values in same position overlap or
                 level and dtypes of table indices do not match)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -734,13 +734,69 @@ class Database(HeaderBase):
             assert_equal(other, 'license')
             assert_equal(other, 'usage')
 
-        # can only join databases with relatvie paths
+        # can only join databases with relative paths
         for database in [self] + others:
             if not database.is_portable:
                 raise RuntimeError(
                     f"You can only update with databases that are portable. "
                     f"The database '{database.name}' is not portable."
                 )
+
+        # join schemes with labels
+        for other in others:
+            for scheme_id in other.schemes:
+                if scheme_id in self.schemes:
+                    other_labels = other.schemes[scheme_id].labels
+                    self_labels = self.schemes[scheme_id].labels
+
+                    # join labels from misc tables
+                    if (
+                        isinstance(other_labels, str)
+                        or isinstance(self_labels, str)
+                    ):
+
+                        if (
+                            isinstance(other_labels, str)
+                            != isinstance(self_labels, str)
+                        ):
+                            raise ValueError(
+                                f"Cannot join scheme "
+                                f"'{scheme_id}' "
+                                f"when one is using a misc table "
+                                f"and the other is not."
+                            )
+
+                        if other_labels != self_labels:
+                            raise ValueError(
+                                f"Cannot join scheme "
+                                f"'{scheme_id}' "
+                                f"when using misc tables "
+                                f"with different IDs: "
+                                f"'{self_labels}' "
+                                f"!= "
+                                f"'{other_labels}'."
+                            )
+
+                        other_table = other[other_labels]
+                        self_table = self[self_labels]
+                        index = utils.union(
+                            [
+                                other_table.index,
+                                self_table.index,
+                            ],
+                        )
+                        other_table.extend_index(index, inplace=True)
+                        self_table.extend_index(index, inplace=True)
+                        # ensure same index order in both tables
+                        other_table._df = other_table.df.reindex(index)
+                        self_table._df = self_table.df.reindex(index)
+
+                    # join other labels
+                    elif (
+                        other_labels is not None
+                        and self_labels is not None
+                    ):
+                        utils.join_schemes([self, other], scheme_id)
 
         # join fields
         for other in others:
@@ -759,15 +815,8 @@ class Database(HeaderBase):
 
         # join tables
         for other in others:
-            # update misc tables first
-            # as they might be used in schemes
-            # linked by audformat tables
-            for misc_id, misc in other.misc_tables.items():
-                if misc_id in self.misc_tables:
-                    self[misc_id].update(misc, overwrite=overwrite)
-                else:
-                    self[misc_id] = misc.copy()
-            for table_id, table in other.tables.items():
+            for table_id in list(other.misc_tables) + list(other.tables):
+                table = other[table_id]
                 if table_id in self.tables:
                     self[table_id].update(table, overwrite=overwrite)
                 else:


### PR DESCRIPTION
Closes #61

`Database.update()` now automatically updates schemes if labels do not match. This also works for misc table schemes and in that case missing columns / values will be added. 

![image](https://user-images.githubusercontent.com/10383417/182856602-96099536-7c1a-4404-a9bb-2cf48c4d331d.png)
