### PR TITLE
Fix Database.load() for db with misc table as scheme

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1080,6 +1080,16 @@ class Database(HeaderBase):
                     db.schemes[scheme_id] = scheme
             for scheme_id, scheme in misc_table_schemes.items():
                 db.schemes[scheme_id] = scheme
+            # restore order of scheme IDs
+            order = list(header['schemes'])
+            db.schemes = HeaderDict(
+                sorted(
+                    db.schemes.items(),
+                    key=lambda item: order.index(item[0]),
+                ),
+                value_type=Scheme,
+                set_callback=db._set_scheme,
+            )
 
         if 'splits' in header and header['splits']:
             for split_id, split_d in header['splits'].items():

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1080,6 +1080,12 @@ class Database(HeaderBase):
                     db.schemes[scheme_id] = scheme
             for scheme_id, scheme in misc_table_schemes.items():
                 db.schemes[scheme_id] = scheme
+            # resort dict entries
+            db.schemes = HeaderDict(
+                sorted(db.schemes.items()),
+                value_type=Scheme,
+                set_callback=db._set_scheme,
+            )
 
         if 'splits' in header and header['splits']:
             for split_id, split_d in header['splits'].items():

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1080,12 +1080,6 @@ class Database(HeaderBase):
                     db.schemes[scheme_id] = scheme
             for scheme_id, scheme in misc_table_schemes.items():
                 db.schemes[scheme_id] = scheme
-            # resort dict entries
-            db.schemes = HeaderDict(
-                sorted(db.schemes.items()),
-                value_type=Scheme,
-                set_callback=db._set_scheme,
-            )
 
         if 'splits' in header and header['splits']:
             for split_id, split_d in header['splits'].items():

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1072,19 +1072,12 @@ class Database(HeaderBase):
                 # as they might be needed
                 # when loading a misc table
                 scheme = Scheme()
-                if (
-                        'labels' in scheme_d
-                        and isinstance(scheme_d['labels'], str)
-                ):
-                    misc_table_schemes[scheme_id] = scheme_d
+                scheme.from_dict(scheme_d)
+                if scheme.uses_table:
+                    misc_table_schemes[scheme_id] = scheme
                 else:
-                    scheme.from_dict(scheme_d)
                     db.schemes[scheme_id] = scheme
-            for scheme_id, scheme_d in misc_table_schemes.items():
-                scheme = Scheme(
-                    scheme_d['dtype'],
-                    labels=scheme_d['labels'],
-                )
+            for scheme_id, scheme in misc_table_schemes.items():
                 db.schemes[scheme_id] = scheme
 
         if 'splits' in header and header['splits']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1070,7 +1070,7 @@ class Database(HeaderBase):
             for scheme_id, scheme_d in header['schemes'].items():
                 # ensure to load first all non misc table schemes
                 # as they might be needed
-                # when checking the scheme
+                # when checking the column schemes
                 # of the underlying misc table
                 scheme = Scheme()
                 scheme.from_dict(scheme_d)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1070,7 +1070,8 @@ class Database(HeaderBase):
             for scheme_id, scheme_d in header['schemes'].items():
                 # ensure to load first all non misc table schemes
                 # as they might be needed
-                # when loading a misc table
+                # when checking the scheme
+                # of the underlying misc table
                 scheme = Scheme()
                 scheme.from_dict(scheme_d)
                 if scheme.uses_table:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -977,12 +977,12 @@ class Database(HeaderBase):
             params = []
             table_ids = []
 
-            if 'tables' in header and header['tables']:
-                for table_id in header['tables']:
-                    table_ids.append(table_id)
-
             if 'misc_tables' in header and header['misc_tables']:
                 for table_id in header['misc_tables']:
+                    table_ids.append(table_id)
+
+            if 'tables' in header and header['tables']:
+                for table_id in header['tables']:
                     table_ids.append(table_id)
 
             for table_id in table_ids:
@@ -1066,9 +1066,25 @@ class Database(HeaderBase):
                 db.raters[rater_id] = rater
 
         if 'schemes' in header and header['schemes']:
+            misc_table_schemes = {}
             for scheme_id, scheme_d in header['schemes'].items():
+                # ensure to load first all non misc table schemes
+                # as they might be needed
+                # when loading a misc table
                 scheme = Scheme()
