### PR TITLE
Support relative path in expand_file_path()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -491,8 +491,7 @@ def expand_file_path(
     and puts it in front of the file path in the index.
 
     Args:
-        index: index with absolute or relative file path
-            conform to
+        index: index conform to
             :ref:`table specifications <data-tables:Tables>`
         root: relative or absolute path added in front
             of the index file path
@@ -507,8 +506,8 @@ def expand_file_path(
     Examples:
         >>> expand_file_path(filewise_index(['f1', 'f2']), '/a')
         Index(['/a/f1', '/a/f2'], dtype='string', name='file')
-        >>> expand_file_path(filewise_index(['/f1', '/f2']), './a')
-        Index(['a//f1', 'a//f2'], dtype='string', name='file')
+        >>> expand_file_path(filewise_index(['f1', 'f2']), './a')
+        Index(['a/f1', 'a/f2'], dtype='string', name='file')
 
     """  # noqa: E501
     if len(index) == 0:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -509,7 +509,7 @@ def expand_file_path(
         >>> index
         Index(['/b/f1', '/b/f2'], dtype='string', name='file')
         >>> expand_file_path(index, './a')
-        Index(['a/b/f1', 'a/b/f2'], dtype='string', name='file')
+        Index(['a//b/f1', 'a//b/f2'], dtype='string', name='file')
 
     """  # noqa: E501
     if len(index) == 0:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -483,7 +483,12 @@ def expand_file_path(
         index: pd.Index,
         root: str,
 ) -> pd.Index:
-    r"""Expand relative path in index with root.
+    r"""Expand path in index with root.
+
+    It applies :func:`os.path.normpath`
+    to the provided path ``root``,
+    adds a file separator at its end
+    and puts it in front of the file path in the index.
 
     Args:
         index: index with absolute or relative file path
@@ -500,16 +505,10 @@ def expand_file_path(
             :ref:`table specifications <data-tables:Tables>`
 
     Examples:
-        >>> index = filewise_index(['f1', 'f2'])
-        >>> index
-        Index(['f1', 'f2'], dtype='string', name='file')
-        >>> expand_file_path(index, '/some/where')
-        Index(['/some/where/f1', '/some/where/f2'], dtype='string', name='file')
-        >>> index = filewise_index(['/b/f1', '/b/f2'])
-        >>> index
-        Index(['/b/f1', '/b/f2'], dtype='string', name='file')
-        >>> expand_file_path(index, './a')
-        Index(['a//b/f1', 'a//b/f2'], dtype='string', name='file')
+        >>> expand_file_path(filewise_index(['f1', 'f2']), '/a')
+        Index(['/a/f1', '/a/f2'], dtype='string', name='file')
+        >>> expand_file_path(filewise_index(['/f1', '/f2']), './a')
+        Index(['a//f1', 'a//f2'], dtype='string', name='file')
 
     """  # noqa: E501
     if len(index) == 0:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -910,31 +910,11 @@ def test_duration(obj, expected_duration):
         ),
         (
             audformat.filewise_index(['f1', 'f2']),
-            '/some/where',
+            audeer.path('/some', 'where'),
             audformat.filewise_index(
                 [
-                    '/some/where/f1',
-                    '/some/where/f2',
-                ]
-            ),
-        ),
-        (
-            audformat.filewise_index(['f1', 'f2']),
-            'some/where',
-            audformat.filewise_index(
-                [
-                    'some/where/f1',
-                    'some/where/f2',
-                ]
-            ),
-        ),
-        (
-            audformat.filewise_index(['f1', 'f2']),
-            os.path.join('some', 'where'),
-            audformat.filewise_index(
-                [
-                    os.path.join('some', 'where', 'f1'),
-                    os.path.join('some', 'where', 'f2'),
+                    audeer.path('/some', 'where', 'f1'),
+                    audeer.path('/some', 'where', 'f2'),
                 ]
             ),
         ),
@@ -945,6 +925,16 @@ def test_duration(obj, expected_duration):
                 [
                     audeer.path('some', 'where', 'f1'),
                     audeer.path('some', 'where', 'f2'),
+                ]
+            ),
+        ),
+        (
+            audformat.filewise_index(['f1', 'f2']),
+            os.path.join('some', 'where'),
+            audformat.filewise_index(
+                [
+                    os.path.join('some', 'where', 'f1'),
+                    os.path.join('some', 'where', 'f2'),
                 ]
             ),
         ),
@@ -983,11 +973,11 @@ def test_duration(obj, expected_duration):
                 ['1s', '3s'],
                 ['2s', '4s'],
             ),
-            '/some/where',
+            audeer.path('/some', 'where'),
             audformat.segmented_index(
                 [
-                    '/some/where/f1',
-                    '/some/where/f2',
+                    audeer.path('/some', 'where', 'f1'),
+                    audeer.path('/some', 'where', 'f2'),
                 ],
                 ['1s', '3s'],
                 ['2s', '4s'],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -910,17 +910,37 @@ def test_duration(obj, expected_duration):
         ),
         (
             audformat.filewise_index(['f1', 'f2']),
-            '.',
+            '/some/where',
             audformat.filewise_index(
                 [
-                    audeer.path('f1'),
-                    audeer.path('f2'),
+                    '/some/where/f1',
+                    '/some/where/f2',
+                ]
+            ),
+        ),
+        (
+            audformat.filewise_index(['f1', 'f2']),
+            'some/where',
+            audformat.filewise_index(
+                [
+                    'some/where/f1',
+                    'some/where/f2',
                 ]
             ),
         ),
         (
             audformat.filewise_index(['f1', 'f2']),
             os.path.join('some', 'where'),
+            audformat.filewise_index(
+                [
+                    os.path.join('some', 'where', 'f1'),
+                    os.path.join('some', 'where', 'f2'),
+                ]
+            ),
+        ),
+        (
+            audformat.filewise_index(['f1', 'f2']),
+            audeer.path('some', 'where'),
             audformat.filewise_index(
                 [
                     audeer.path('some', 'where', 'f1'),
@@ -933,18 +953,8 @@ def test_duration(obj, expected_duration):
             os.path.join('some', 'where') + os.path.sep,
             audformat.filewise_index(
                 [
-                    audeer.path('some', 'where', 'f1'),
-                    audeer.path('some', 'where', 'f2'),
-                ]
-            ),
-        ),
-        (
-            audformat.filewise_index(['f1', 'f2']),
-            audeer.path('some', 'where'),
-            audformat.filewise_index(
-                [
-                    audeer.path('some', 'where', 'f1'),
-                    audeer.path('some', 'where', 'f2'),
+                    os.path.join('some', 'where', 'f1'),
+                    os.path.join('some', 'where', 'f2'),
                 ]
             ),
         ),
@@ -973,11 +983,11 @@ def test_duration(obj, expected_duration):
                 ['1s', '3s'],
                 ['2s', '4s'],
             ),
-            '.',
+            '/some/where',
             audformat.segmented_index(
                 [
-                    audeer.path('f1'),
-                    audeer.path('f2'),
+                    '/some/where/f1',
+                    '/some/where/f2',
                 ],
                 ['1s', '3s'],
                 ['2s', '4s'],


### PR DESCRIPTION
Closes #371 

This extends `audformat.expand_file_path()` to support relative and absolute path in both arguments (`root` and `index`).

![image](https://user-images.githubusercontent.com/173624/232040887-8a16d613-e5c1-4537-b856-32c9f1d8ba9a.png)
