### PR TITLE
TST: Use temporary working directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,11 @@ import pytest
 import audformat.testing
 
 
+pytest.DB = audformat.testing.create_db()
+pytest.DB_ROOT = 'db'
+pytest.FILE_DUR = pd.to_timedelta('1s')
+
+
 @pytest.fixture(scope='package', autouse=True)
 def prepare_tests():
 
@@ -32,8 +37,3 @@ def prepare_tests():
         yield
 
         os.chdir(current_dir)
-
-
-pytest.DB = audformat.testing.create_db()
-pytest.DB_ROOT = 'db'
-pytest.FILE_DUR = pd.to_timedelta('1s')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-import shutil
+import tempfile
 
 import pandas as pd
 import pytest
@@ -7,21 +7,33 @@ import pytest
 import audformat.testing
 
 
-pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
+@pytest.fixture(scope='package', autouse=True)
+def prepare_tests():
+
+    # Prepare files used in tests
+    # and set a temporary working directory
+    with tempfile.TemporaryDirectory() as tmp:
+
+        current_dir = os.getcwd()
+        os.chdir(tmp)
+
+        pytest.DB.save(pytest.DB_ROOT)
+
+        audformat.testing.create_audio_files(
+            pytest.DB,
+            pytest.DB.root,
+            file_duration=pytest.FILE_DUR,
+        )
+        audformat.testing.create_attachment_files(
+            pytest.DB,
+            pytest.DB.root,
+        )
+
+        yield
+
+        os.chdir(current_dir)
+
 
 pytest.DB = audformat.testing.create_db()
-pytest.DB_ROOT = os.path.join(pytest.ROOT, 'db')
-audformat.testing.create_attachment_files(pytest.DB, pytest.DB_ROOT)
-pytest.DB.save(pytest.DB_ROOT)
-
+pytest.DB_ROOT = 'db'
 pytest.FILE_DUR = pd.to_timedelta('1s')
-
-
-@pytest.fixture(scope='session', autouse=True)
-def create_audio_files():
-    audformat.testing.create_audio_files(
-        pytest.DB,
-        file_duration=pytest.FILE_DUR,
-    )
-    yield
-    shutil.rmtree(pytest.DB_ROOT)


### PR DESCRIPTION
Applies the same technique we used in #370 to set a temporary working directory when executing tests under `/tests`.