### PR TITLE
Replace y[pos] by y.iloc[pos] for Series

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1630,7 +1630,7 @@ def to_segmented_index(
             # in order to preserve precision of duration values
 
             ends = ends.to_series()
-            ends[idx_nat] = durs
+            ends.iloc[idx_nat] = durs
 
             # Create a new index
             index = segmented_index(files, starts, ends)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -69,7 +69,7 @@ def test_filewise(num_files, values):
     series.iloc[0] = values[0]
     index = audformat.filewise_index(table.files[0])
     column.set(values[0], index=index)
-    pd.testing.assert_series_equal(column.get(index), series.iloc[0])
+    pd.testing.assert_series_equal(column.get(index), series.iloc[[0]])
     pd.testing.assert_series_equal(column.get(), series)
 
     # set slice
@@ -306,7 +306,7 @@ def test_segmented(num_files, num_segments_per_file, values):
         ends=table.ends[0],
     )
     column.set(values[0], index=index)
-    pd.testing.assert_series_equal(column.get(index), series.iloc[0])
+    pd.testing.assert_series_equal(column.get(index), series.iloc[[0]])
     pd.testing.assert_series_equal(column.get(), series)
 
     # set slice

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -66,10 +66,10 @@ def test_filewise(num_files, values):
     # set single
     series[:] = np.nan
     table.df['column'] = np.nan
-    series[0] = values[0]
+    series.iloc[0] = values[0]
     index = audformat.filewise_index(table.files[0])
     column.set(values[0], index=index)
-    pd.testing.assert_series_equal(column.get(index), series[[0]])
+    pd.testing.assert_series_equal(column.get(index), series.iloc[0])
     pd.testing.assert_series_equal(column.get(), series)
 
     # set slice
@@ -299,14 +299,14 @@ def test_segmented(num_files, num_segments_per_file, values):
     # set single
     series[:] = np.nan
     table.df['column'] = np.nan
-    series[0] = values[0]
+    series.iloc[0] = values[0]
     index = audformat.segmented_index(
         table.files[0],
         starts=table.starts[0],
         ends=table.ends[0],
     )
     column.set(values[0], index=index)
-    pd.testing.assert_series_equal(column.get(index), series[[0]])
+    pd.testing.assert_series_equal(column.get(index), series.iloc[0])
     pd.testing.assert_series_equal(column.get(), series)
 
     # set slice


### PR DESCRIPTION
Change deprecated Series assignments (which will raise a warning with `pandas` 2.1.0).