### PR TITLE
HeaderDict: properly maintain sorted order 

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -40,6 +40,8 @@ class HeaderDict(OrderedDict):
         BadTypeError: if a value of an invalid type is added
 
     Example:
+        >>> HeaderDict()
+
         >>> d = HeaderDict()
         >>> d['b'] = 1
         >>> d['a'] = 0
@@ -82,6 +84,7 @@ class HeaderDict(OrderedDict):
         r"""Callback function when item is requested"""
         self.set_callback = set_callback
         r"""Callback function when item is added"""
+
         super().__init__(*args, **kwargs)
 
     def __getitem__(self, key):

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -85,17 +85,20 @@ class HeaderDict(OrderedDict):
             value = self.get_callback(key, value)
         return value
 
-    def items(self):
+    def __iter__(self):
         if self.sorted_iter:
-            return iter(sorted(super().items()))
+            return sorted(super().keys()).__iter__()
         else:
-            return super().items()
+            return super().__iter__()
 
-    def keys(self):
-        return iter([key for key, _ in self.items()])
+    def __repr__(self) -> str:
+        return self.dump()
 
-    def values(self):
-        return iter([value for _, value in self.items()])
+    def __reversed__(self):
+        if self.sorted_iter:
+            return sorted(super().keys()).__reversed__()
+        else:
+            return super().__reversed__()
 
     def dump(self) -> str:
         if not self:
@@ -109,8 +112,29 @@ class HeaderDict(OrderedDict):
                 ]
             )
 
-    def __repr__(self) -> str:
-        return self.dump()
+    def items(self):
+        if self.sorted_iter:
+            return iter(sorted(super().items()))
+        else:
+            return super().items()
+
+    def keys(self):
+        return iter([key for key, _ in self.items()])
+
+    def popitem(self, last: bool = True):
+        if len(self) > 0 and self.sorted_iter:
+            keys = list(self)
+            if last:
+                key = keys[-1]
+            else:
+                key = keys[0]
+            value = super().pop(key)
+            return key, value
+        else:
+            return super().popitem(last)
+
+    def values(self):
+        return iter([value for _, value in self.items()])
 
 
 class HeaderBase:

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -29,7 +29,8 @@ class HeaderDict(OrderedDict):
 
     Args:
         *args: default arguments
-        sorted_iter: if set, ``items()`` returns a sorted iterator
+        sort_by_key: if ``True`` maintain a sorted order,
+            otherwise order by assignment
         value_type: only accept values of this type
         get_callback: call this function when an item is requested
         set_callback: call this function when an item is added
@@ -39,8 +40,22 @@ class HeaderDict(OrderedDict):
         BadTypeError: if a value of an invalid type is added
 
     Example:
-        >>> HeaderDict()
-
+        >>> d = HeaderDict()
+        >>> d['b'] = 1
+        >>> d['a'] = 0
+        >>> d
+        a:
+          0
+        b:
+          1
+        >>> d = HeaderDict(sort_by_key=False)
+        >>> d['b'] = 1
+        >>> d['a'] = 0
+        >>> d
+        b:
+          1
+        a:
+          0
         >>> HeaderDict(
         ...     get_callback=lambda key, value: value + value,
         ...     set_callback=lambda key, value: value.upper(),
@@ -53,14 +68,14 @@ class HeaderDict(OrderedDict):
     def __init__(
             self,
             *args,
-            sorted_iter: bool = True,
+            sort_by_key: bool = True,
             value_type: type = None,
             get_callback: typing.Callable = None,
             set_callback: typing.Callable = None,
             **kwargs,
     ):
-        self.sorted_iter = sorted_iter
-        r"""Use sorted iterator"""
+        self.sort_by_key = sort_by_key
+        r"""Sort items by key"""
         self.value_type = value_type
         r"""Only accept values of this type"""
         self.get_callback = get_callback
@@ -68,14 +83,6 @@ class HeaderDict(OrderedDict):
         self.set_callback = set_callback
         r"""Callback function when item is added"""
         super().__init__(*args, **kwargs)
-
-    def __setitem__(self, key, value):
-        if self.set_callback is not None:
-            value = self.set_callback(key, value)
-        if self.value_type is not None:
-            if not isinstance(value, self.value_type):
-                raise BadTypeError(value, self.value_type)
-        super().__setitem__(key, value)
 
     def __getitem__(self, key):
         if key not in self:
@@ -86,7 +93,7 @@ class HeaderDict(OrderedDict):
         return value
 
     def __iter__(self):
-        if self.sorted_iter:
+        if self.sort_by_key:
             return sorted(super().keys()).__iter__()
         else:
             return super().__iter__()
@@ -95,10 +102,18 @@ class HeaderDict(OrderedDict):
         return self.dump()
 
     def __reversed__(self):
-        if self.sorted_iter:
+        if self.sort_by_key:
             return sorted(super().keys()).__reversed__()
         else:
             return super().__reversed__()
+
+    def __setitem__(self, key, value):
+        if self.set_callback is not None:
+            value = self.set_callback(key, value)
+        if self.value_type is not None:
+            if not isinstance(value, self.value_type):
+                raise BadTypeError(value, self.value_type)
+        super().__setitem__(key, value)
 
     def dump(self) -> str:
         if not self:
@@ -113,7 +128,7 @@ class HeaderDict(OrderedDict):
             )
 
     def items(self):
-        if self.sorted_iter:
+        if self.sort_by_key:
             return iter(sorted(super().items()))
         else:
             return super().items()
