### PR TITLE
DOC: add missing entries to header specification

### DIFF
--- a/docs/data-header.rst
+++ b/docs/data-header.rst
@@ -32,11 +32,15 @@ source          yes        Original source,
 usage           yes        What the database can be used for,
                            one of ``'commercial'``, ``'other'``,
                            ``'research'``, ``'restricted'``, ``'unrestricted'``
+author                     Author(s) of the database
 description                Description of the database
 expires                    Until when we are allowed to use the data
 languages                  List of languages that appear in the media files
+license                    License of the database
+license_url                Link to license statement
 attachments                Dictionary of attachment objects (see below)
 media                      Dictionary of media objects (see below)
+organization               Organization that created the database
 raters                     Dictionary of rater objects (see below)
 schemes                    Dictionary of scheme objects (see below)
 splits                     Dictionary of rater objects (see below)


### PR DESCRIPTION
Closes #353 

This extends the database header specification by the following non-mandatory entries:

* author
* license
* lcense_url
* organization

![image](https://user-images.githubusercontent.com/173624/231790022-3e9fad98-1d16-4399-9fae-a7c6f6c6864f.png)
