### PR TITLE
CI: fix name of Github release name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,5 +80,5 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
         body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
There was a typo which lead to a wrong name under for the title of the automatic generated release entry on Github.