### PR TITLE
DOC: add ipykernel to requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
 
     - name: Test building documentation
       run: |
+        python -m jupyter kernelspec list
         # Disable -W until
         # https://github.com/audeering/audformat/issues/328
         # is solved

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,6 @@ jobs:
 
     - name: Test building documentation
       run: |
-        python -m jupyter kernelspec list
         # Disable -W until
         # https://github.com/audeering/audformat/issues/328
         # is solved

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 graphviz
+ipykernel
 jupyter-sphinx
 sphinx
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
As discussed in https://github.com/audeering/audformat/pull/354#issuecomment-1479352467,
building the documentation fails as no `python3` kernel can be found.

It seems that the kernel was before installed by some of the package `jupyter-sphinx` depend on, but I was not able to track this down.

I would suggest, we simply add it to the dependencies.