@@ -122,7 +137,7 @@ class HeaderDict(OrderedDict):
         return iter([key for key, _ in self.items()])
 
     def popitem(self, last: bool = True):
-        if len(self) > 0 and self.sorted_iter:
+        if len(self) > 0 and self.sort_by_key:
             keys = list(self)
             if last:
                 key = keys[-1]

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -91,6 +91,12 @@ class HeaderDict(OrderedDict):
         else:
             return super().items()
 
+    def keys(self):
+        return iter([key for key, _ in self.items()])
+
+    def values(self):
+        return iter([value for _, value in self.items()])
+
     def dump(self) -> str:
         if not self:
             return ''

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -52,7 +52,7 @@ class Base(HeaderBase):
         self.media_id = media_id
         r"""Media ID"""
         self.columns = HeaderDict(
-            sorted_iter=False,
+            sort_by_key=False,
             value_type=Column,
             set_callback=self._set_column,
         )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -91,14 +91,32 @@ def test_items_order():
 
     d = audformat.core.common.HeaderDict(sorted_iter=False)
     d['b'] = 1
+    d['c'] = 2
     d['a'] = 0
-    assert dict(d.items()) == {'b': 1, 'a': 0}
-    assert list(d.keys()) == ['b', 'a']
-    assert list(d.values()) == [1, 0]
+    assert dict(d.items()) == {'b': 1, 'c': 2, 'a': 0}
+    assert list(d.keys()) == ['b', 'c', 'a']
+    assert list(d.values()) == [1, 2, 0]
+    assert list(d) == ['b', 'c', 'a']
+    for item, expected in zip(d, ['b', 'c', 'a']):
+        assert item == expected
+    for item, expected in zip(reversed(d), ['a', 'c', 'b']):
+        assert item == expected
+    assert d.popitem(last=True) == ('a', 0)
+    assert d.popitem(last=False) == ('b', 1)
+    assert list(d) == ['c']
 
     d = audformat.core.common.HeaderDict(sorted_iter=True)
     d['b'] = 1
+    d['c'] = 2
     d['a'] = 0
-    assert dict(d.items()) == {'a': 0, 'b': 1}
-    assert list(d.keys()) == ['a', 'b']
-    assert list(d.values()) == [0, 1]
+    assert dict(d.items()) == {'a': 0, 'b': 1, 'c': 2}
+    assert list(d.keys()) == ['a', 'b', 'c']
+    assert list(d.values()) == [0, 1, 2]
+    assert list(d) == ['a', 'b', 'c']
+    for item, expected in zip(d, ['a', 'b', 'c']):
+        assert item == expected
+    for item, expected in zip(reversed(d), ['c', 'b', 'a']):
+        assert item == expected
+    assert d.popitem(last=True) == ('c', 2)
+    assert d.popitem(last=False) == ('a', 0)
+    assert list(d) == ['b']

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -89,7 +89,7 @@ def test_to_pandas_dtype(dtype, expected):
 
 def test_items_order():
 
-    d = audformat.core.common.HeaderDict(sorted_iter=False)
+    d = audformat.core.common.HeaderDict(sort_by_key=False)
     d['b'] = 1
     d['c'] = 2
     d['a'] = 0
@@ -105,7 +105,7 @@ def test_items_order():
     assert d.popitem(last=False) == ('b', 1)
     assert list(d) == ['c']
 
-    d = audformat.core.common.HeaderDict(sorted_iter=True)
+    d = audformat.core.common.HeaderDict(sort_by_key=True)
     d['b'] = 1
     d['c'] = 2
     d['a'] = 0

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -85,3 +85,20 @@ def test_to_audformat_dtype(dtype, expected):
 def test_to_pandas_dtype(dtype, expected):
     dtype = audformat.core.common.to_pandas_dtype(dtype)
     assert dtype == expected
+
+
+def test_items_order():
+
+    d = audformat.core.common.HeaderDict(sorted_iter=False)
+    d['b'] = 1
+    d['a'] = 0
+    assert dict(d.items()) == {'b': 1, 'a': 0}
+    assert list(d.keys()) == ['b', 'a']
+    assert list(d.values()) == [1, 0]
+
+    d = audformat.core.common.HeaderDict(sorted_iter=True)
+    d['b'] = 1
+    d['a'] = 0
+    assert dict(d.items()) == {'a': 0, 'b': 1}
+    assert list(d.keys()) == ['a', 'b']
+    assert list(d.values()) == [0, 1]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -434,11 +434,9 @@ def test_load(tmpdir):
         labels='misc-in-scheme',
     )
     db.schemes['scheme2'] = audformat.Scheme('float')
-    # Order of schemes should be order of assigment
-    assert list(db.schemes) == ['scheme3', 'scheme1', 'misc', 'scheme2']
+    assert list(db.schemes) == ['misc', 'scheme1', 'scheme2', 'scheme3']
     db.save(tmpdir)
     db = audformat.Database.load(tmpdir)
-    # After loading from disc, order should be alphabetical
     assert list(db.schemes) == ['misc', 'scheme1', 'scheme2', 'scheme3']
 
 


### PR DESCRIPTION
Closes #296 

Applies the following changes to `HeaderDict`:

* rename argument `sort_iter` to `sort_by_key`
* in addition to `iter()` also implement `keys()`, `values()`, `__iter__()`, `__reversed__()` and `popitem()` to properly maintain sorted order