-                scheme.from_dict(scheme_d)
+                if (
+                        'labels' in scheme_d
+                        and isinstance(scheme_d['labels'], str)
+                ):
+                    misc_table_schemes[scheme_id] = scheme_d
+                else:
+                    scheme.from_dict(scheme_d)
+                    db.schemes[scheme_id] = scheme
+            for scheme_id, scheme_d in misc_table_schemes.items():
+                scheme = Scheme(
+                    scheme_d['dtype'],
+                    labels=scheme_d['labels'],
+                )
                 db.schemes[scheme_id] = scheme
 
         if 'splits' in header and header['splits']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -977,12 +977,12 @@ class Database(HeaderBase):
             params = []
             table_ids = []
 
-            if 'misc_tables' in header and header['misc_tables']:
-                for table_id in header['misc_tables']:
-                    table_ids.append(table_id)
-
             if 'tables' in header and header['tables']:
                 for table_id in header['tables']:
+                    table_ids.append(table_id)
+
+            if 'misc_tables' in header and header['misc_tables']:
+                for table_id in header['misc_tables']:
                     table_ids.append(table_id)
 
             for table_id in table_ids:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -419,6 +419,7 @@ def test_load(tmpdir):
     # Test loading a database containg a misc table as scheme,
     # see https://github.com/audeering/audformat/issues/294
     db = audformat.testing.create_db(minimal=True)
+    db.schemes['scheme3'] = audformat.Scheme('str')
     db.schemes['scheme1'] = audformat.Scheme(
         labels=['some', 'test', 'labels']
     )
@@ -433,9 +434,12 @@ def test_load(tmpdir):
         labels='misc-in-scheme',
     )
     db.schemes['scheme2'] = audformat.Scheme('float')
+    # Order of schemes should be order of assigment
+    assert list(db.schemes) == ['scheme3', 'scheme1', 'misc', 'scheme2']
     db.save(tmpdir)
     db = audformat.Database.load(tmpdir)
-    assert list(db.schemes) == ['scheme1', 'misc', 'scheme2']
+    # After loading from disc, order should be alphabetical
+    assert list(db.schemes) == ['misc', 'scheme1', 'scheme2', 'scheme3']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -419,22 +419,23 @@ def test_load(tmpdir):
     # Test loading a database containg a misc table as scheme,
     # see https://github.com/audeering/audformat/issues/294
     db = audformat.testing.create_db(minimal=True)
-    db.schemes['scheme'] = audformat.Scheme(
+    db.schemes['scheme1'] = audformat.Scheme(
         labels=['some', 'test', 'labels']
     )
     audformat.testing.add_misc_table(
         db,
         'misc-in-scheme',
         pd.Index([0, 1, 2], dtype='Int64', name='idx'),
-        columns={'emotion': ('scheme', None)}
+        columns={'emotion': ('scheme1', None)}
     )
     db.schemes['misc'] = audformat.Scheme(
         'int',
         labels='misc-in-scheme',
     )
+    db.schemes['scheme2'] = audformat.Scheme('float')
     db.save(tmpdir)
     db = audformat.Database.load(tmpdir)
-    assert list(db.schemes) == ['scheme', 'misc']
+    assert list(db.schemes) == ['scheme1', 'misc', 'scheme2']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -434,6 +434,7 @@ def test_load(tmpdir):
     )
     db.save(tmpdir)
     db = audformat.Database.load(tmpdir)
+    assert list(db.schemes) == ['misc', 'scheme']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -434,7 +434,7 @@ def test_load(tmpdir):
     )
     db.save(tmpdir)
     db = audformat.Database.load(tmpdir)
-    assert list(db.schemes) == ['misc', 'scheme']
+    assert list(db.schemes) == ['scheme', 'misc']
 
 
 @pytest.mark.parametrize(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -415,6 +415,27 @@ def test_license(license, license_url, expected_license, expected_url):
     assert db.license_url == expected_url
 
 
+def test_load(tmpdir):
+    # Test loading a database containg a misc table as scheme,
+    # see https://github.com/audeering/audformat/issues/294
+    db = audformat.testing.create_db(minimal=True)
+    db.schemes['scheme'] = audformat.Scheme(
+        labels=['some', 'test', 'labels']
+    )
+    audformat.testing.add_misc_table(
+        db,
+        'misc-in-scheme',
+        pd.Index([0, 1, 2], dtype='Int64', name='idx'),
+        columns={'emotion': ('scheme', None)}
+    )
+    db.schemes['misc'] = audformat.Scheme(
+        'int',
+        labels='misc-in-scheme',
+    )
+    db.save(tmpdir)
+    db = audformat.Database.load(tmpdir)
+
+
 @pytest.mark.parametrize(
     'num_workers',
     [


### PR DESCRIPTION
Closes #294 

Ensures to first assign schemes that are not using a misc table to the database during loading as `Scheme._check_labels()` need those assigned to the database when checking schemes of a misc table used as a scheme.