### PR TITLE
Always set dtype of file level to 'string'

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1560,13 +1560,13 @@ def _assert_file_level_dtype_is_string(
 ) -> pd.Index:
     r"""Possibly set dtype of file level to 'string'."""
     if (
-        (
-            is_filewise_index(index)
-            and index.dtype == 'object'
-        ) or (
-            is_segmented_index(index)
-            and index.dtypes[define.IndexField.FILE] == 'object'
-        )
+            (
+                is_filewise_index(index)
+                and index.dtype == 'object'
+            ) or (
+                is_segmented_index(index)
+                and index.dtypes[define.IndexField.FILE] == 'object'
+            )
     ):
         index = utils.set_index_dtypes(
             index,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -314,6 +314,7 @@ class Base(HeaderBase):
         """
         table = self if inplace else self.copy()
 
+        index = _assert_file_level_dtype_is_string(index)
         _assert_table_index(table, index, 'drop rows from')
 
         index = utils.intersect([table.index, index])
@@ -353,6 +354,7 @@ class Base(HeaderBase):
         """
         table = self if inplace else self.copy()
 
+        index = _assert_file_level_dtype_is_string(index)
         _assert_table_index(table, index, 'extend')
 
         new_index = utils.union([table.index, index])
@@ -558,6 +560,7 @@ class Base(HeaderBase):
         """
         table = self if inplace else self.copy()
 
+        index = _assert_file_level_dtype_is_string(index)
         _assert_table_index(table, index, 'pick rows from')
 
         new_index = utils.intersect([table.index, index])
@@ -917,19 +920,7 @@ class Base(HeaderBase):
             ):
                 df[column_id] = df[column_id].astype('string', copy=False)
         # Fix index entries as well
-        if (
-                (
-                    is_filewise_index(df.index)
-                    and df.index.dtype == 'object'
-                ) or (
-                    is_segmented_index(df.index)
-                    and df.index.dtypes[define.IndexField.FILE] == 'object'
-                )
-        ):
-            df.index = utils.set_index_dtypes(
-                df.index,
-                {define.IndexField.FILE: 'string'},
-            )
+        df.index = _assert_file_level_dtype_is_string(df.index)
 
         self._df = df
 
@@ -1267,6 +1258,8 @@ class Table(Base):
         if index is None:
             index = filewise_index()
 
+        index = _assert_file_level_dtype_is_string(index)
+
         self.type = index_type(index)
         r"""Table type
 
@@ -1560,6 +1553,26 @@ class Table(Base):
                 result = self.df.loc[files]
 
         return result, result_is_copy
+
+
+def _assert_file_level_dtype_is_string(
+        index: pd.Index,
+) -> pd.Index:
+    r"""Possibly set dtype of file level to 'string'."""
+    if (
+        (
+            is_filewise_index(index)
+            and index.dtype == 'object'
+        ) or (
+            is_segmented_index(index)
+            and index.dtypes[define.IndexField.FILE] == 'object'
+        )
+    ):
+        index = utils.set_index_dtypes(
+            index,
+            {define.IndexField.FILE: 'string'},
+        )
+    return index
 
 
 def _assert_table_index(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -708,6 +708,22 @@ def test_drop_extend_and_pick_index_order():
             ),
             audformat.segmented_index('f1', 0, 1),
         ),
+        # dtype of file level is object
+        (
+            create_table(audformat.filewise_index(['f1', 'f2'])),
+            pd.Index(['f2', 'f3'], dtype=object, name='file'),
+            audformat.filewise_index(['f1']),
+        ),
+        (
+            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            audformat.filewise_index(['f2', 'f3']),
+            audformat.filewise_index(['f1']),
+        ),
+        (
+            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            pd.Index(['f2', 'f3'], dtype=object, name='file'),
+            audformat.filewise_index(['f1']),
+        ),
         # different index type
         pytest.param(
             create_table(audformat.segmented_index()),
@@ -890,6 +906,16 @@ def test_extend_index():
         db['table']['columns'].get().values,
         np.array(['a', 'a', 'b']),
     )
+    index = pd.Index(['4.wav'], dtype=object, name='file')
+    db['table'].extend_index(
+        index,
+        fill_values='c',
+        inplace=True,
+    )
+    np.testing.assert_equal(
+        db['table']['columns'].get().values,
+        np.array(['a', 'a', 'b', 'c']),
+    )
 
     db.drop_tables('table')
 
@@ -925,6 +951,23 @@ def test_extend_index():
     np.testing.assert_equal(
         db['table']['columns'].get().values,
         np.array(['a', 'a', 'b']),
+    )
+    index = pd.MultiIndex.from_arrays(
+        [
+            ['3.wav'],
+            [pd.Timedelta(0)],
+            [pd.Timedelta(4, unit='s')],
+        ],
+        names=['file', 'start', 'end'],
+    )
+    db['table'].extend_index(
+        index,
+        fill_values={'columns': 'c'},
+        inplace=True,
+    )
+    np.testing.assert_equal(
+        db['table']['columns'].get().values,
+        np.array(['a', 'a', 'b', 'c']),
     )
 
     db.drop_tables('table')
