### PR TITLE
Speed up utils.union()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1724,8 +1724,37 @@ def union(
     # Combine all MultiIndex entries and drop duplicates afterwards,
     # faster than using index.union(),
     # compare https://github.com/audeering/audformat/pull/98
-    df = pd.concat([o.to_frame() for o in objs])
-    index = df.index
+
+    if isinstance(objs[0], pd.MultiIndex):
+
+        names = objs[0].names
+        num_levels = len(names)
+        dtypes = {name: dtype for name, dtype in zip(names, objs[0].dtypes)}
+        values = [[] for _ in range(num_levels)]
+
+        for obj in objs:
+            for idx in range(num_levels):
+                values[idx].extend(obj.get_level_values(idx))
+
+        index = pd.MultiIndex.from_arrays(
+            values,
+            names=names,
+        )
+        index = set_index_dtypes(index, dtypes)
+
+    else:
+
+        name = objs[0].name
+        values = []
+
+        for obj in objs:
+            values.extend(obj.to_list())
+
+        index = pd.Index(values, name=name)
+        index = set_index_dtypes(index, objs[0].dtype)
+
+    # df = pd.concat([o.to_frame() for o in objs])
+    # index = df.index
     index = index.drop_duplicates()
 
     return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1753,8 +1753,6 @@ def union(
         index = pd.Index(values, name=name)
         index = set_index_dtypes(index, objs[0].dtype)
 
-    # df = pd.concat([o.to_frame() for o in objs])
-    # index = df.index
     index = index.drop_duplicates()
 
     return index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1609,7 +1609,7 @@ def to_segmented_index(
     return obj
 
 
-UNION_MAX_NUM_SEG_THRES = 500
+UNION_MAX_INDEX_LEN_THRES = 500
 
 
 def union(
@@ -1734,7 +1734,7 @@ def union(
     # compare https://github.com/audeering/audformat/pull/354
 
     max_num_seg = max([len(obj) for obj in objs])
-    if max_num_seg > UNION_MAX_NUM_SEG_THRES:
+    if max_num_seg > UNION_MAX_INDEX_LEN_THRES:
 
         df = pd.concat([o.to_frame() for o in objs])
         index = df.index

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1724,6 +1724,10 @@ def union(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
+    # Combine all MultiIndex entries and drop duplicates afterwards,
+    # faster than using index.union(),
+    # compare https://github.com/audeering/audformat/pull/98
+
     # Use pd.concat() if at least one index has
     # more than 500 segments
     # otherwise create index from lists,
@@ -1762,10 +1766,6 @@ def union(
 
         index = pd.Index(values, name=name)
         index = set_index_dtypes(index, objs[0].dtype)
-
-    # Combine all MultiIndex entries and drop duplicates afterwards,
-    # faster than using index.union(),
-    # compare https://github.com/audeering/audformat/pull/98
 
     index = index.drop_duplicates()
 

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -8,6 +8,18 @@ import audeer
 import audformat
 
 
+# Benchmark for the utility function
+# audformat.utils.union()
+# that concatenates a list of index objects.
+# This can be achieved with pd.concat().
+# However,
+# for indices with less than 500 entries,
+# it is faster to convert the level values to lists
+# and create the index from those.
+#
+# See also https://github.com/audeering/audformat/pull/354
+
+
 cache_root = audeer.mkdir('cache')
 
 

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -43,7 +43,7 @@ def benchmark(
     if os.path.exists(cache_path):
         return pd.read_pickle(cache_path)
 
-    audformat.core.utils.UNION_MAX_NUM_SEG_THRES = threshold
+    audformat.core.utils.UNION_MAX_INDEX_LEN_THRES = threshold
 
     ds = []
 
@@ -81,7 +81,7 @@ def benchmark(
 
 def main():
 
-    default_threshold = audformat.core.utils.UNION_MAX_NUM_SEG_THRES
+    default_threshold = audformat.core.utils.UNION_MAX_INDEX_LEN_THRES
 
     num_segs = tuple(range(100, 1000, 100))
     num_objs = (10, 100, 1000)

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -1,0 +1,115 @@
+import os
+import time
+import typing
+
+import pandas as pd
+
+import audeer
+import audformat
+
+
+cache_root = audeer.mkdir('cache')
+
+
+def benchmark(
+        segmented: bool,
+        num_segs: typing.Tuple[int],
+        num_objs: typing.Tuple[int],
+        num_repeat: int,
+        threshold: int,
+) -> pd.Series:
+
+    cache_name = (
+            hash(segmented) +
+            hash(num_segs) +
+            hash(num_objs) +
+            hash(num_repeat) +
+            hash(threshold)
+    )
+    cache_path = audeer.path(cache_root, f'{cache_name}.pkl')
+
+    if os.path.exists(cache_path):
+        return pd.read_pickle(cache_path)
+
+    audformat.core.utils.UNION_MAX_NUM_SEG_THRES = threshold
+
+    ds = []
+
+    for num_seg in num_segs:
+        for num_obj in num_objs:
+
+            objs = []
+            for idx in range(num_obj):
+                files = [f'file-{idx}-{seg}' for seg in range(num_seg)]
+                if segmented:
+                    starts = [0] * len(files)
+                    ends = [1] * len(files)
+                    index = audformat.segmented_index(files, starts, ends)
+                else:
+                    index = audformat.filewise_index(files)
+                objs.append(index)
+
+            t = time.time()
+            for _ in range(num_repeat):
+                _ = audformat.utils.union(objs)
+            dt = (time.time() - t) / num_repeat
+
+            d = {
+                'num_obj': num_obj,
+                'num_seg': num_seg,
+                'elapsed': dt,
+            }
+            ds.append(d)
+
+    y = pd.DataFrame(ds).set_index(['num_obj', 'num_seg'])['elapsed']
+    y.to_pickle(cache_path)
+
+    return y
+
+
+def main():
+
+    default_threshold = audformat.core.utils.UNION_MAX_NUM_SEG_THRES
+
+    num_segs = tuple(range(100, 1000, 100))
+    num_objs = (10, 100, 1000)
+    num_repeat = 5
+
+    for segmented in [False, True]:
+
+        print(f'{"segmented" if segmented else "filewise"} index')
+
+        # always use pd.concat()
+        y_pandas = benchmark(
+            segmented,
+            num_segs,
+            num_objs,
+            num_repeat,
+            0,
+        )
+
+        # use pd.concat() only when at least one index
+        # has more than UNION_MAX_NUM_SEG_THRES elements
+        # otherwise create index from lists
+        y_audformat = benchmark(
+            segmented,
+            num_segs,
+            num_objs,
+            num_repeat,
+            default_threshold,
+        )
+
+        df = pd.DataFrame(
+            {
+                'pandas': y_pandas.values,
+                'audformat': y_audformat.values,
+                'factor': (y_audformat / y_pandas).values,
+            },
+            index=y_pandas.index,
+        )
+        print(df.round(2))
+        print(df.mean())
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -101,7 +101,7 @@ def main():
         )
 
         # use pd.concat() only when at least one index
-        # has more than UNION_MAX_NUM_SEG_THRES elements
+        # has more than UNION_MAX_INDEX_LEN_THRES entries
         # otherwise create index from lists
         y_audformat = benchmark(
             segmented,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2707,6 +2707,13 @@ def test_to_filewise_index(tmpdir, obj, expected_file_names):
 
 
 @pytest.mark.parametrize(
+    'max_num_seg_thres',
+    [
+        None,  # default
+        0,     # force pd.concat() solution
+    ],
+)
+@pytest.mark.parametrize(
     'objs, expected',
     [
         # empty
@@ -2959,7 +2966,12 @@ def test_to_filewise_index(tmpdir, obj, expected_file_names):
         ),
     ]
 )
-def test_union(objs, expected):
+def test_union(max_num_seg_thres, objs, expected):
+
+    max_num_seg_thres_default = audformat.core.utils.UNION_MAX_NUM_SEG_THRES
+    if max_num_seg_thres is not None:
+        audformat.core.utils.UNION_MAX_NUM_SEG_THRES = max_num_seg_thres
+
     pd.testing.assert_index_equal(
         audformat.utils.union(objs),
         expected,
@@ -2980,3 +2992,5 @@ def test_union(objs, expected):
                 ]
             ),
         )
+
+    audformat.core.utils.UNION_MAX_NUM_SEG_THRES = max_num_seg_thres_default

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2968,9 +2968,9 @@ def test_to_filewise_index(tmpdir, obj, expected_file_names):
 )
 def test_union(max_num_seg_thres, objs, expected):
 
-    max_num_seg_thres_default = audformat.core.utils.UNION_MAX_NUM_SEG_THRES
+    max_num_seg_thres_default = audformat.core.utils.UNION_MAX_INDEX_LEN_THRES
     if max_num_seg_thres is not None:
-        audformat.core.utils.UNION_MAX_NUM_SEG_THRES = max_num_seg_thres
+        audformat.core.utils.UNION_MAX_INDEX_LEN_THRES = max_num_seg_thres
 
     pd.testing.assert_index_equal(
         audformat.utils.union(objs),
@@ -2993,4 +2993,4 @@ def test_union(max_num_seg_thres, objs, expected):
             ),
         )
 
-    audformat.core.utils.UNION_MAX_NUM_SEG_THRES = max_num_seg_thres_default
+    audformat.core.utils.UNION_MAX_INDEX_LEN_THRES = max_num_seg_thres_default


### PR DESCRIPTION
Applies the same technique as in https://github.com/audeering/audinterface/pull/107 to speed up `utils.union()`.

### Benchmark

```python
import audformat
import time

objs = []
for idx in range(1000):
  index = audformat.segmented_index(f'file{idx}.wav', 0, 1)
  objs.append(index)

t = time.time()
audformat.utils.union(objs)
print(time.time() - t)
```

* this branch: 6.7s
* main branch: 13.9s 