### PR TITLE
Fix load_data in Database.load() for attachments

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -954,6 +954,7 @@ class Database(HeaderBase):
             FileNotFoundError: if a file or folder
                 associated with an attachment
                 cannot be found
+                when using ``load_data=True``
 
         """
         ext = '.yaml'

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -973,7 +973,8 @@ class Database(HeaderBase):
 
             if 'attachments' in header and header['attachments']:
                 for attachment_id in header['attachments']:
-                    db.attachments[attachment_id]._check_path(root)
+                    if load_data:
+                        db.attachments[attachment_id]._check_path(root)
 
             if 'tables' in header and header['tables']:
                 for table_id in header['tables']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -973,8 +973,8 @@ class Database(HeaderBase):
             table_ids = []
 
             if 'attachments' in header and header['attachments']:
-                for attachment_id in header['attachments']:
-                    if load_data:
+                if load_data:
+                    for attachment_id in header['attachments']:
                         db.attachments[attachment_id]._check_path(root)
 
             if 'tables' in header and header['tables']:

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -96,7 +96,9 @@ def test_attachment(tmpdir):
     assert db.attachments['folder'].description == 'Attached folder'
     assert db.attachments['folder'].meta == {'mime': 'inode/directory'}
 
-    # Load database, path needs to exist
+    # Load database
+    #
+    # path needs to exist when requesting data
     audeer.rmdir(audeer.path(db_path, os.path.dirname(file_path)))
     assert not os.path.exists(audeer.path(db_path, file_path))
     error_msg = (
@@ -105,7 +107,9 @@ def test_attachment(tmpdir):
         "does not exist."
     )
     with pytest.raises(FileNotFoundError, match=error_msg):
-        db = audformat.Database.load(db_path)
+        db = audformat.Database.load(db_path, load_data=True)
+    # but not when not requesting data
+    db = audformat.Database.load(db_path, load_data=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I have no tested to integrate `audformat.Attachment` into `audb` and found only one missing implementation/issue in `audformat`: when loading a header with `audformat.Database.load(..., load_data=False)` it should not raise an error if attachment files do not exists.

I added a test for this in this pull request and updated the behavior and the docstring.

![image](https://user-images.githubusercontent.com/173624/211829004-23aacc24-f305-4116-80f9-25acb1508e92.png)
