### PR TITLE
Fix: require audeer>=1.19.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audeer >=1.18.0,<2.0.0
+    audeer >=1.19.0,<2.0.0
     audiofile >=0.4.0
     iso-639
     iso3166


### PR DESCRIPTION
In `audformat.Attachment.files` introduced in #337 we rely on `hidden=True` in `audeer.list_file_names()` which was added only in v1.19.0 of `audeer`.