### PR TITLE
Add audformat.Attachment.files

### DIFF
--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -73,9 +73,9 @@ class Attachment(HeaderBase):
 
         Raises:
             FileNotFoundError: if a path
-                associated with an attachment
+                associated with the attachment
                 cannot be found
-            RuntimeError: if any file
+            RuntimeError: if a path
                 associated with the attachment
                 is a symlink
             RuntimeError: if attachment is not part
@@ -104,10 +104,15 @@ class Attachment(HeaderBase):
                 recursive=True,
                 hidden=True,
             )
-            for file in files:
-                if os.path.islink(file):
+            dirs = audeer.list_dir_names(
+                path,
+                recursive=True,
+                hidden=True,
+            )
+            for path in files + dirs:
+                if os.path.islink(path):
                     raise RuntimeError(
-                        f"The file '{file}' "
+                        f"The path '{path}' "
                         f"included in attachment '{self._id}' "
                         "is not allowed to be a symlink."
                     )

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -114,7 +114,7 @@ class Attachment(HeaderBase):
                     raise RuntimeError(
                         f"The path '{path}' "
                         f"included in attachment '{self._id}' "
-                        "is not allowed to be a symlink."
+                        "must not be a symlink."
                     )
         else:
             files = [path]
@@ -156,5 +156,5 @@ class Attachment(HeaderBase):
             raise RuntimeError(
                 f"The provided path '{self.path}' "
                 f"of attachment '{self._id}' "
-                "is not allowed to be a symlink."
+                "must not be a symlink."
             )

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -66,8 +66,9 @@ class Attachment(HeaderBase):
     ) -> typing.List:
         r"""List all files part of the attachment.
 
-        Uses the path to the attachment
-        and list recursively all files that exist
+        List recursively the absolute path
+        of all files that exist
+        under :attr:`audformat.Attachment.path`
         on hard disc.
 
         """
@@ -83,9 +84,6 @@ class Attachment(HeaderBase):
             files = audeer.list_file_names(path, recursive=True)
         else:
             files = [path]
-
-        # Remove db root path
-        files = [f.replace(f'{self._db.root}/', '') for f in files]
 
         return files
 

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -1,4 +1,5 @@
 import os
+import typing
 
 import audeer
 
@@ -58,6 +59,36 @@ class Attachment(HeaderBase):
 
         self.path = path
         r"""Attachment path"""
+
+    @property
+    def files(
+            self,
+            full_path: bool = False,
+    ) -> typing.List:
+        r"""List all files part of the attachment.
+
+        Uses the path to the attachment
+        and list recursively all files that exist
+        on hard disc.
+
+        """
+        files = []
+        if not self._db.root:
+            return files
+
+        path = audeer.path(self._db.root, self.path)
+        if not os.path.exists(path):
+            return files
+
+        if os.path.isdir(path):
+            files = audeer.list_file_names(path, recursive=True)
+        else:
+            files = [path]
+
+        if not full_path:
+            files = [f.replace(f'{self._db.root}/', '') for f in files]
+
+        return files
 
     def _check_overlap(
             self,

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -66,7 +66,7 @@ class Attachment(HeaderBase):
     ) -> typing.List[str]:
         r"""List all files part of the attachment.
 
-        List recursively the absolute path
+        List recursively the relative path
         of all files that exist
         under :attr:`audformat.Attachment.path`
         on hard disc.
@@ -84,6 +84,9 @@ class Attachment(HeaderBase):
             files = audeer.list_file_names(path, recursive=True)
         else:
             files = [path]
+
+        # Remove absolute path
+        files = [f.replace(f'{self._db.root}{os.path.sep}', '') for f in files]
 
         return files
 

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -69,7 +69,7 @@ class Attachment(HeaderBase):
         List recursively the relative path
         of all files that exist
         under :attr:`audformat.Attachment.path`
-        on hard disc.
+        on hard disk.
 
         Raises:
             FileNotFoundError: if a path

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -63,7 +63,6 @@ class Attachment(HeaderBase):
     @property
     def files(
             self,
-            full_path: bool = False,
     ) -> typing.List:
         r"""List all files part of the attachment.
 
