### PR TITLE
Preserve dtypes when get() is called with an index

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -418,7 +418,7 @@ class Base(HeaderBase):
         if index is None:
             result = self.df
         else:
-            result, result_is_copy = self._get_by_index(index)
+            result = self._get_by_index(index)
 
         if map is not None:
 
@@ -1136,8 +1136,8 @@ class MiscTable(Base):
             meta=meta,
         )
 
-    def _get_by_index(self, index: pd.Index) -> (pd.DataFrame, bool):
-        return self.df.loc[index], False
+    def _get_by_index(self, index: pd.Index) -> pd.DataFrame:
+        return self.df.loc[index]
 
 
 class Table(Base):
@@ -1533,26 +1533,20 @@ class Table(Base):
     def _get_by_index(
             self,
             index: pd.Index,
-    ) -> (pd.DataFrame, bool):
-
-        result_is_copy = False
+    ) -> pd.DataFrame:
 
         if index_type(self.index) == index_type(index):
             result = self.df.loc[index]
         else:
             files = index.get_level_values(define.IndexField.FILE)
             if self.is_filewise:  # index is segmented
-                result = pd.DataFrame(
-                    self.df.loc[files].values,
-                    index,
-                    columns=self.columns
-                )
-                result_is_copy = True  # to avoid another copy
+                result = self.df.loc[files]
+                result.index = index
             else:  # index is filewise
                 files = list(dict.fromkeys(files))  # remove duplicates
                 result = self.df.loc[files]
 
-        return result, result_is_copy
+        return result
 
 
 def _assert_table_index(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1102,15 +1102,15 @@ def test_get_from_index():
         for index in [db[table_id].files, db.segments]:
             df_from_index = db[table_id].get(index)
             # if table is filewise and index is segmented
-            # index does not change
+            # the index of the table will be kept
             if (
                 audformat.is_segmented_index(df.index) and
                 audformat.is_filewise_index(index)
             ):
-                pd.testing.assert_index_equal(df.index, df_from_index.index)
-            # otherwise result has the requested index
+                pd.testing.assert_index_equal(df_from_index.index, df.index)
+            # otherwise the result gets a new index
             else:
-                pd.testing.assert_index_equal(index, df_from_index.index)
+                pd.testing.assert_index_equal(df_from_index.index, index)
             # assert dtypes are preserved
             pd.testing.assert_series_equal(df.dtypes, df_from_index.dtypes)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1093,15 +1093,16 @@ def test_get_as_segmented():
     db._files_duration = {}
 
 
-def test_get_preserve_dtypes():
+def test_get_preserves_dtypes():
 
     db = pytest.DB
 
-    for table_id in ['files', 'segments']:
-        df = db[table_id].get()
-        for index in [db[table_id].files, db.segments]:
-            df_from_index = db[table_id].get(index)
-            pd.testing.assert_series_equal(df.dtypes, df_from_index.dtypes)
+    for table in [db['files'], db['segments']]:
+        df = table.get()
+        pd.testing.assert_series_equal(df.dtypes, table.df.dtypes)
+        for index in [table.files, db.segments]:
+            df = table.get(index)
+            pd.testing.assert_series_equal(df.dtypes, table.df.dtypes)
 
 
 def test_load(tmpdir):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1093,6 +1093,28 @@ def test_get_as_segmented():
     db._files_duration = {}
 
 
+def test_get_from_index():
+
+    db = pytest.DB
+
+    for table_id in ['files', 'segments']:
+        df = db[table_id].get()
+        for index in [db[table_id].files, db.segments]:
+            df_from_index = db[table_id].get(index)
+            # if table is filewise and index is segmented
+            # index does not change
+            if (
+                audformat.is_segmented_index(df.index) and
+                audformat.is_filewise_index(index)
+            ):
+                pd.testing.assert_index_equal(df.index, df_from_index.index)
+            # otherwise result has the requested index
+            else:
+                pd.testing.assert_index_equal(index, df_from_index.index)
+            # assert dtypes are preserved
+            pd.testing.assert_series_equal(df.dtypes, df_from_index.dtypes)
+
+
 def test_load(tmpdir):
 
     path_pkl = os.path.join(tmpdir, 'db.table.pkl')

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1093,7 +1093,7 @@ def test_get_as_segmented():
     db._files_duration = {}
 
 
-def test_get_from_index():
+def test_get_preserve_dtypes():
 
     db = pytest.DB
 
@@ -1101,17 +1101,6 @@ def test_get_from_index():
         df = db[table_id].get()
         for index in [db[table_id].files, db.segments]:
             df_from_index = db[table_id].get(index)
-            # if table is filewise and index is segmented
-            # the index of the table will be kept
-            if (
-                audformat.is_segmented_index(df.index) and
-                audformat.is_filewise_index(index)
-            ):
-                pd.testing.assert_index_equal(df_from_index.index, df.index)
-            # otherwise the result gets a new index
-            else:
-                pd.testing.assert_index_equal(df_from_index.index, index)
-            # assert dtypes are preserved
             pd.testing.assert_series_equal(df.dtypes, df_from_index.dtypes)
 
 


### PR DESCRIPTION
Closes #324

Solves issue described in #324 and adds a test for it.