### PR TITLE
Add copy_attachments argument to Database.update()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -605,7 +605,7 @@ class Database(HeaderBase):
             self,
             others: typing.Union['Database', typing.Sequence['Database']],
             *,
-            copy_attachment: bool = False,
+            copy_attachments: bool = False,
             copy_media: bool = False,
             overwrite: bool = False,
     ) -> 'Database':
@@ -638,7 +638,7 @@ class Database(HeaderBase):
 
         Args:
             others: database object(s)
-            copy_attachment: if ``True`` it copies the attachment files
+            copy_attachments: if ``True`` it copies the attachment files
                 associated with ``others`` to the current database root folder
             copy_media: if ``True`` it copies the media files
                 associated with ``others`` to the current database root folder
@@ -656,7 +656,9 @@ class Database(HeaderBase):
             ValueError: if tables cannot be combined
                 (e.g. values in same position overlap or
                 level and dtypes of table indices do not match)
-            RuntimeError: if ``copy_media`` or ``copy_attachment`` is ``True``,
+            RuntimeError: if ``copy_media``
+                or ``copy_attachments``
+                is ``True``,
                 but one of the involved databases was not saved
                 (contains files but no root folder)
             RuntimeError: if any involved database is not portable
@@ -826,19 +828,16 @@ class Database(HeaderBase):
                 else:
                     self[table_id] = table.copy()
 
-        if (
-                copy_attachment
-                or copy_media
-                and self.root is None
-        ):
-            raise RuntimeError(
-                f"You can only update a saved database. "
-                f"'{self.name}' was not saved yet."
-            )
+        if copy_attachments or copy_media:
+            if self.root is None:
+                raise RuntimeError(
+                    f"You can only update a saved database. "
+                    f"'{self.name}' was not saved yet."
+                )
 
         # copy attachment files
 
-        if copy_attachment:
+        if copy_attachments:
             for other in others:
                 if other.root is None:
                     raise RuntimeError(
@@ -846,7 +845,7 @@ class Database(HeaderBase):
                         f"The database '{other.name}' was not saved yet."
                     )
                 for attachment_id in other.attachments:
-                    for file in other.attachments[attachment_id]:
+                    for file in other.attachments[attachment_id].files:
                         src_file = os.path.join(other.root, file)
                         dst_file = os.path.join(self.root, file)
                         dst_dir = os.path.dirname(dst_file)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -605,6 +605,7 @@ class Database(HeaderBase):
             self,
             others: typing.Union['Database', typing.Sequence['Database']],
             *,
+            copy_attachment: bool = False,
             copy_media: bool = False,
             overwrite: bool = False,
     ) -> 'Database':
@@ -614,7 +615,9 @@ class Database(HeaderBase):
         *license* and *usage* have to match.
         Labels and values of *schemes*
         with the same ID are combined.
-        *Media*, *raters*, *schemes* and *splits* that are not part of
+        *Media*, *raters*, *schemes*, *splits*,
+        and *attachments*
+        that are not part of
         the database yet are added.
         Other fields will be updated by
         applying the following rules:
@@ -635,6 +638,8 @@ class Database(HeaderBase):
 
         Args:
             others: database object(s)
+            copy_attachment: if ``True`` it copies the attachment files
+                associated with ``others`` to the current database root folder
             copy_media: if ``True`` it copies the media files
                 associated with ``others`` to the current database root folder
             overwrite: overwrite table values where indices overlap
@@ -644,14 +649,14 @@ class Database(HeaderBase):
 
         Raises:
             ValueError: if database has different license or usage
-            ValueError: if different media, rater, scheme or split with
-                same ID is found
+            ValueError: if different media, rater, scheme, split, or attachment
+                with same ID is found
             ValueError: if schemes cannot be combined,
                 e.g. labels have different dtype
             ValueError: if tables cannot be combined
                 (e.g. values in same position overlap or
                 level and dtypes of table indices do not match)
-            RuntimeError: if ``copy_media=True``,
+            RuntimeError: if ``copy_media`` or ``copy_attachment`` is ``True``,
                 but one of the involved databases was not saved
                 (contains files but no root folder)
             RuntimeError: if any involved database is not portable
@@ -806,6 +811,11 @@ class Database(HeaderBase):
             join_field(other, 'source', ', '.join)
             join_field(other, 'splits', lambda x: join_dict('splits', x))
             join_field(other, 'raters', lambda x: join_dict('raters', x))
+            join_field(
+                other,
+                'attachments',
+                lambda x: join_dict('attachments', x),
+            )
 
         # join tables
         for other in others:
@@ -816,14 +826,36 @@ class Database(HeaderBase):
                 else:
                     self[table_id] = table.copy()
 
+        if (
+                copy_attachment
+                or copy_media
+                and self.root is None
+        ):
+            raise RuntimeError(
+                f"You can only update a saved database. "
+                f"'{self.name}' was not saved yet."
+            )
+
+        # copy attachment files
+
+        if copy_attachment:
+            for other in others:
+                if other.root is None:
+                    raise RuntimeError(
+                        f"You can only update with saved databases. "
+                        f"The database '{other.name}' was not saved yet."
+                    )
+                for attachment_id in other.attachments:
+                    for file in other.attachments[attachment_id]:
+                        src_file = os.path.join(other.root, file)
+                        dst_file = os.path.join(self.root, file)
+                        dst_dir = os.path.dirname(dst_file)
+                        audeer.mkdir(dst_dir)
+                        shutil.copy(src_file, dst_file)
+
         # copy media files
 
         if copy_media:
-            if self.root is None:
-                raise RuntimeError(
-                    f"You can only update a saved database. "
-                    f"'{self.name}' was not saved yet."
-                )
             for other in others:
                 if len(other.files) > 0 and other.root is None:
                     raise RuntimeError(


### PR DESCRIPTION
Closes #350 

Add `copy_attachments` argument to `audformat.Database.update()`. If `True` it will automatically copy files associated with attachments. If the same attachment exists with same filename but different file content, the file is overwritten by the file associated with the attachment from `other`.

In #350 you proposed to check for checksum for same attachment files to see if they have changed. I decided against this as we also don't do this for media files, but just overwrite them. This is even one of the use-cases of `update()`. We have an `overwrite` argument, but this refers only to table entries not to media or attachment files.
![image](https://user-images.githubusercontent.com/173624/216610747-6d86cd40-7bb1-4f9d-a6e9-96b17aadc1b7.png)


