### PR TITLE
Allow to save database with missing attachments

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -970,10 +970,8 @@ class Database(HeaderBase):
             database object
 
         Raises:
-            FileNotFoundError: if a file or folder
-                associated with an attachment
+            FileNotFoundError: if the header file of the database
                 cannot be found
-                when using ``load_data=True``
 
         """
         ext = '.yaml'
@@ -990,11 +988,6 @@ class Database(HeaderBase):
 
             params = []
             table_ids = []
-
-            if 'attachments' in header and header['attachments']:
-                if load_data:
-                    for attachment_id in header['attachments']:
-                        db.attachments[attachment_id]._check_path(root)
 
             if 'tables' in header and header['tables']:
                 for table_id in header['tables']:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1169,8 +1169,6 @@ class Database(HeaderBase):
     ) -> Attachment:
         attachment._db = self
         attachment._id = attachment_id
-        if self.root is not None:
-            attachment._check_path(self.root)
         for other_id in list(self.attachments):
             attachment._check_overlap(self.attachments[other_id])
         return attachment

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -969,10 +969,6 @@ class Database(HeaderBase):
         Returns:
             database object
 
-        Raises:
-            FileNotFoundError: if the header file of the database
-                cannot be found
-
         """
         ext = '.yaml'
         root = audeer.path(root)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -555,14 +555,6 @@ class Database(HeaderBase):
                 on the machine multiplied by 5
             verbose: show progress bar
 
-        Raises:
-            FileNotFoundError: if a file or folder
-                associated with an attachment
-                cannot be found
-            RuntimeError: if a file or folder
-                associated with an attachment
-                is a symlink
-
         """
         root = audeer.mkdir(root)
 
@@ -593,10 +585,6 @@ class Database(HeaderBase):
                 progress_bar=verbose,
                 task_description='Save tables',
             )
-
-            # Check attachments exist
-            for attachment_id in list(self.attachments):
-                self.attachments[attachment_id]._check_path(root)
 
         self._name = name
         self._root = root

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -27,7 +27,7 @@ def test_attachment(tmpdir):
         with pytest.raises(ValueError, match=re.escape(error_msg)):
             audformat.Attachment(path)
 
-    # Create database (path does not need to exist)
+    # Create database, path does not need to exist
     file_path = 'attachments/file.txt'
     folder_path = 'attachments/folder'
     db = audformat.Database('db')
@@ -53,29 +53,19 @@ def test_attachment(tmpdir):
     db_path = audeer.path(tmpdir, 'db')
     audeer.mkdir(db_path)
 
-    # Save database, path needs to exist
-    error_msg = (
-        f"The provided path '{file_path}' "
-        f"of attachment 'file' "
-        "does not exist."
-    )
-    with pytest.raises(FileNotFoundError, match=error_msg):
-        db.save(db_path)
+    # Save database, path does not need to exist
+    db.save(db_path)
 
-    # Save database, path is not allowed to be a symlink
+    # Save database, path is allowed to be a symlink
+    audeer.rmdir(db_path)
     audeer.mkdir(audeer.path(db_path, folder_path))
     os.symlink(
         audeer.path(db_path, folder_path),
         audeer.path(db_path, file_path),
     )
-    error_msg = (
-        f"The provided path '{file_path}' "
-        f"of attachment 'file' "
-        "must not be a symlink."
-    )
-    with pytest.raises(RuntimeError, match=error_msg):
-        db.save(db_path)
+    db.save(db_path)
 
+    # Replace symlink by file
     os.remove(os.path.join(db_path, file_path))
     audeer.touch(audeer.path(db_path, file_path))
     db.save(db_path)

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -88,7 +88,7 @@ def test_attachment(tmpdir):
 
     # Load database
     #
-    # path needs not to exist when loading the database
+    # path must not exist when loading the database
     audeer.rmdir(audeer.path(db_path, os.path.dirname(file_path)))
     assert not os.path.exists(audeer.path(db_path, file_path))
     audformat.Database.load(db_path, load_data=True)

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -88,18 +88,11 @@ def test_attachment(tmpdir):
 
     # Load database
     #
-    # path needs to exist when requesting data
+    # path needs not to exist when loading the database
     audeer.rmdir(audeer.path(db_path, os.path.dirname(file_path)))
     assert not os.path.exists(audeer.path(db_path, file_path))
-    error_msg = (
-        f"The provided path '{file_path}' "
-        f"of attachment 'file' "
-        "does not exist."
-    )
-    with pytest.raises(FileNotFoundError, match=error_msg):
-        db = audformat.Database.load(db_path, load_data=True)
-    # but not when not requesting data
-    db = audformat.Database.load(db_path, load_data=False)
+    audformat.Database.load(db_path, load_data=True)
+    audformat.Database.load(db_path, load_data=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This removes checks introduced in https://github.com/audeering/audformat/pull/318 that ensure the path of an attachment exists and is no symlink when saving a database to disk or assigning an attachment to a database.

The idea is that we support saving a database with empty attachments and treat them like media files.
The actual checking if the files exist are then done by `audb` when publishing the database, see https://github.com/audeering/audb/pull/262

I did not delete `audformat.Attachment._check_path()` as the method is still used to raise the error for non-existing files or symlinks when calling `audformat.Attachment.files`.