### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Flake8
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,14 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
+    - name: Install pre-commit hooks
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files
+
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,14 +51,6 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
-    - name: Install pre-commit hooks
-      run: |
-        pre-commit install --install-hooks
-
-    - name: Code style check via pre-commit
-      run: |
-        pre-commit run --all-files
-
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,39 @@ This way, your installation always stays up-to-date,
 even if you pull new changes from the Github repository.
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -295,7 +295,7 @@ class DefineBase:
         return sorted(
             [
                 a[1] for a in attributes
-                if not(a[0].startswith('__') and a[0].endswith('__'))
+                if not (a[0].startswith('__') and a[0].endswith('__'))
             ]
         )
 

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -1,8 +1,3 @@
-import typing
-
-import numpy as np
-import pandas as pd
-
 from audformat.core.common import DefineBase
 
 

--- a/audformat/core/split.py
+++ b/audformat/core/split.py
@@ -1,5 +1,3 @@
-import typing
-
 from audformat.core import define
 from audformat.core.common import HeaderBase
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audformat
     --cov-fail-under=100
@@ -51,7 +50,12 @@ xfail_strict = true
 
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401 F403  # ignore unused and * imports
-    docs/examples/*.py F821  # ignore undefined variables
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused and * imports
+    __init__.py: F401, F403,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 audiofile >=1.1.0
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
+pre-commit
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,6 @@
-import itertools
 from io import StringIO
 import os
 import re
-import shutil
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.