@@ -85,8 +84,8 @@ class Attachment(HeaderBase):
         else:
             files = [path]
 
-        if not full_path:
-            files = [f.replace(f'{self._db.root}/', '') for f in files]
+        # Remove db root path
+        files = [f.replace(f'{self._db.root}/', '') for f in files]
 
         return files
 

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -87,6 +87,8 @@ class Attachment(HeaderBase):
 
         # Remove absolute path
         files = [f.replace(f'{self._db.root}{os.path.sep}', '') for f in files]
+        # Make sure we use `/` as sep
+        files = [f.replace(os.path.sep, '/') for f in files]
 
         return files
 

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -63,7 +63,7 @@ class Attachment(HeaderBase):
     @property
     def files(
             self,
-    ) -> typing.List:
+    ) -> typing.List[str]:
         r"""List all files part of the attachment.
 
         List recursively the absolute path

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -64,7 +64,7 @@ class Attachment(HeaderBase):
     def files(
             self,
     ) -> typing.List[str]:
-        r"""List all files part of the attachment.
+        r"""List all files that are part of the attachment.
 
         List recursively the relative path
         of all files that exist

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -91,13 +91,13 @@ def test_attachment(tmpdir):
     audeer.touch(audeer.path(db_path, file_path))
 
     # File exist now, folder is empty
-    assert db.attachments['file'].files == [audeer.path(db_path, file_path)]
+    assert db.attachments['file'].files == [file_path]
     assert db.attachments['folder'].files == []
 
     # Load database
     db = audformat.Database.load(db_path)
     assert list(db.attachments) == ['file', 'folder']
-    assert db.attachments['file'].files == [audeer.path(db_path, file_path)]
+    assert db.attachments['file'].files == [file_path]
     assert db.attachments['folder'].files == []
     assert db.attachments['file'].path == file_path
     assert db.attachments['file'].description == 'Attached file'
@@ -119,10 +119,6 @@ def test_attachment(tmpdir):
 
 
 @pytest.mark.parametrize(
-    # `expected` should be given as a relative path
-    # starting from `db.root`
-    # and will be converted to an absolute path
-    # in the test
     'root, folders, files, expected',
     [
         (
@@ -159,8 +155,6 @@ def test_attachment(tmpdir):
 )
 def test_attachment_files(tmpdir, root, folders, files, expected):
     db_path = audeer.path(tmpdir, 'db')
-    # Convert `expected` to absolute path
-    expected = [audeer.path(db_path, p) for p in expected]
     root_path = audeer.path(db_path, root)
     audeer.mkdir(root_path)
     for folder in folders:
@@ -279,7 +273,7 @@ def test_attachment_overlapping(tmpdir, attachments):
     for n, attachment in enumerate(attachments):
         expected_files = []
         if '.' in attachment:
-            expected_files = [audeer.path(db_path, attachment)]
+            expected_files = [attachment]
         assert db.attachments[str(n)].files == expected_files
 
     # Test for saved database,

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -84,6 +84,12 @@ def test_attachment(tmpdir):
     audeer.touch(audeer.path(db_path, file_path))
     db.save(db_path)
 
+    # Remove file and check output of .files
+    os.remove(os.path.join(db_path, file_path))
+    assert db.attachments['file'].files == []
+    assert db.attachments['folder'].files == []
+    audeer.touch(audeer.path(db_path, file_path))
+
     # File exist now, folder is empty
     assert db.attachments['file'].files == [file_path]
     assert db.attachments['folder'].files == []

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -225,7 +225,7 @@ def test_attachment_files_errors(tmpdir):
         f"included in attachment 'attachment' "
         "is not allowed to be a symlink."
     )
-    with pytest.raises(RuntimeError, match=error_msg):
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
         attachment.files
 
 

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -211,9 +211,25 @@ def test_attachment_files_errors(tmpdir):
     with pytest.raises(RuntimeError, match=error_msg):
         attachment.files
 
-    # Some files of the attachments are symlinks
+    # Some files are inside a symlink folder
     os.remove(os.path.join(db_path, attachment_path))
     audeer.mkdir(audeer.path(db_path, attachment_path))
+    audeer.touch(audeer.path(db_path, attachment_path, 'file1.txt'))
+    audeer.touch(audeer.path(db_path, folder_link, 'file2.txt'))
+    os.symlink(
+        audeer.path(db_path, folder_link),
+        audeer.path(db_path, attachment_path, 'link'),
+    )
+    error_msg = (
+        f"The path '{os.path.join(db_path, attachment_path, 'link')}' "
+        f"included in attachment 'attachment' "
+        "is not allowed to be a symlink."
+    )
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+        attachment.files
+
+    # Some files of the attachments are symlinks
+    os.remove(os.path.join(db_path, attachment_path, 'link'))
     audeer.touch(audeer.path(db_path, attachment_path, 'file1.txt'))
     audeer.touch(audeer.path(db_path, folder_link, 'file2.txt'))
     os.symlink(
@@ -221,7 +237,7 @@ def test_attachment_files_errors(tmpdir):
         audeer.path(db_path, attachment_path, 'file2.txt'),
     )
     error_msg = (
-        f"The file '{os.path.join(db_path, attachment_path, 'file2.txt')}' "
+        f"The path '{os.path.join(db_path, attachment_path, 'file2.txt')}' "
         f"included in attachment 'attachment' "
         "is not allowed to be a symlink."
     )

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -113,6 +113,45 @@ def test_attachment(tmpdir):
 
 
 @pytest.mark.parametrize(
+    'folder, files, expected',
+    [
+        (
+            'extra',
+            [],
+            [],
+        ),
+        (
+            'extra',
+            ['file1.txt'],
+            ['extra/file1.txt'],
+        ),
+        (
+            'extra',
+            ['sub/file1.txt'],
+            ['extra/sub/file1.txt'],
+        ),
+        (
+            'extra',
+            ['f1.txt', 'f2.txt'],
+            ['extra/f1.txt', 'extra/f2.txt'],
+        ),
+    ]
+)
+def test_attachment_files(tmpdir, folder, files, expected):
+    folder_path = audeer.path(tmpdir, 'db', folder)
+    audeer.mkdir(folder_path)
+    for file in files:
+        path = audeer.path(folder_path, file)
+        audeer.mkdir(os.path.dirname(path))
+        audeer.touch(path)
+    db = audformat.Database('db')
+    db.attachments['extra'] = audformat.Attachment(folder)
+    db_path = audeer.path(tmpdir, 'db')
+    db.save(db_path)
+    assert db.attachments['extra'].files == expected
+
+
+@pytest.mark.parametrize(
     'attachments',
     [
         [

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -71,7 +71,7 @@ def test_attachment(tmpdir):
     error_msg = (
         f"The provided path '{file_path}' "
         f"of attachment 'file' "
-        "is not allowed to be a symlink."
+        "must not be a symlink."
     )
     with pytest.raises(RuntimeError, match=error_msg):
         db.save(db_path)
@@ -206,7 +206,7 @@ def test_attachment_files_errors(tmpdir):
     error_msg = (
         f"The provided path '{attachment_path}' "
         "of attachment 'attachment' "
-        "is not allowed to be a symlink."
+        "must not be a symlink."
     )
     with pytest.raises(RuntimeError, match=error_msg):
         attachment.files
@@ -223,7 +223,7 @@ def test_attachment_files_errors(tmpdir):
     error_msg = (
         f"The path '{os.path.join(db_path, attachment_path, 'link')}' "
         f"included in attachment 'attachment' "
-        "is not allowed to be a symlink."
+        "must not be a symlink."
     )
     with pytest.raises(RuntimeError, match=re.escape(error_msg)):
         attachment.files
@@ -239,7 +239,7 @@ def test_attachment_files_errors(tmpdir):
     error_msg = (
         f"The path '{os.path.join(db_path, attachment_path, 'file2.txt')}' "
         f"included in attachment 'attachment' "
-        "is not allowed to be a symlink."
+        "must not be a symlink."
     )
     with pytest.raises(RuntimeError, match=re.escape(error_msg)):
         attachment.files

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -119,39 +119,52 @@ def test_attachment(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'folder, files, expected',
+    'root, folders, files, expected',
     [
         (
             'extra',
             [],
             [],
+            [],
         ),
         (
             'extra',
+            [],
             ['file1.txt'],
             ['extra/file1.txt'],
         ),
         (
             'extra',
+            [],
             ['sub/file1.txt'],
             ['extra/sub/file1.txt'],
         ),
         (
             'extra',
+            ['sub1'],
+            ['sub2/file1.txt'],
+            ['extra/sub2/file1.txt'],
+        ),
+        (
+            'extra',
+            [],
             ['f1.txt', 'f2.txt'],
             ['extra/f1.txt', 'extra/f2.txt'],
         ),
     ]
 )
-def test_attachment_files(tmpdir, folder, files, expected):
-    folder_path = audeer.path(tmpdir, 'db', folder)
-    audeer.mkdir(folder_path)
+def test_attachment_files(tmpdir, root, folders, files, expected):
+    root_path = audeer.path(tmpdir, 'db', root)
+    audeer.mkdir(root_path)
+    for folder in folders:
+        path = audeer.path(root_path, folder)
+        audeer.mkdir(path)
     for file in files:
-        path = audeer.path(folder_path, file)
+        path = audeer.path(root_path, file)
         audeer.mkdir(os.path.dirname(path))
         audeer.touch(path)
     db = audformat.Database('db')
-    db.attachments['extra'] = audformat.Attachment(folder)
+    db.attachments['extra'] = audformat.Attachment(root)
     db_path = audeer.path(tmpdir, 'db')
     db.save(db_path)
     assert db.attachments['extra'].files == expected

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -91,13 +91,13 @@ def test_attachment(tmpdir):
     audeer.touch(audeer.path(db_path, file_path))
 
     # File exist now, folder is empty
-    assert db.attachments['file'].files == [file_path]
+    assert db.attachments['file'].files == [audeer.path(db_path, file_path)]
     assert db.attachments['folder'].files == []
 
     # Load database
     db = audformat.Database.load(db_path)
     assert list(db.attachments) == ['file', 'folder']
-    assert db.attachments['file'].files == [file_path]
+    assert db.attachments['file'].files == [audeer.path(db_path, file_path)]
     assert db.attachments['folder'].files == []
     assert db.attachments['file'].path == file_path
     assert db.attachments['file'].description == 'Attached file'
@@ -119,6 +119,10 @@ def test_attachment(tmpdir):
 
 
 @pytest.mark.parametrize(
+    # `expected` should be given as a relative path
+    # starting from `db.root`
+    # and will be converted to an absolute path
+    # in the test
     'root, folders, files, expected',
     [
         (
@@ -154,7 +158,10 @@ def test_attachment(tmpdir):
     ]
 )
 def test_attachment_files(tmpdir, root, folders, files, expected):
-    root_path = audeer.path(tmpdir, 'db', root)
+    db_path = audeer.path(tmpdir, 'db')
+    # Convert `expected` to absolute path
+    expected = [audeer.path(db_path, p) for p in expected]
+    root_path = audeer.path(db_path, root)
     audeer.mkdir(root_path)
     for folder in folders:
         path = audeer.path(root_path, folder)
@@ -272,7 +279,7 @@ def test_attachment_overlapping(tmpdir, attachments):
     for n, attachment in enumerate(attachments):
         expected_files = []
         if '.' in attachment:
-            expected_files = [attachment]
+            expected_files = [audeer.path(db_path, attachment)]
         assert db.attachments[str(n)].files == expected_files
 
     # Test for saved database,


### PR DESCRIPTION
Closes #326 
Closes #336 

This adds the property `audformat.Attachment.files` which list all files that exist in the attachment by relative path. It simply ignores all empty folders and non-existing files.

I implemented it as a property to be in line with [Table.files](https://audeering.github.io/audformat/api.html#audformat.Table.files). This has the disadvantage that we can only return relative or absolute paths as we cannot add a `full_path` argument. We decided to return relative path.

![image](https://user-images.githubusercontent.com/173624/211591648-93cf2278-3589-45d5-a54f-56bc2ffa4b2e.png)
