### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
-Version 1.0.0 (2023-04-17)
+Version 1.0.0 (2023-04-25)
 --------------------------
 
 * Added: ``audformat.Scheme.labels_as_list`` property

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,32 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.0.0 (2023-04-17)
+--------------------------
+
+* Added: ``audformat.Scheme.labels_as_list`` property
+  to list all scheme labels
+* Added: example to the documentation of
+  ``audformat.utils.to_filewise_index()``
+* Changed: convert dates to UTC timezone
+  in ``audformat.Column.set()``
+  when using a scheme of type ``'date'``
+* Fixed: support ``pandas>=2.0.0``
+* Fixed: mention ``author``,
+  ``license``,
+  ``license_url``,
+  ``organization``
+  in the specification documentation
+  of the database header
+* Fixed: missing ``Raises`` section
+  in the documentation of ``audformat.Database.load()``
+  and ``audformat.Database.attachments``
+* Fixed: when the ``root`` argument
+  of ``audformat.utils.expand_file_path()``
+  is a relative path
+  it is no longer expanded to an absolute path
+
+  
 Version 0.16.1 (2023-03-29)
 ---------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
-Version 1.0.0 (2023-04-25)
+Version 1.0.0 (2023-04-27)
 --------------------------
 
 * Added: ``audformat.Scheme.labels_as_list`` property


### PR DESCRIPTION
As the handling of the attachments in `audb` is now finished and working (https://github.com/audeering/audb/milestone/1), we should be able to make the 1.0.0 release for `audformat`.

![image](https://user-images.githubusercontent.com/173624/234866986-4b33e2a3-cb43-489c-8798-4c357d3da87d.png)
