### PR TITLE
Release 0.16.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 0.16.1 (2023-03-29)
+---------------------------
+
+* Added: ``copy_attachments`` argument
+  to ``audformat.Database.update()``
+* Changed: preserve ``dtypes``
+  when ``audformat.Table.get()``
+  is called with an index
+* Changed: speed up ``audformat.utils.union()``
+* Changed: allow to save a database
+  with missing attachments
+
+
 Version 0.16.0 (2023-01-12)
 ---------------------------
 


### PR DESCRIPTION
To continue with https://github.com/audeering/audb/pull/262 I propose that we make a new `audformat` release.

![image](https://user-images.githubusercontent.com/173624/228449991-6885ac2d-b402-4ff9-9052-fb6382ef15d0.png)
