### PR TITLE
DOC: improve sketches of database structure

### DIFF
--- a/docs/pics/audformat-database.dot
+++ b/docs/pics/audformat-database.dot
@@ -11,7 +11,7 @@ digraph {
     label=<
       <table>
         <tr><td colspan='3'>Table#1</td></tr>
-        <tr><td>File</td><td>Name</td><td>Gender</td></tr>
+        <tr><td>file</td><td>name</td><td>gender</td></tr>
         <tr><td>alice.wav</td><td>Alice</td><td>female</td></tr>
         <tr><td>bob.wav</td><td>Bob</td><td>male</td></tr>
       </table>
@@ -21,7 +21,7 @@ digraph {
     label=<
       <table>
         <tr><td colspan='4'>Table#2</td></tr>
-        <tr><td>File</td><td>Start</td><td>End</td><td>Text</td></tr>
+        <tr><td>file</td><td>start</td><td>end</td><td>text</td></tr>
         <tr><td>alice.wav</td><td>0.2</td><td>1.1</td><td>Hi, I'm Alice</td></tr>
         <tr><td>bob.wav</td><td>1.4</td><td>3.0</td><td>How are you doing?</td></tr>
         <tr><td>alice.wav</td><td>3.4</td><td>4.7</td><td>Thanks, I'm good!</td></tr>

--- a/docs/pics/audformat-misc-table.dot
+++ b/docs/pics/audformat-misc-table.dot
@@ -3,12 +3,12 @@ digraph structs {
     rankdir=LR
     node[shape=record]
 
-    header [label="Header | ... | <table> table | <split> split | media | <rater> rater | <scheme> scheme | ... "]
+    header [label="Header | ... | <misctable> misc table | <table> table | <split> split | media | <rater> rater | <scheme> scheme | ... "]
     table [label="MiscTable | { idx | <column> x | y }"]
 
     header:split -> table [style="dotted"]
     header:rater -> table:column [style="dotted"]
     header:scheme -> table:column [style="dotted"]
-    header:table -> table
+    header:misctable -> table
 
 }

--- a/docs/pics/audformat-misc-table.dot
+++ b/docs/pics/audformat-misc-table.dot
@@ -3,10 +3,11 @@ digraph structs {
     rankdir=LR
     node[shape=record]
 
-    header [label="Header | ... | <misctable> misc table | <table> table | <split> split | media | <rater> rater | <scheme> scheme | ... "]
-    table [label="MiscTable | { idx | <column> x | y }"]
+    header [label="Header | ... | <misctable> misc table | <table> table | <split> split | <media> media | <rater> rater | <scheme> scheme | ... "]
+    table [label="MiscTable | { <idx> idx | <column> x | y }"]
 
     header:split -> table [style="dotted"]
+    header:media -> table:idx [style="dotted"]
     header:rater -> table:column [style="dotted"]
     header:scheme -> table:column [style="dotted"]
     header:misctable -> table

--- a/docs/pics/audformat-table.dot
+++ b/docs/pics/audformat-table.dot
@@ -3,7 +3,7 @@ digraph structs {
     rankdir=LR
     node[shape=record]
 
-    header [label="Header | ... | <table> table | <split> split | <media> media | <rater> rater | <scheme> scheme | ... "]
+    header [label="Header | ... | <misctable> misc table | <table> table | <split> split | <media> media | <rater> rater | <scheme> scheme | ... "]
     table [label="Table | { <files> files | <column> x | y }"]
 
     header:split -> table [style="dotted"]


### PR DESCRIPTION
Two changes to improve definition of an `audformat` database

## Use lower case for column names

Changes

![image](https://user-images.githubusercontent.com/173624/199004834-d69e8050-7511-4980-a0a2-cdc3894b0f51.png)

to

![image](https://user-images.githubusercontent.com/173624/199004892-435b4856-8ce5-41cb-921b-494104470c54.png)

## Mention misc table in header

We show how header entries and tables are connected, but where listing misc tables as table before.
To improve this I changed

![image](https://user-images.githubusercontent.com/173624/199005063-8a0b062e-3763-4215-8e9e-dd05536f198a.png)

to

![image](https://user-images.githubusercontent.com/173624/199204968-23467eb9-651b-40be-9e66-737a446260e8.png)


and

![image](https://user-images.githubusercontent.com/173624/199005123-b80f4f8a-6b27-463c-9c31-1e16726fa299.png)

to

![image](https://user-images.githubusercontent.com/173624/199204997-09aa2629-a667-41a9-99ec-08b9d91b5de1.png)

