### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering
 
 [options]


### PR DESCRIPTION
Add a test for Python 3.11 under Ubuntu and mention Python 3.11 as supported in `setup.cfg`.