### PR TITLE
Support pandas >= 2.0.0

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -261,6 +261,8 @@ def concat(
             )
         columns_reindex[column.name][column.index] = column
 
+    # Use `None` to force `{}` return the correct index, see
+    # https://github.com/pandas-dev/pandas/issues/52404
     df = pd.DataFrame(columns_reindex or None, index=index)
 
     if not return_as_frame and len(df.columns) == 1:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -261,7 +261,7 @@ def concat(
             )
         columns_reindex[column.name][column.index] = column
 
-    df = pd.DataFrame(columns_reindex, index=index)
+    df = pd.DataFrame(columns_reindex or None, index=index)
 
     if not return_as_frame and len(df.columns) == 1:
         return df[df.columns[0]]
@@ -1281,8 +1281,8 @@ def set_index_dtypes(
         dtype: object
         >>> index5 = set_index_dtypes(index3, 'string')
         >>> index5.dtypes
-        level1    string
-        level2    string
+        level1    string[python]
+        level2    string[python]
         dtype: object
 
     """

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 audiofile >=1.1.0
+pandas >=2.0.0
 pytest
 pytest-doctestplus
 pytest-console-scripts

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2261,13 +2261,13 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
         ),
         (
             audformat.filewise_index(['1', '2']),
-            'int',
+            'int64',
             pd.Index([1, 2], name='file'),
         ),
         (
             audformat.segmented_index(['1', '2'], [0, 0], [1, 1]),
             {
-                'file': 'int',
+                'file': 'int64',
                 'start': 'str',
                 'end': 'str',
             },
@@ -2289,7 +2289,7 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
                 names=['idx', 'time'],
             ),
             {
-                'idx': 'int',
+                'idx': 'int64',
                 'time': 'timedelta64[ns]',
             },
             pd.MultiIndex.from_arrays(
@@ -2309,7 +2309,7 @@ def test_replace_file_extension(index, extension, pattern, expected_index):
                 names=['idx', 'date'],
             ),
             {
-                'idx': 'int',
+                'idx': 'int64',
                 'date': 'datetime64[ns]',
             },
             pd.MultiIndex.from_arrays(


### PR DESCRIPTION
Closes #362 

As mentioned in #362 we have two failings tests with pandas 2.0. 

The first one is because the pandas string type now prints `string[pandas]` instead of just `string`. We fix it by requiring `pandas >= 2.0.0` in the test requirements. 

The second one turned out a little bit more tricky but basically boils down to a change how the column index is created for an empty `DataFrame` (see https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html#empty-dataframes-series-will-now-default-to-have-a-rangeindex):

pre 2.0.0:

```python
>>> pd.DataFrame().columns
Index([], dtype='object')
```

with 2.0.0:

```python
>>> pd.DataFrame().columns
RangeIndex(start=0, stop=0, step=1)
```

In principle this would not be a problem, but for some reason (bug?) with 2.0.0 you still get:

```python
>>> pd.DataFrame({}).columns
Index([], dtype='object')
```

We fix it by setting `None` if a `DataFrame` is created with `{}`.