### PR TITLE
Force timezone unaware dates in Column.set()

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -338,6 +338,14 @@ class Column(HeaderBase):
             if is_scalar(values):
                 values = [values] * len(index)
             values = to_array(values)
+            if dtype == 'datetime64[ns]':
+                # Ensure all date values are timezone unaware,
+                # see https://github.com/audeering/audformat/issues/364
+                values = [
+                    pd.to_datetime(value).tz_localize(None)
+                    if value is not None else value
+                    for value in values
+                ]
             with warnings.catch_warnings():
                 # Avoid FutureWarning and DeprecationWarning
                 # for pandas 1.5.0 to 1.5.3

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -359,6 +359,17 @@ def test_segmented(num_files, num_segments_per_file, values):
     pd.testing.assert_series_equal(table.df[column_id], series)
 
 
+def test_set_dates():
+    # Ensure we handle dates with different time zones,
+    # see https://github.com/audeering/audformat/issues/364
+    db = audformat.Database('db')
+    db.schemes['date'] = audformat.Scheme('date')
+    db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
+    db['table']['column'] = audformat.Column(scheme_id='date')
+    db['table']['column'].set(pd.to_datetime([1, 1], utc=True))
+    # TODO: add assert statement
+
+
 def test_set_labels():
     # Ensure we handle NaN when setting labels
     # from Series and ndarray,

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -359,15 +359,33 @@ def test_segmented(num_files, num_segments_per_file, values):
     pd.testing.assert_series_equal(table.df[column_id], series)
 
 
-def test_set_dates():
+@pytest.mark.parametrize(
+    'timezone, values, expected_dates',
+    [
+        (
+            'UTC',
+            [1],
+            [pd.Timestamp('1970-01-01T00:00:00.000000001')],
+        ),
+        (
+            'Europe/Berlin',
+            [1],
+            [pd.Timestamp('1970-01-01T01:00:00.000000001')],
+        ),
+    ]
+)
+def test_set_dates(timezone, values, expected_dates):
     # Ensure we handle dates with different time zones,
     # see https://github.com/audeering/audformat/issues/364
     db = audformat.Database('db')
     db.schemes['date'] = audformat.Scheme('date')
-    db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
+    index = audformat.filewise_index([f'f{n}' for n in range(len(values))])
+    db['table'] = audformat.Table(index)
     db['table']['column'] = audformat.Column(scheme_id='date')
-    db['table']['column'].set(pd.to_datetime([1, 1], utc=True))
-    # TODO: add assert statement
+    dates = pd.to_datetime(values, utc=True)
+    dates = dates.tz_convert(timezone)
+    db['table']['column'].set(dates)
+    assert list(db['table'].df.column) == expected_dates
 
 
 def test_set_labels():


### PR DESCRIPTION
Closes #364

This ensures that whenever we set values to a column with a scheme of type `date` the values are timezone unaware (compare https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.tz_localize.html and https://pandas.pydata.org/docs/reference/api/pandas.DatetimeIndex.tz_convert.html#pandas.DatetimeIndex.tz_convert) as we don't store a timezone in `audformat`.

I also added a test that checks that the values are adjusted for a given timezone when converting them to an timezone unaware format.