### PR TITLE
DOC: enhance utils.map_file_path() example

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1021,7 +1021,7 @@ def map_file_path(
         elif len(table.df.index) > 0:
             table.df.index.set_levels(
                 root + table.df.index.levels[0] + ext,
-                audformat.define.IndexField.FILE,
+                level=audformat.define.IndexField.FILE,
                 inplace=True,
             )
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1019,10 +1019,9 @@ def map_file_path(
             table.df.index = root + table.df.index + ext
             table.df.index.name = audformat.define.IndexField.FILE
         elif len(table.df.index) > 0:
-            table.df.index.set_levels(
+            table.df.index = table.df.index.set_levels(
                 root + table.df.index.levels[0] + ext,
                 level=audformat.define.IndexField.FILE,
-                inplace=True,
             )
 
     Args:


### PR DESCRIPTION
To avoid the following warnings:

```
FutureWarning: In a future version of pandas all arguments of MultiIndex.set_levels except for the argument 'levels' will be keyword-only.
FutureWarning: inplace is deprecated and will be removed in a future version.
```

when executing the alternative example code I updated it by adding a keyword and removed `inplace`.

![image](https://user-images.githubusercontent.com/173624/212951394-d4e36b15-e32e-4c5a-89e2-8007f7f4c254.png)
