### PR TITLE
CI: make doc test an extra Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes graphviz libsndfile1
+        sudo apt-get install --no-install-recommends --yes libsndfile1
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
 
     - name: Install dependencies
@@ -48,7 +48,6 @@ jobs:
         python -V
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
     - name: Test with pytest
@@ -60,13 +59,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-20.04'
-
-    - name: Test building documentation
-      run: |
-        # Disable -W until
-        # https://github.com/audeering/audformat/issues/328
-        # is solved
-        python -m sphinx docs/ docs/_build/ -b html # -W
-        python -m sphinx docs/ build/sphinx/html -b linkcheck
       if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
Separates the doc test into an extra Action.

It also re-enables failing the doc test when a warning is raised since https://github.com/audeering/audformat/issues/328 is closed.