### PR TITLE
Return categorical dtype when get() is called with a mapping

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -268,7 +268,7 @@ class Column(HeaderBase):
                             f"{list(value)}."
                         )
                 mapping[key] = value
-            result = result.map(mapping)
+            result = result.map(mapping).astype('category')
             result.name = map
 
         return result.copy() if copy else result

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -198,6 +198,8 @@ def test_map(column, map):
 
 def test_map_returns_categorical_dtype():
 
+    # See https://github.com/audeering/audformat/issues/317
+    
     # use scheme with labels
 
     db = audformat.testing.create_db(minimal=True)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -196,6 +196,71 @@ def test_map(column, map):
     pd.testing.assert_series_equal(result, expected)
 
 
+def test_map_returns_categorical_dtype():
+
+    # use scheme with labels
+
+    db = audformat.testing.create_db(minimal=True)
+
+    db.schemes['scheme'] = audformat.Scheme(
+        labels={
+            'a': {'alias': 'A'},
+            'b': {'alias': 'B'},
+            'c': {'alias': 'C'},
+        },
+    )
+
+    db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
+    db['table']['column'] = audformat.Column(scheme_id='scheme')
+    db['table']['column'].set(['a', 'b', 'c'])
+
+    y = db['table']['column'].get()
+    assert y.dtype == pd.Series(['a', 'b', 'c']).astype('category').dtype
+
+    y = db['table']['column'].get(map='alias')
+    assert y.dtype == pd.Series(['A', 'B', 'C']).astype('category').dtype
+
+    db.schemes['scheme'].replace_labels(  # set one label to None
+        {
+            'a': {'alias': 'A'},
+            'b': {'alias': 'B'},
+        }
+    )
+
+    y = db['table']['column'].get(map='alias')
+    assert y.dtype == pd.Series(['A', 'B']).astype('category').dtype
+
+    # repeat using a misc table
+
+    db = audformat.testing.create_db(minimal=True)
+
+    db['misc'] = audformat.MiscTable(
+        pd.Index(
+            ['a', 'b', 'c'],
+            name='index',
+            dtype='string',
+        ),
+    )
+    db['misc']['alias'] = audformat.Column()
+    db['misc']['alias'].set(['A', 'B', 'C'])
+
+    db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
+    db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
+    db['table']['column'] = audformat.Column(scheme_id='scheme')
+    db['table']['column'].set(['a', 'b', 'c'])
+
+    y = db['table']['column'].get()
+    assert y.dtype == pd.Series(['a', 'b', 'c']).astype('category').dtype
+
+    y = db['table']['column'].get(map='alias')
+    assert y.dtype == pd.Series(['A', 'B', 'C']).astype('category').dtype
+
+    db['misc']['alias'].set(['A', 'B', None])  # set one label to None
+
+    y = db['table']['column'].get(map='alias')
+    assert y.dtype == pd.Series(['A', 'B']).astype('category').dtype
+
+
 @pytest.mark.parametrize(
     'num_files, num_segments_per_file, values', [
         (3, 2, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -199,7 +199,7 @@ def test_map(column, map):
 def test_map_returns_categorical_dtype():
 
     # See https://github.com/audeering/audformat/issues/317
-    
+
     # use scheme with labels
 
     db = audformat.testing.create_db(minimal=True)


### PR DESCRIPTION
Closes #317 

Solves the issue described in #317 and adds a test for it.