### PR TITLE
Ensure to_segmented_index() uses high precision

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1630,7 +1630,7 @@ def to_segmented_index(
             # by the collected duration values
 
             # Reverse durs list as pop()
-            # will return last enrty first
+            # will return last entry first
             durs.reverse()
 
             # Add an additional entry to the list

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1589,7 +1589,7 @@ def to_segmented_index(
 
         if any(has_nat):
 
-            # First gather duration values
+            # Gather duration values
             # for all NaT end entries
 
             idx_nat = np.where(has_nat)[0]
@@ -1626,7 +1626,7 @@ def to_segmented_index(
                 task_description='Read duration',
             )
 
-            # Now replace all NaT entries in end
+            # Replace all NaT entries in end
             # by the collected duration values.
             # We have to convert ends to a series first
             # in order to preserve precision of duration values
@@ -1635,8 +1635,6 @@ def to_segmented_index(
             ends[idx_nat] = durs
 
             # Create a new index
-            # as index.set_levels() does not work
-            # if the level contains only NaT entries
             index = segmented_index(files, starts, ends)
 
     if isinstance(obj, pd.Index):

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1647,6 +1647,9 @@ def to_segmented_index(
                     x = pd.to_timedelta(durs.pop(), unit='s')
                 return x
 
+            # Create a new index
+            # as index.set_levels() doe snot work
+            # if the level contains only NaT entries
             index = segmented_index(files, starts, ends.map(replace_nan))
 
     if isinstance(obj, pd.Index):

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1648,7 +1648,7 @@ def to_segmented_index(
                 return x
 
             # Create a new index
-            # as index.set_levels() doe snot work
+            # as index.set_levels() does not work
             # if the level contains only NaT entries
             index = segmented_index(files, starts, ends.map(replace_nan))
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1627,7 +1627,9 @@ def to_segmented_index(
             )
 
             # Now replace all NaT entries in end
-            # by the collected duration values
+            # by the collected duration values.
+            # We have to convert ends to a series first
+            # in order to preserve precision of duration values
 
             ends = ends.to_series()
             ends[idx_nat] = durs

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1629,28 +1629,13 @@ def to_segmented_index(
             # Now replace all NaT entries in end
             # by the collected duration values
 
-            # Reverse durs list as pop()
-            # will return last entry first
-            durs.reverse()
-
-            # Add an additional entry to the list
-            # as the very first entry
-            # passed by map() is the whole index
-            # which will also trigger a call
-            # to durs.pop()
-            # if ends contains only a single entry
-            if len(ends) == 1:
-                durs.append(0)
-
-            def replace_nan(x):
-                if pd.isna(x):
-                    x = pd.to_timedelta(durs.pop(), unit='s')
-                return x
+            ends = ends.to_series()
+            ends[idx_nat] = durs
 
             # Create a new index
             # as index.set_levels() does not work
             # if the level contains only NaT entries
-            index = segmented_index(files, starts, ends.map(replace_nan))
+            index = segmented_index(files, starts, ends)
 
     if isinstance(obj, pd.Index):
         return index

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2509,6 +2509,25 @@ def test_set_index_dtypes(index, dtypes, expected):
                 [pytest.FILE_DUR, pytest.FILE_DUR * 2],
             ),
         ),
+        # file duration and precision problem
+        (
+            audformat.segmented_index(
+                [pytest.DB.files[0]],
+                [0],
+                [pd.NaT],
+            ),
+            False,
+            {
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                pd.to_timedelta(2.5225, unit='s'),
+            },
+            pytest.DB_ROOT,
+            audformat.segmented_index(
+                [pytest.DB.files[0]],
+                [0],
+                [2.5225],
+            ),
+        ),
         # file not found
         pytest.param(
             audformat.filewise_index(pytest.DB.files[:2]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2539,9 +2539,9 @@ def test_set_index_dtypes(index, dtypes, expected):
             {
                 os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
                 pd.to_timedelta(2.5225, unit='s'),
-                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[1]):
                 pd.to_timedelta(2.37485, unit='s'),
-                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[2]):
                 pd.to_timedelta(3.458697083, unit='s'),
             },
             pytest.DB_ROOT,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2529,6 +2529,28 @@ def test_set_index_dtypes(index, dtypes, expected):
                 [2.5225],
             ),
         ),
+        (
+            audformat.segmented_index(
+                pytest.DB.files[:3],
+                [1, 0, 0],
+                [pd.NaT, 2.37485, pd.NaT],
+            ),
+            False,
+            {
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                pd.to_timedelta(2.5225, unit='s'),
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                pd.to_timedelta(2.37485, unit='s'),
+                os.path.join(pytest.DB_ROOT, pytest.DB.files[0]):
+                pd.to_timedelta(3.458697083, unit='s'),
+            },
+            pytest.DB_ROOT,
+            audformat.segmented_index(
+                pytest.DB.files[:3],
+                [1, 0, 0],
+                [2.5225, 2.37485, 3.458697083],
+            ),
+        ),
         # file not found
         pytest.param(
             audformat.filewise_index(pytest.DB.files[:2]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2509,7 +2509,8 @@ def test_set_index_dtypes(index, dtypes, expected):
                 [pytest.FILE_DUR, pytest.FILE_DUR * 2],
             ),
         ),
-        # file duration and precision problem
+        # file duration with high precision
+        # covering https://github.com/audeering/audformat/issues/379
         (
             audformat.segmented_index(
                 [pytest.DB.files[0]],


### PR DESCRIPTION
Closes #379 

This implements a test that fails for the problem described in #379 with:

```
>       pd.testing.assert_index_equal(result, expected)                                                                                                                                        
E       AssertionError: MultiIndex level [2] are different                                                                                                                                     
E                                                                                                                                                                                              
E       MultiIndex level [2] values are different (100.0 %)    
E       [left]:  TimedeltaIndex(['0 days 00:00:02.522499'], dtype='timedelta64[ns]', name='end', freq=None)
E       [right]: TimedeltaIndex(['0 days 00:00:02.522499999'], dtype='timedelta64[ns]', name='end', freq=None)
```

and fixes the test by updating the implementation as outlined in #379.
