### PR TITLE
Fix sorting of imports

### DIFF
--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -2,6 +2,7 @@ import os
 import typing
 
 import audeer
+
 from audformat.core.common import HeaderBase
 from audformat.core.common import is_relative_path
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -14,6 +14,8 @@ except ImportError:  # pragma: nocover
 import pandas as pd
 
 import audeer
+import audiofile
+
 from audformat.core import define
 from audformat.core import utils
 from audformat.core.attachment import Attachment
@@ -30,7 +32,6 @@ from audformat.core.scheme import Scheme
 from audformat.core.split import Split
 from audformat.core.table import MiscTable
 from audformat.core.table import Table
-import audiofile
 
 
 class Database(HeaderBase):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -8,6 +8,7 @@ import typing
 import pandas as pd
 
 import audeer
+
 from audformat.core import define
 from audformat.core import utils
 from audformat.core.column import Column

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -11,6 +11,8 @@ import numpy as np
 import pandas as pd
 
 import audeer
+import audiofile as af
+
 from audformat.core import define
 from audformat.core.attachment import Attachment
 from audformat.core.column import Column
@@ -25,7 +27,6 @@ from audformat.core.scheme import Scheme
 from audformat.core.split import Split
 from audformat.core.table import MiscTable
 from audformat.core.table import Table
-import audiofile as af
 
 
 def add_misc_table(

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -12,6 +12,8 @@ import numpy as np
 import pandas as pd
 
 import audeer
+import audiofile
+
 from audformat.core import define
 from audformat.core.common import to_audformat_dtype
 from audformat.core.database import Database
@@ -20,7 +22,6 @@ from audformat.core.index import is_filewise_index
 from audformat.core.index import is_segmented_index
 from audformat.core.index import segmented_index
 from audformat.core.scheme import Scheme
-import audiofile
 
 
 # Exclude examples that return a path containing `\`

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -5,6 +5,7 @@ import typing
 import pandas as pd
 
 import audeer
+
 import audformat
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,7 +163,7 @@ section-order = [
     'audeer',
     'audiofile',
     'audfactory',
-    'audformat',
+    'audinterface',
     'audmath',
     'audmetric',
     'audobject',

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 import audeer
+
 import audformat
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,9 +7,10 @@ import pandas as pd
 import pytest
 
 import audeer
+import audiofile
+
 import audformat
 import audformat.testing
-import audiofile
 
 
 def full_path(

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import audeer
+
 import audformat.testing
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 import audeer
+
 import audformat
 import audformat.testing
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 import audeer
+
 import audformat
 from audformat import define
 from audformat import utils


### PR DESCRIPTION
Ensures that `audformat` is treated as current project and not `audiofile` when sorting the imports with `ruff`.