### PR TITLE
DOC: add example to utils.to_filewise_index()

### DIFF
--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -17,8 +17,6 @@ def prepare_docstring_tests(doctest_namespace):
 
         # audformat.utils.to_filewise_index()
         audiofile.write(audeer.path(tmp, 'f.wav'), np.ones((1, 8000)), 8000)
-        assert os.path.exists(audeer.path(tmp, 'f.wav'))
-        assert audiofile.duration(audeer.path(tmp, 'f.wav')) == 1.0
 
         current_dir = os.getcwd()
         os.chdir(tmp)

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -15,11 +15,11 @@ def prepare_docstring_tests(doctest_namespace):
     with tempfile.TemporaryDirectory() as tmp:
         doctest_namespace['tmp'] = tmp
 
-        # audformat.utils.to_filewise_index()
-        audiofile.write(audeer.path(tmp, 'f.wav'), np.ones((1, 8000)), 8000)
-
         current_dir = os.getcwd()
         os.chdir(tmp)
+
+        # audformat.utils.to_filewise_index()
+        audiofile.write('f.wav', np.ones((1, 8000)), 8000)
 
         yield
 

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import audiofile
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='package', autouse=True)
 def prepare_docstring_tests(doctest_namespace):
 
     # Prepare files and tmp folder needed in doctests

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -4,7 +4,6 @@ import tempfile
 import numpy as np
 import pytest
 
-import audeer
 import audiofile
 
 

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import numpy as np
@@ -16,5 +17,12 @@ def prepare_docstring_tests(doctest_namespace):
 
         # audformat.utils.to_filewise_index()
         audiofile.write(audeer.path(tmp, 'f.wav'), np.ones((1, 8000)), 8000)
+        assert os.path.exists(audeer.path(tmp, 'f.wav'))
+        assert audiofile.duration(audeer.path(tmp, 'f.wav')) == 1.0
 
-    yield
+        current_dir = os.getcwd()
+        os.chdir(tmp)
+
+        yield
+
+        os.chdir(current_dir)

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -1,4 +1,4 @@
-import os
+import tempfile
 
 import numpy as np
 import pytest
@@ -8,19 +8,13 @@ import audiofile
 
 
 @pytest.fixture(scope='session', autouse=True)
-def prepare_docstring_tests():
+def prepare_docstring_tests(doctest_namespace):
 
-    # Prepare WAV files needed in doctests
-    #
-    # audformat.utils.to_filewise_index()
-    audiofile.write('f.wav', np.ones((1, 8000)), 8000)
+    # Prepare files and tmp folder needed in doctests
+    with tempfile.TemporaryDirectory() as tmp:
+        doctest_namespace['tmp'] = tmp
+
+        # audformat.utils.to_filewise_index()
+        audiofile.write(audeer.path(tmp, 'f.wav'), np.ones((1, 8000)), 8000)
 
     yield
-
-    # Remove WAV files
-    # and files generated during the doctests
-    #
-    # audformat.utils.to_filewise_index()
-    audeer.rmdir('split')
-    if os.path.exists('f.wav'):
-        os.remove('f.wav')

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import numpy as np
+import pytest
+
+import audeer
+import audiofile
+
+
+@pytest.fixture(scope='session', autouse=True)
+def prepare_docstring_tests():
+
+    # Prepare WAV files needed in doctests
+    #
+    # audformat.utils.to_filewise_index()
+    audiofile.write('f.wav', np.ones((1, 8000)), 8000)
+
+    yield
+
+    # Remove WAV files
+    # and files generated during the doctests
+    #
+    # audformat.utils.to_filewise_index()
+    audeer.rmdir('split')
+    if os.path.exists('f.wav'):
+        os.remove('f.wav')

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1406,7 +1406,6 @@ def to_filewise_index(
         ...     starts=[0, 0.5],
         ...     ends=[0.5, 1],
         ... )
-        >>> # Split into single files
         >>> to_filewise_index(index, '.', 'split')
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -31,6 +31,7 @@ from audformat.core.scheme import Scheme
 if platform.system() in ['Windows']:  # pragma: no cover
     __doctest_skip__ = [
         'expand_file_path',
+        'to_filewise_index',
     ]
 
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1408,6 +1408,7 @@ def to_filewise_index(
         ...     starts=[0, 0.5],
         ...     ends=[0.5, 1],
         ... )
