### PR TITLE
Require pandas<2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     'iso3166',
     'oyaml',
     'pyyaml >=5.4.1',
-    'pandas >=1.4.1',
+    'pandas >=1.4.1,<2.1.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Relates to #391.

Until `pandas` has fixed the issue of changing `hash` values, we restrict its required version to <2.1.0.