### PR TITLE
Avoid FutureWarning for audformat.Column.set()

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -337,11 +337,16 @@ class Column(HeaderBase):
             if is_scalar(values):
                 values = [values] * len(index)
             values = to_array(values)
-            df.loc[index, column_id] = pd.Series(
-                values,
-                index=index,
-                dtype=dtype,
-            )
+            with warnings.catch_warnings():
+                # Avoid FutureWarning for setting values in place
+                # as introduced at
+                # https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html#inplace-operation-when-setting-values-with-loc-and-iloc
+                warnings.simplefilter(action='ignore', category=FutureWarning)
+                df.loc[index, column_id] = pd.Series(
+                    values,
+                    index=index,
+                    dtype=dtype,
+                )
 
     def __eq__(
             self,

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # allow typing without string
 
 import typing
+import warnings
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Closes #319 

As there seems to be no obvious solution how to avoid the warning, and we are fine with assigning the values in place, I added code that suppresses the `FutureWarning`.