### PR TITLE
Add audformat.Attachment

### DIFF
--- a/audformat/__init__.py
+++ b/audformat/__init__.py
@@ -1,6 +1,7 @@
 from audformat import define
 from audformat import errors
 from audformat import utils
+from audformat.core.attachment import Attachment
 from audformat.core.column import Column
 from audformat.core.database import Database
 from audformat.core.index import (

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -76,7 +76,7 @@ class Attachment(HeaderBase):
 
     def _check_path(
             self,
-            root: str,
+            root: typing.Optional[str],
     ):
         r"""Check if path exists and is not a symlink."""
         if root is None:

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -11,10 +11,14 @@ from audformat.core.common import (
 class Attachment(HeaderBase):
     r"""Database attachment.
 
-    Adds a file as attachment to a database.
+    Adds a file or folder
+    as attachment to a database.
+    If a folder is provided,
+    all of its sub-folders
+    and files are included.
 
     Args:
-        path: relative path to file
+        path: relative path to file or folder
         description: attachment description
         meta: additional meta fields
 
@@ -60,9 +64,9 @@ class Attachment(HeaderBase):
                 f"of attachment '{self._id}' "
                 "does not exist."
             )
-        if not os.path.isfile(audeer.path(root, self.path)):
-            raise FileNotFoundError(
+        if os.path.islink(os.path.join(root, self.path)):
+            raise RuntimeError(
                 f"The provided path '{self.path}' "
                 f"of attachment '{self._id}' "
-                "is not a file."
+                "is not allowed to be a symlink."
             )

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -19,8 +19,6 @@ class Attachment(HeaderBase):
         ValueError: if ``path`` is absolute
 
     Example:
-        >>> import audeer
-        >>> _ = audeer.touch('file.txt')
         >>> Attachment('file.txt', description='Attached file')
         {description: Attached file, path: file.txt}
 

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -2,7 +2,10 @@ import os
 
 import audeer
 
-from audformat.core.common import HeaderBase
+from audformat.core.common import (
+    HeaderBase,
+    is_relative_path,
+)
 
 
 class Attachment(HeaderBase):
@@ -33,14 +36,7 @@ class Attachment(HeaderBase):
     ):
         super().__init__(description=description, meta=meta)
 
-        if (
-                os.path.isabs(path)
-                or '\\' in path
-                or path.startswith('./')
-                or '/./' in path
-                or path.startswith('../')
-                or '/../' in path
-        ):
+        if not is_relative_path(path):
             raise ValueError(
                 f"The provided path '{path}' needs to be relative "
                 "and not contain '\\', '.', or '..'."

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -76,11 +76,9 @@ class Attachment(HeaderBase):
 
     def _check_path(
             self,
-            root: typing.Optional[str],
+            root: str,
     ):
         r"""Check if path exists and is not a symlink."""
-        if root is None:
-            return
         if not os.path.exists(audeer.path(root, self.path)):
             raise FileNotFoundError(
                 f"The provided path '{self.path}' "

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -17,6 +17,7 @@ class Attachment(HeaderBase):
 
     Raises:
         ValueError: if ``path`` is absolute
+            or contains ``\``, ``..`` or ``.``
 
     Example:
         >>> Attachment('file.txt', description='Attached file')
@@ -32,9 +33,17 @@ class Attachment(HeaderBase):
     ):
         super().__init__(description=description, meta=meta)
 
-        if os.path.isabs(path):
+        if (
+                os.path.isabs(path)
+                or '\\' in path
+                or path.startswith('./')
+                or '/./' in path
+                or path.startswith('../')
+                or '/../' in path
+        ):
             raise ValueError(
-                f"The provided path '{path}' needs to be relative."
+                f"The provided path '{path}' needs to be relative "
+                "and not contain '\\', '.', or '..'."
             )
 
         self._db = None

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -1,0 +1,65 @@
+import os
+
+import audeer
+
+from audformat.core.common import HeaderBase
+
+
+class Attachment(HeaderBase):
+    r"""Database attachment.
+
+    Adds a file as attachment to a database.
+
+    Args:
+        path: relative path to file
+        description: attachment description
+        meta: additional meta fields
+
+    Raises:
+        ValueError: if ``path`` is absolute
+
+    Example:
+        >>> import audeer
+        >>> _ = audeer.touch('file.txt')
+        >>> Attachment('file.txt', description='Attached file')
+        {description: Attached file, path: file.txt}
+
+    """
+    def __init__(
+            self,
+            path: str,
+            *,
+            description: str = None,
+            meta: dict = None,
+    ):
+        super().__init__(description=description, meta=meta)
+
+        if os.path.isabs(path):
+            raise ValueError(
+                f"The provided path '{path}' needs to be relative."
+            )
+
+        self._db = None
+        self._id = None
+
+        self.path = path
+        r"""Attachment path"""
+
+    def _check_path(
+            self,
+            root: str,
+    ):
+        if root is None:
+            return
+        if not os.path.exists(audeer.path(root, self.path)):
+            raise FileNotFoundError(
+                f"The provided path '{self.path}' "
+                f"of attachment '{self._id}' "
+                "does not exist."
+            )
+        if not os.path.isfile(audeer.path(root, self.path)):
+            raise FileNotFoundError(
+                f"The provided path '{self.path}' "
+                f"of attachment '{self._id}' "
+                "is not a file."
+            )

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import oyaml as yaml
 import typing
 import textwrap
@@ -308,6 +309,17 @@ def index_to_html(self):  # pragma: no cover
     df = self.to_frame()
     df = df.drop(columns=df.columns)
     return df.to_html()
+
+
+def is_relative_path(path):
+    return not (
+        os.path.isabs(path)
+        or '\\' in path
+        or path.startswith('./')
+        or '/./' in path
+        or path.startswith('../')
+        or '/../' in path
+    )
 
 
 def series_to_html(self):  # pragma: no cover

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1143,7 +1143,8 @@ class Database(HeaderBase):
     ) -> Attachment:
         attachment._db = self
         attachment._id = attachment_id
-        attachment._check_path(self.root)
+        if self.root is not None:
+            attachment._check_path(self.root)
         for other_id in list(self.attachments):
             attachment._check_overlap(self.attachments[other_id])
         return attachment

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -946,9 +946,9 @@ class Database(HeaderBase):
             database object
 
         Raises:
-            FileNotFoundError: if a file associated with an attachment
+            FileNotFoundError: if a file or folder
+                associated with an attachment
                 cannot be found
-                or is not a file
 
         """
         ext = '.yaml'

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -591,9 +591,6 @@ class Database(HeaderBase):
 
             # Check attachments exist
             for attachment_id in list(self.attachments):
-                print(
-                    f'{attachment_id}: {self.attachments[attachment_id].path}'
-                )
                 self.attachments[attachment_id]._check_path(root)
 
         self._name = name
@@ -905,12 +902,6 @@ class Database(HeaderBase):
             TableExistsError: if setting a miscellaneous table
                 when a filewise or segmented table with the same ID exists
                 (or vice versa)
-            FileNotFoundError: if a file or folder
-                associated with an attachment
-                cannot be found
-            RuntimeError: if a file or folder
-                associated with an attachment
-                is a symlink
 
         """
         if isinstance(table, MiscTable):
@@ -1153,6 +1144,8 @@ class Database(HeaderBase):
         attachment._db = self
         attachment._id = attachment_id
         attachment._check_path(self.root)
+        for other_id in list(self.attachments):
+            attachment._check_overlap(self.attachments[other_id])
         return attachment
 
     def _set_scheme(

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -19,6 +19,7 @@ from audformat.core import utils
 from audformat.core.attachment import Attachment
 from audformat.core.column import Column
 from audformat.core.common import (
+    is_relative_path,
     HeaderBase,
     HeaderDict,
 )
@@ -247,17 +248,7 @@ class Database(HeaderBase):
         """
         if len(self.files) == 0:
             return True
-        return not any(
-            (
-                os.path.isabs(f)
-                or '\\' in f
-                or f.startswith('./')
-                or '/./' in f
-                or f.startswith('../')
-                or '/../' in f
-            )
-            for f in self.files
-        )
+        return all(is_relative_path(f) for f in self.files)
 
     @property
     def root(self) -> typing.Optional[str]:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1046,7 +1046,7 @@ class Database(HeaderBase):
         if 'attachments' in header and header['attachments']:
             for attachment_id, attachment_d in header['attachments'].items():
                 attachment = Attachment(attachment_d['path'])
-                attachment = attachment.from_dict(attachment_d)
+                attachment.from_dict(attachment_d)
                 db.attachments[attachment_id] = attachment
 
         if 'media' in header and header['media']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -551,9 +551,12 @@ class Database(HeaderBase):
             verbose: show progress bar
 
         Raises:
-            FileNotFoundError: if a file associated with an attachment
+            FileNotFoundError: if a file or folder
+                associated with an attachment
                 cannot be found
-                or is not a file
+            RuntimeError: if a file or folder
+                associated with an attachment
+                is a symlink
 
         """
         root = audeer.mkdir(root)
@@ -588,6 +591,9 @@ class Database(HeaderBase):
 
             # Check attachments exist
             for attachment_id in list(self.attachments):
+                print(
+                    f'{attachment_id}: {self.attachments[attachment_id].path}'
+                )
                 self.attachments[attachment_id]._check_path(root)
 
         self._name = name
@@ -899,9 +905,12 @@ class Database(HeaderBase):
             TableExistsError: if setting a miscellaneous table
                 when a filewise or segmented table with the same ID exists
                 (or vice versa)
-            FileNotFoundError: if a file associated with an attachment
+            FileNotFoundError: if a file or folder
+                associated with an attachment
                 cannot be found
-                or is not a file
+            RuntimeError: if a file or folder
+                associated with an attachment
+                is a symlink
 
         """
         if isinstance(table, MiscTable):

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -194,6 +194,10 @@ def create_attachment_files(
 ):
     r"""Create attachment folders and files of a database.
 
+    If an attachment path contains a ``.``
+    it is considered to represent a file,
+    otherwise a directory.
+
     Args:
         db: a database
         root: root folder of database
@@ -202,8 +206,11 @@ def create_attachment_files(
     for attachment_id in list(db.attachments):
         path = audeer.path(root, db.attachments[attachment_id].path)
         if not os.path.exists(path):
-            audeer.mkdir(os.path.dirname(path))
-            audeer.touch(path)
+            if '.' in os.path.basename(path):
+                audeer.mkdir(os.path.dirname(path))
+                audeer.touch(path)
+            else:
+                audeer.mkdir(path)
 
 
 def create_audio_files(
@@ -335,7 +342,8 @@ def create_db(
     # Attachments #
     ###############
 
-    db.attachments['attachment'] = Attachment('extra/attachment.txt')
+    db.attachments['file'] = Attachment('extra/file.txt')
+    db.attachments['folder'] = Attachment('extra/folder')
 
     #########
     # Media #

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -194,7 +194,7 @@ def create_attachment_files(
 ):
     r"""Create attachment folders and files of a database.
 
-    If an attachment path contains a ``.``
+    If the basename of an attachment path contains a dot (``.``)
     it is considered to represent a file,
     otherwise a directory.
 

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -13,9 +13,11 @@ import warnings
 import numpy as np
 import pandas as pd
 
+import audeer
 import audiofile as af
 
 from audformat.core import define
+from audformat.core.attachment import Attachment
 from audformat.core.column import Column
 from audformat.core.database import Database
 from audformat.core.index import (
@@ -186,6 +188,24 @@ def add_table(
     return db[table_id]
 
 
+def create_attachment_files(
+        db: Database,
+        root: str,
+):
+    r"""Create attachment folders and files of a database.
+
+    Args:
+        db: a database
+        root: root folder of database
+
+    """
+    for attachment_id in list(db.attachments):
+        path = audeer.path(root, db.attachments[attachment_id].path)
+        if not os.path.exists(path):
+            audeer.mkdir(os.path.dirname(path))
+            audeer.touch(path)
+
+
 def create_audio_files(
         db: Database,
         root: str = None,
@@ -310,6 +330,12 @@ def create_db(
                 db[table_id][column_id] = Column(scheme_id=dtype)
             db[table_id].set(obj)
         return db
+
+    ###############
+    # Attachments #
+    ###############
+
+    db.attachments['attachment'] = Attachment('extra/attachment.txt')
 
     #########
     # Media #

--- a/audformat/testing/__init__.py
+++ b/audformat/testing/__init__.py
@@ -1,6 +1,7 @@
 from audformat.core.testing import (
-    create_db,
     add_misc_table,
     add_table,
+    create_attachment_files,
     create_audio_files,
+    create_db,
 )

--- a/docs/api-testing.rst
+++ b/docs/api-testing.rst
@@ -24,6 +24,11 @@ add_table
 
 .. autofunction:: add_table
 
+create_attachment_files
+-----------------------
+
+.. autofunction:: create_attachment_files
+
 create_audio_files
 ------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,6 +14,13 @@ assert_no_duplicates
 
 .. autofunction:: assert_no_duplicates
 
+Attachment
+----------
+
+.. autoclass:: Attachment
+    :members:
+    :inherited-members:
+
 Column
 ------
 

--- a/docs/data-header.rst
+++ b/docs/data-header.rst
@@ -79,7 +79,7 @@ This part of the header is represented by :class:`audformat.Attachment`.
 ==============  =========  ====================================================
 Field           Mandatory  Description
 ==============  =========  ====================================================
-path            yes        Relative path to attached file
+path            yes        Relative path to attached file/folder
 description                Description of rater
 *meta-key-1*               1st optional meta field
 ...                        ...

--- a/docs/data-header.rst
+++ b/docs/data-header.rst
@@ -34,6 +34,7 @@ usage           yes        What the database can be used for,
 description                Description of the database
 expires                    Until when we are allowed to use the data
 languages                  List of languages that appear in the media files
+attachments                Dictionary of attachment objects (see below)
 media                      Dictionary of media objects (see below)
 raters                     Dictionary of rater objects (see below)
 schemes                    Dictionary of scheme objects (see below)
@@ -68,6 +69,45 @@ audformat implementation
         usage=audformat.define.Usage.COMMERCIAL,
     )
     db
+
+
+Attachment
+----------
+
+This part of the header is represented by :class:`audformat.Attachment`.
+
+==============  =========  ====================================================
+Field           Mandatory  Description
+==============  =========  ====================================================
+path            yes        Relative path to attached file
+description                Description of rater
+*meta-key-1*               1st optional meta field
+...                        ...
+*meta-key-N*               Nth optional meta field
+==============  =========  ====================================================
+
+Minimal example
+^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    attachments:
+        attachmentid:
+            path: docs/setup.pdf
+
+audformat implementation
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. jupyter-execute::
+
+    # Create minimal Attachment
+    attachment = audformat.Attachment('docs/setup.pdf')
+    # Add Attachment to Database
+    db.attachments['attachmentid'] = attachment
+    # Access path of Attachment
+    db.attachments['attachmentid'].path
+    # Access attachments
+    db.attachments
 
 
 Rater

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
 
 pytest.DB = audformat.testing.create_db()
 pytest.DB_ROOT = os.path.join(pytest.ROOT, 'db')
+audformat.testing.create_attachment_files(pytest.DB, pytest.DB_ROOT)
 pytest.DB.save(pytest.DB_ROOT)
 
 pytest.FILE_DUR = pd.to_timedelta('1s')

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 
@@ -8,11 +9,22 @@ import audformat
 
 def test_attachment(tmpdir):
 
-    # Path needs to be relative
-    path = '/root/file.txt'
-    error_msg = f"The provided path '{path}' needs to be relative."
-    with pytest.raises(ValueError, match=error_msg):
-        audformat.Attachment(path)
+    # Path needs to be relative and not contain ., .., \
+    for path in [
+        '/root/file.txt',
+        './file.txt',
+        '../file.txt',
+        'doc/./file.txt',
+        'doc/../file.txt',
+        'doc/../../file.txt',
+        r'C:\\doc\file.txt',
+    ]:
+        error_msg = (
+            f"The provided path '{path}' needs to be relative "
+            "and not contain '\\', '.', or '..'."
+        )
+        with pytest.raises(ValueError, match=re.escape(error_msg)):
+            audformat.Attachment(path)
 
     # Create database (path does not need to exist)
     path = 'attachments/file.txt'

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -191,9 +191,16 @@ def test_attachment(tmpdir):
     ]
 )
 def test_attachment_overlapping(tmpdir, attachments):
+    # Test for non-saved database
     db = audformat.Database('db')
     for n, attachment in enumerate(attachments):
         db.attachments[str(n)] = audformat.Attachment(attachment)
     db_path = audeer.path(tmpdir, 'db')
     audformat.testing.create_attachment_files(db, db_path)
     db.save(db_path)
+    # Test for saved database,
+    # that contains attachment files
+    db = audformat.Database('db')
+    db.save(db_path)
+    for n, attachment in enumerate(attachments):
+        db.attachments[str(n)] = audformat.Attachment(attachment)

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -12,6 +12,7 @@ def test_attachment(tmpdir):
     # Path needs to be relative and not contain ., .., \
     for path in [
         '/root/file.txt',
+        './root',
         './file.txt',
         '../file.txt',
         'doc/./file.txt',
@@ -27,58 +28,73 @@ def test_attachment(tmpdir):
             audformat.Attachment(path)
 
     # Create database (path does not need to exist)
-    path = 'attachments/file.txt'
+    file_path = 'attachments/file.txt'
+    folder_path = 'attachments/folder'
     db = audformat.Database('db')
     db.attachments['file'] = audformat.Attachment(
-        path,
+        file_path,
         description='Attached file',
         meta={'mime': 'text'},
     )
+    db.attachments['folder'] = audformat.Attachment(
+        folder_path,
+        description='Attached folder',
+        meta={'mime': 'inode/directory'},
+    )
 
-    assert list(db.attachments) == ['file']
-    assert db.attachments['file'].path == path
+    assert list(db.attachments) == ['file', 'folder']
+    assert db.attachments['file'].path == file_path
     assert db.attachments['file'].description == 'Attached file'
     assert db.attachments['file'].meta == {'mime': 'text'}
+    assert db.attachments['folder'].path == folder_path
+    assert db.attachments['folder'].description == 'Attached folder'
+    assert db.attachments['folder'].meta == {'mime': 'inode/directory'}
 
     db_path = audeer.path(tmpdir, 'db')
     audeer.mkdir(db_path)
 
     # Save database, path needs to exist
     error_msg = (
-        f"The provided path '{path}' "
+        f"The provided path '{file_path}' "
         f"of attachment 'file' "
         "does not exist."
     )
     with pytest.raises(FileNotFoundError, match=error_msg):
         db.save(db_path)
 
-    # Save database, path needs to be a file
-    audeer.mkdir(audeer.path(db_path, path))
-    error_msg = (
-        f"The provided path '{path}' "
-        f"of attachment 'file' "
-        "is not a file."
+    # Save database, path is not allowed to be a symlink
+    audeer.mkdir(audeer.path(db_path, folder_path))
+    os.symlink(
+        audeer.path(db_path, folder_path),
+        audeer.path(db_path, file_path),
     )
-    with pytest.raises(FileNotFoundError, match=error_msg):
+    error_msg = (
+        f"The provided path '{file_path}' "
+        f"of attachment 'file' "
+        "is not allowed to be a symlink."
+    )
+    with pytest.raises(RuntimeError, match=error_msg):
         db.save(db_path)
 
-    audeer.rmdir(audeer.path(db_path, path))
-    audeer.mkdir(audeer.path(db_path, os.path.dirname(path)))
-    audeer.touch(audeer.path(db_path, path))
+    os.remove(os.path.join(db_path, file_path))
+    audeer.touch(audeer.path(db_path, file_path))
     db.save(db_path)
 
     # Load database
     db = audformat.Database.load(db_path)
-    assert list(db.attachments) == ['file']
-    assert db.attachments['file'].path == path
+    assert list(db.attachments) == ['file', 'folder']
+    assert db.attachments['file'].path == file_path
     assert db.attachments['file'].description == 'Attached file'
     assert db.attachments['file'].meta == {'mime': 'text'}
+    assert db.attachments['folder'].path == folder_path
+    assert db.attachments['folder'].description == 'Attached folder'
+    assert db.attachments['folder'].meta == {'mime': 'inode/directory'}
 
     # Load database, path needs to exist
-    audeer.rmdir(audeer.path(db_path, os.path.dirname(path)))
-    assert not os.path.exists(audeer.path(db_path, path))
+    audeer.rmdir(audeer.path(db_path, os.path.dirname(file_path)))
+    assert not os.path.exists(audeer.path(db_path, file_path))
     error_msg = (
-        f"The provided path '{path}' "
+        f"The provided path '{file_path}' "
         f"of attachment 'file' "
         "does not exist."
     )

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,0 +1,74 @@
+import os
+
+import pytest
+
+import audeer
+import audformat
+
+
+def test_attachment(tmpdir):
+
+    # Path needs to be relative
+    path = '/root/file.txt'
+    error_msg = f"The provided path '{path}' needs to be relative."
+    with pytest.raises(ValueError, match=error_msg):
+        audformat.Attachment(path)
+
+    # Create database (path does not need to exist)
+    path = 'attachments/file.txt'
+    db = audformat.Database('db')
+    db.attachments['file'] = audformat.Attachment(
+        path,
+        description='Attached file',
+        meta={'mime': 'text'},
+    )
+
+    assert list(db.attachments) == ['file']
+    assert db.attachments['file'].path == path
+    assert db.attachments['file'].description == 'Attached file'
+    assert db.attachments['file'].meta == {'mime': 'text'}
+
+    db_path = audeer.path(tmpdir, 'db')
+    audeer.mkdir(db_path)
+
+    # Save database, path needs to exist
+    error_msg = (
+        f"The provided path '{path}' "
+        f"of attachment 'file' "
+        "does not exist."
+    )
+    with pytest.raises(FileNotFoundError, match=error_msg):
+        db.save(db_path)
+
+    # Save database, path needs to be a file
+    audeer.mkdir(audeer.path(db_path, path))
+    error_msg = (
+        f"The provided path '{path}' "
+        f"of attachment 'file' "
+        "is not a file."
+    )
+    with pytest.raises(FileNotFoundError, match=error_msg):
+        db.save(db_path)
+
+    audeer.rmdir(audeer.path(db_path, path))
+    audeer.mkdir(audeer.path(db_path, os.path.dirname(path)))
+    audeer.touch(audeer.path(db_path, path))
+    db.save(db_path)
+
+    # Load database
+    db = audformat.Database.load(db_path)
+    assert list(db.attachments) == ['file']
+    assert db.attachments['file'].path == path
+    assert db.attachments['file'].description == 'Attached file'
+    assert db.attachments['file'].meta == {'mime': 'text'}
+
+    # Load database, path needs to exist
+    audeer.rmdir(audeer.path(db_path, os.path.dirname(path)))
+    assert not os.path.exists(audeer.path(db_path, path))
+    error_msg = (
+        f"The provided path '{path}' "
+        f"of attachment 'file' "
+        "does not exist."
+    )
+    with pytest.raises(FileNotFoundError, match=error_msg):
+        db = audformat.Database.load(db_path)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -120,3 +120,24 @@ def test_items_order():
     assert d.popitem(last=True) == ('c', 2)
     assert d.popitem(last=False) == ('a', 0)
     assert list(d) == ['b']
+
+
+@pytest.mark.parametrize(
+    'path, expected',
+    [
+        ('/root/file.txt', False),
+        ('./file.txt', False),
+        ('../file.txt', False),
+        ('doc/./file.txt', False),
+        ('doc/../file.txt', False),
+        ('doc/../../file.txt', False),
+        (r'C:\\doc\file.txt', False),
+        (r'a\b', False),
+        ('a/b', True),
+        ('b', True),
+        ('file.txt', True),
+    ],
+)
+def test_is_relative_path(path, expected):
+    relative = audformat.core.common.is_relative_path(path)
+    assert relative == expected

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -495,6 +495,7 @@ def test_map_files(num_workers):
 def test_save_and_load(tmpdir, db, storage_format, load_data, num_workers):
 
     assert db.root is None
+    audformat.testing.create_attachment_files(db, tmpdir)
     db.save(
         tmpdir,
         storage_format=storage_format,

--- a/tests/test_eq.py
+++ b/tests/test_eq.py
@@ -27,6 +27,7 @@ def test_with_data(tmpdir):
 
     # compare with db that has same data
 
+    audformat.testing.create_attachment_files(db, tmpdir)
     db.save(tmpdir)
     db3 = audformat.Database.load(tmpdir)
 


### PR DESCRIPTION
Closes #313 

This allows to store additional files/folders as attachments to a database.

It is a little bit tricky as we not only need a header entry, but also the actual file/folder.
I designed it that you can assign a file/folder path when the file/folder does not exist as long as the database has `db.root = None`. As soon as this changes, e.g. by saving or loading a database or assigning the attachment to an existing database with a given `root` it will then raise an error.

This adds:
* Attachment to the specifications of the database
* `audformat.Attachment`
* `audformat.testing.create_attachemnt_files()`

### Specifications

![image](https://user-images.githubusercontent.com/173624/196419555-95393a00-957e-40dc-ac34-2d498157b221.png)

[...]

![image](https://user-images.githubusercontent.com/173624/204247719-4f8a4687-873b-4c9d-8613-b5e4c5eae26a.png)

### audformat.Attachment

![image](https://user-images.githubusercontent.com/173624/204248136-55da651f-c08b-43e9-a163-15d43058785a.png)

[...]

### audformat.testing.create_attachment_files()

![image](https://user-images.githubusercontent.com/173624/204248616-9e4967fb-24f2-4d8b-a047-09d64bb85d2f.png)


