### PR TITLE
Fix audformat.utils.hash() for pandas>=2.1.0

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -546,7 +546,12 @@ def hash(
         '5251663970176285425'
 
     """
-    return str(pd.util.hash_pandas_object(obj).sum())
+    # Convert to int64
+    # to enforce same behavior
+    # across different pandas versions,
+    # see
+    # https://github.com/pandas-dev/pandas/issues/55452
+    return str(pd.util.hash_pandas_object(obj).astype('int64').sum())
 
 
 def index_has_overlap(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     'iso3166',
     'oyaml',
     'pyyaml >=5.4.1',
-    'pandas >=1.4.1,<2.1.0',
+    'pandas >=1.4.1',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)


### PR DESCRIPTION
Closes #391 

This fixes `audformat.utils.hash()` for `pandas>=2.1.0` by applying the workaround proposed in https://github.com/pandas-dev/pandas/issues/55452#issuecomment-1753152175.
The original code in `pandas` was casting the hashes to `int64` before summing, which was a long time bug that was fixed in https://github.com/pandas-dev/pandas/pull/53418. In order to provide backward compatibility we now always cast the hashes to `int64`.