+        >>> # Split into single files
         >>> to_filewise_index(index, '.', 'split')
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
         >>> audiofile.duration('split/f_0.wav')

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1399,6 +1399,20 @@ def to_filewise_index(
         ValueError: if ``output_folder`` contained in path to files of
             original data
 
+    Examples:
+        >>> # Create a 1s audio file + segmented index
+        >>> import audiofile
+        >>> audiofile.write('f.wav', np.ones((1, 8000)), 8000)
+        >>> index = segmented_index(
+        ...     files=['f.wav', 'f.wav'],
+        ...     starts=[0, 0.5],
+        ...     ends=[0.5, 1],
+        ... )
+        >>> to_filewise_index(index, '.', 'split')
+        Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
+        >>> audiofile.duration('split/f_0.wav')
+        0.5
+
     """
     if is_filewise_index(obj):
         return obj

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1407,7 +1407,7 @@ def to_filewise_index(
         ...     ends=[0.5, 1],
         ... )
         >>> # Split into single files
-        >>> to_filewise_index(index, tmp, os.path.join(tmp, 'split'))
+        >>> to_filewise_index(index, '.', 'split')
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
 
     """

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1407,7 +1407,7 @@ def to_filewise_index(
         ...     ends=[0.5, 1],
         ... )
         >>> # Split into single files
-        >>> to_filewise_index(index, '.', 'split')
+        >>> to_filewise_index(index, tmp, os.path.join(tmp, 'split'))
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
 
     """

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1401,9 +1401,6 @@ def to_filewise_index(
             original data
 
     Examples:
-        >>> # Create a 1s audio file + segmented index
-        >>> import audiofile
-        >>> audiofile.write('f.wav', np.ones((1, 8000)), 8000)
         >>> index = segmented_index(
         ...     files=['f.wav', 'f.wav'],
         ...     starts=[0, 0.5],
@@ -1412,8 +1409,6 @@ def to_filewise_index(
         >>> # Split into single files
         >>> to_filewise_index(index, '.', 'split')
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
-        >>> audiofile.duration('split/f_0.wav')
-        0.5
 
     """
     if is_filewise_index(obj):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,7 @@ def create_audio_files():
     )
     yield
     shutil.rmtree(pytest.DB_ROOT)
+    # Clean up docstring generated files
+    # from audformat.utils.to_filewise_index()
+    shutil.rmtree('split')
+    os.remove('f.wav')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
-import shutil
 
 import pandas as pd
 import pytest
 
+import audeer
 import audformat.testing
 
 
@@ -24,8 +24,8 @@ def create_audio_files():
         file_duration=pytest.FILE_DUR,
     )
     yield
-    shutil.rmtree(pytest.DB_ROOT)
+    audeer.rmdir(pytest.DB_ROOT)
     # Clean up docstring generated files
     # from audformat.utils.to_filewise_index()
-    shutil.rmtree('split')
+    audeer.rmdir('split')
     os.remove('f.wav')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
+import shutil
 
 import pandas as pd
 import pytest
 
-import audeer
 import audformat.testing
 
 
@@ -24,9 +24,4 @@ def create_audio_files():
         file_duration=pytest.FILE_DUR,
     )
     yield
-    audeer.rmdir(pytest.DB_ROOT)
-    # Clean up docstring generated files
-    # from audformat.utils.to_filewise_index()
-    audeer.rmdir('split')
-    if os.path.exists('f.wav'):
-        os.remove('f.wav')
+    shutil.rmtree(pytest.DB_ROOT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,4 +28,5 @@ def create_audio_files():
     # Clean up docstring generated files
     # from audformat.utils.to_filewise_index()
     audeer.rmdir('split')
-    os.remove('f.wav')
+    if os.path.exists('f.wav'):
+        os.remove('f.wav')


### PR DESCRIPTION
Closes #288 

This adds a docstring example to `audformat.utils.to_filewise_index()`.

![image](https://user-images.githubusercontent.com/173624/232059474-0fbe1472-937c-4af2-9d6e-217806ef2c96.png)
