### PR TITLE
DOC: add raises section to Database.attachments

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -188,7 +188,13 @@ class Database(HeaderBase):
             value_type=Attachment,
             set_callback=self._set_attachment,
         )
-        r"""Dictionary of attachments"""
+        r"""Dictionary of attachments.
+
+        Raises:
+            RuntimeError: if the path of a newly assigned attachment
+                overlaps with the path of already assigned attachments
+
+        """
         self.media = HeaderDict(value_type=Media)
         r"""Dictionary of media information"""
         self.raters = HeaderDict(value_type=Rater)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -192,7 +192,7 @@ class Database(HeaderBase):
 
         Raises:
             RuntimeError: if the path of a newly assigned attachment
-                overlaps with the path of already assigned attachments
+                overlaps with the path of an existing attachment
 
         """
         self.media = HeaderDict(value_type=Media)


### PR DESCRIPTION
Closes #357

This adds a raises section to the `audformat.Database.attachments` property. It feels a little bit strange to add it to a property, but I couldn't find another matching place to add this error that might happen when a new attachment is assigned to a database object, e.g. `db.attachments['file'] = audformat.Attachment('file.txt')`.

![image](https://user-images.githubusercontent.com/173624/231468365-b8a5ccb2-a47b-4c76-8a21-ff049f0c1c9c.png)
