### PR TITLE
Fix minimum/maximum scheme checking for None

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -42,6 +42,10 @@ def assert_values(
                 values = values.values
             if isinstance(values, np.ndarray):
                 if scheme.is_numeric:
+                    # Support type object with None entries,
+                    # which need to be converted to NaN
+                    # to support min/max
+                    values = values.astype(float)
                     values = [
                         np.nanmin(values),
                         np.nanmax(values),

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -78,6 +78,32 @@ def test_scheme_assign_values():
             np.array([1.0, np.NaN, 3.0]),
             marks=pytest.mark.xfail(raises=ValueError),
         ),
+        (
+            audformat.Scheme(
+                audformat.define.DataType.FLOAT,
+                minimum=1.0,
+                maximum=2.0,
+            ),
+            np.array([1.0, None, 2.0]),
+        ),
+        pytest.param(  # minimum too low
+            audformat.Scheme(
+                audformat.define.DataType.FLOAT,
+                minimum=1.0,
+                maximum=2.0,
+            ),
+            np.array([0.0, None, 2.0]),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # maximum too high
+            audformat.Scheme(
+                audformat.define.DataType.FLOAT,
+                minimum=1.0,
+                maximum=2.0,
+            ),
+            np.array([1.0, None, 3.0]),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_scheme_minimum_maximum(scheme, values):
@@ -100,6 +126,7 @@ def test_scheme_minimum_maximum(scheme, values):
         values,
         audformat.filewise_index(table.files),
         name=column_id,
+        dtype='float64',
     )
     column.set(values)
     pd.testing.assert_series_equal(column.get(), expected_series)


### PR DESCRIPTION
Closes #307 

When a user tries to assign `np.array([1.0, None])` to a float scheme it will be automatically converted to float:

```python
import audformat.testing
import numpy as np


db = audformat.testing.create_db(minimal=True)
audformat.testing.add_table(db, 'table', 'filewise', num_files=2)
db.schemes['scheme'] = audformat.Scheme('float')
db['table']['column'] = audformat.Column(scheme_id='scheme')
db['table']['column'].set(np.array([1.0, None]))
print(db['table']['column'].get())
```
returns
```
file
audio/001.wav    1.0
audio/002.wav    NaN
Name: column, dtype: float64
```

But if the scheme contains a minimum or maximum it fails as it needs to do the conversion first (see also https://github.com/audeering/audformat/pull/219) otherwise it fails as shown in #307.

This is fixed here by converting to float before looking for min and max in the array.