@@ -1305,6 +1348,22 @@ def test_pick_files(files, table):
                 [1, 0],
                 [2, 3],
             ),
+        ),
+        # dtype of file level is object
+        (
+            create_table(audformat.filewise_index(['f1', 'f2'])),
+            pd.Index(['f2'], dtype=object, name='file'),
+            audformat.filewise_index(['f2']),
+        ),
+        (
+            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            audformat.filewise_index(['f2']),
+            audformat.filewise_index(['f2']),
+        ),
+        (
+            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            pd.Index(['f2'], dtype=object, name='file'),
+            audformat.filewise_index(['f2']),
         ),
         # different index type
         pytest.param(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1022,6 +1022,18 @@ def test_filewise(num_files, values):
     )
     pd.testing.assert_frame_equal(table.get(), df)
 
+    # dtype of file level is object
+    df['column'] = np.nan
+    table.df['column'] = np.nan
+    df['column'][1:-1] = values[1:-1]
+    index = pd.Index(table.files[1:-1], dtype='object', name='file')
+    table.set({'column': values[1:-1]}, index=index)
+    pd.testing.assert_frame_equal(
+        table.get(index),
+        df.loc[table.files[1:-1]],
+    )
+    pd.testing.assert_frame_equal(table.get(), df)
+
     # all
     df['column'] = np.nan
     table.df['column'] = np.nan
@@ -1437,6 +1449,24 @@ def test_segmented(num_files, num_segments_per_file, values):
         table.files[1:-1],
         starts=table.starts[1:-1],
         ends=table.ends[1:-1],
+    )
+    df.loc[index, :] = values[1:-1]
+    table.set({'column': values[1:-1]}, index=index)
+    pd.testing.assert_frame_equal(
+        table.get(index),
+        df.loc[index],
+    )
+
+    # dtype of file level is object
+    df['column'] = np.nan
+    table.df['column'] = np.nan
+    index = pd.MultiIndex.from_arrays(
+        [
+            table.files[1:-1].astype('object'),
+            table.starts[1:-1],
+            table.ends[1:-1],
+        ],
+        names=['file', 'start', 'end'],
     )
     df.loc[index, :] = values[1:-1]
     table.set({'column': values[1:-1]}, index=index)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -711,17 +711,17 @@ def test_drop_extend_and_pick_index_order():
         # dtype of file level is object
         (
             create_table(audformat.filewise_index(['f1', 'f2'])),
-            pd.Index(['f2', 'f3'], dtype=object, name='file'),
+            pd.Index(['f2', 'f3'], dtype='object', name='file'),
             audformat.filewise_index(['f1']),
         ),
         (
-            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            create_table(pd.Index(['f1', 'f2'], dtype='object', name='file')),
             audformat.filewise_index(['f2', 'f3']),
             audformat.filewise_index(['f1']),
         ),
         (
-            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
-            pd.Index(['f2', 'f3'], dtype=object, name='file'),
+            create_table(pd.Index(['f1', 'f2'], dtype='object', name='file')),
+            pd.Index(['f2', 'f3'], dtype='object', name='file'),
             audformat.filewise_index(['f1']),
         ),
         # different index type
@@ -906,7 +906,7 @@ def test_extend_index():
         db['table']['columns'].get().values,
         np.array(['a', 'a', 'b']),
     )
-    index = pd.Index(['4.wav'], dtype=object, name='file')
+    index = pd.Index(['4.wav'], dtype='object', name='file')
     db['table'].extend_index(
         index,
         fill_values='c',
@@ -1352,17 +1352,17 @@ def test_pick_files(files, table):
         # dtype of file level is object
         (
             create_table(audformat.filewise_index(['f1', 'f2'])),
-            pd.Index(['f2'], dtype=object, name='file'),
+            pd.Index(['f2'], dtype='object', name='file'),
             audformat.filewise_index(['f2']),
         ),
         (
-            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
+            create_table(pd.Index(['f1', 'f2'], dtype='object', name='file')),
             audformat.filewise_index(['f2']),
             audformat.filewise_index(['f2']),
         ),
         (
-            create_table(pd.Index(['f1', 'f2'], dtype=object, name='file')),
-            pd.Index(['f2'], dtype=object, name='file'),
+            create_table(pd.Index(['f1', 'f2'], dtype='object', name='file')),
+            pd.Index(['f2'], dtype='object', name='file'),
             audformat.filewise_index(['f2']),
         ),
         # different index type


### PR DESCRIPTION
Closes #338 

Ensures file level of an audformat index is set to dtype 'string' in the following methods:

* `Table.__init__()`
* `Table.drop_index()`
* `Table.extend_index()`
* `Table.pick_index()`