### PR TITLE
Show values not matching scheme in Column.set()

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -54,8 +54,9 @@ def assert_values(
         bad_values = [value for value in values if value not in scheme]
 
     if len(bad_values) > 0:
-        values = str(bad_values[:50])[1:-1]
-        if len(bad_values) > 50:
+        max_display = 10
+        values = str(bad_values[:max_display])[1:-1]
+        if len(bad_values) > max_display:
             values += ', ...'
         raise ValueError(
             f"Some value(s) do not match scheme\n{scheme}\n"

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -37,13 +37,12 @@ def test_scheme_assign_values():
     )
     with pytest.raises(ValueError, match=error_msg):
         db['table']['speaker'].set(bad_values)
-    bad_values = list(range(-51, 0))
+    bad_values = list(range(-11, 0))
     error_msg = re.escape(
         "Some value(s) do not match scheme\n"
         f"{db.schemes['age']}\n"
         "with scheme ID 'age':\n"
-        f"{str(bad_values[:50])[1:-1]}"
-        ', ...'
+        f"-11, -10, -9, -8, -7, -6, -5, -4, -3, -2, ..."
     )
     with pytest.raises(ValueError, match=error_msg):
         db['misc'].extend_index(

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -12,8 +14,9 @@ def test_scheme_assign_values():
     speakers = ['spk1', 'spk2', 'spk3']
     ages = [33, 44, 55]
     index = pd.Index(speakers, name='speaker', dtype='string')
+    db.schemes['age'] = audformat.Scheme('int', minimum=0)
     db['misc'] = audformat.MiscTable(index)
-    db['misc']['age'] = audformat.Column()
+    db['misc']['age'] = audformat.Column(scheme_id='age')
     db['misc']['age'].set(ages)
     db.schemes['scheme'] = audformat.Scheme(labels='misc', dtype='str')
     db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
@@ -23,6 +26,35 @@ def test_scheme_assign_values():
     assert list(db['table']['speaker'].get()) == speakers
     assert list(db['table']['speaker'].get(map='age')) == ages
     assert list(db['table'].get(map={'speaker': 'age'})['age']) == ages
+
+    # Set values not matching scheme
+    bad_values = ['spk4', 'spk5', 'spk6']
+    error_msg = re.escape(
+        "Some value(s) do not match scheme\n"
+        f"{db.schemes['scheme']}\n"
+        "with scheme ID 'scheme':\n"
+        "'spk4', 'spk5', 'spk6'"
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        db['table']['speaker'].set(bad_values)
+    bad_values = list(range(-51, 0))
+    error_msg = re.escape(
+        "Some value(s) do not match scheme\n"
+        f"{db.schemes['age']}\n"
+        "with scheme ID 'age':\n"
+        f"{str(bad_values[:50])[1:-1]}"
+        ', ...'
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        db['misc'].extend_index(
+            pd.Index(
+                [f'spk{n}' for n in range(4, 52)],
+                name='speaker',
+                dtype='string',
+            ),
+            inplace=True,
+        )
+        db['misc']['age'].set(bad_values)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #303.

When setting values to a column that do not match a scheme we did not list the wrong values before, this is now changed:

```python
import audformat

db = audformat.Database('db')
db.schemes['scheme'] = audformat.Scheme(labels=['a'])
db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
db['table']['column'] = audformat.Column(scheme_id='scheme')
db['table']['column'].set(['b', 'c'])
```
which returns
```
ValueError: Some value(s) do not match scheme
dtype: str
labels: [a]
with scheme ID 'scheme':
'b', 'c'
```

Only unique values are listed:

```python
db['table']['column'].set(['b', 'b'])
```
returns
```
ValueError: Some value(s) do not match scheme
dtype: str
labels: [a]
with scheme ID 'scheme':
'b'
```

If more than 50 values are affected, they are cut to 50 and `, ...` is added at the end of the error message.