### PR TITLE
Fix precision of start and end in segmented_index()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -28,6 +28,7 @@ from audformat.core.errors import (
     BadIdError,
     TableExistsError,
 )
+from audformat.core.index import to_timedelta
 from audformat.core.media import Media
 from audformat.core.rater import Rater
 from audformat.core.scheme import Scheme
@@ -423,7 +424,7 @@ class Database(HeaderBase):
 
             # calculate duration and cache it
             dur = audiofile.duration(full_file)
-            dur = pd.to_timedelta(dur, unit='s')
+            dur = to_timedelta(dur)
             self._files_duration[full_file] = dur
 
             return dur

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -32,7 +32,8 @@ def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
 def to_timedelta(time):
     r"""Convert time value to pd.Timedelta."""
     time = audmath.duration_in_seconds(time)
-    # Convert to milliseconds and round
+    # Limit precision to 6 digits
+    # by converting to milliseconds and rounding
     # to avoid rounding error in index
     # compare https://github.com/audeering/audinterface/issues/113
     time = round(float(time) * 10 ** 3, 3)

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -25,6 +25,7 @@ from audformat.core.index import (
     is_filewise_index,
     is_segmented_index,
     segmented_index,
+    to_timedelta,
 )
 from audformat.core.media import Media
 from audformat.core.rater import Rater
@@ -170,8 +171,10 @@ def add_table(
 
         for file in files:
 
-            times = [pd.to_timedelta(random.random() * file_duration, unit='s')
-                     for _ in range(num_segments_per_file * 2)]
+            times = [
+                to_timedelta(random.random() * file_duration)
+                for _ in range(num_segments_per_file * 2)
+            ]
             times.sort()
             starts.extend(times[::2])
             ends.extend(times[1::2])
@@ -259,7 +262,7 @@ def create_audio_files(
             "Cannot create files if databases is not portable."
         )
 
-    file_duration = pd.to_timedelta(file_duration)
+    file_duration = to_timedelta(file_duration)
 
     for file in db.files:
         path = os.path.join(db.root, file)

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ packages = find:
 install_requires =
     audeer >=1.19.0,<2.0.0
     audiofile >=0.4.0
+    audmath >=1.2.1
     iso-639
     iso3166
     oyaml

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -284,7 +284,6 @@ def test_index_type(index, index_type):
 def test_to_timedelta():
     # Test precision of time values stored in segmented index,
     # see https://github.com/audeering/audinterface/issues/113
-    duration = 2.522550
-    times = [duration]
-    times = audformat.core.index.to_timedelta(times)
-    assert times[0].total_seconds() == duration
+    time = 2.522550
+    time_timedelta = audformat.core.index.to_timedelta(time)
+    assert time_timedelta.total_seconds() == time

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -284,7 +284,7 @@ def test_index_type(index, index_type):
 def test_to_timedelta():
     # Test precision of time values stored in segmented index,
     # see https://github.com/audeering/audinterface/issues/113
-    duration = 2.5225
+    duration = 2.522550
     times = [duration]
     times = audformat.core.index.to_timedelta(times)
     assert times[0].total_seconds() == duration

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -279,3 +279,12 @@ def test_create_segmented_index(files, starts, ends):
 )
 def test_index_type(index, index_type):
     assert audformat.index_type(index) == index_type
+
+
+def test_to_timedelta():
+    # Test precision of time values stored in segmented index,
+    # see https://github.com/audeering/audinterface/issues/113
+    duration = 2.5225
+    times = [duration]
+    times = audformat.core.index.to_timedelta(times)
+    assert times[0].total_seconds() == duration


### PR DESCRIPTION
Relates to https://github.com/audeering/audinterface/issues/113

This ensures that the precision of the start and end values of a segmented index always end after 6 digits which should be sufficient for all possible audio sampling rates used in the near future.

It turned out that the solution proposed in https://github.com/audeering/audinterface/issues/113#issuecomment-1504741227 does not always work and I had to add some manual rounding as well.
I also added a test that was failing for the current master.

In addition to start and end values, it also fixes the precision for the stored duration of a database. If you prefer we can also move this to another pull request.