### PR TITLE
Add audformat.Database.get()

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -519,6 +519,18 @@ class Database(HeaderBase):
         Returns:
             data frame with values
 
+        Raises:
+            ValueError: if different labels are found
+                for a requested scheme under the same index entry
+            ValueError: if ``original_column_names`` is ``True``
+                and two columns in the returned data frame
+                have the same name
+                and cannot be joined
+                due to overlapping data
+                or different data type
+            TypeError: if labels of different data type are found
+                for a requested scheme
+
         Examples:
             Return all labels that match a requested scheme.
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -702,9 +702,9 @@ class Database(HeaderBase):
         additional_schemes = audeer.to_list(additional_schemes)
 
         if tables is None:
-            selected_tables = list(self.tables)
+            tables = list(self.tables)
         else:
-            selected_tables = audeer.to_list(tables)
+            tables = audeer.to_list(tables)
         if splits is not None:
             splits = audeer.to_list(splits)
 
@@ -733,7 +733,7 @@ class Database(HeaderBase):
 
         # --- Get data for requested schemes
         ys_requested_scheme = []
-        for table_id in selected_tables:
+        for table_id in tables:
 
             # Handle non-existing tables
             if table_id not in self.tables:
@@ -832,42 +832,29 @@ class Database(HeaderBase):
             obj = obj.to_frame()
 
         # Append additional schemes
-        if len(additional_schemes) > 0:
-
-            # Limit available index in database
-            if (
-                    (tables is not None or splits is not None)
-                    and len(obj) > 0
-            ):
-                for _, table in self.tables.items():
-                    table._df = table.get(
-                        utils.intersect([table.index, index]),
-                        copy=False,
-                    )
-
-            objs = [obj]
-            for scheme in additional_schemes:
-                if len(obj) == 0:
-                    obj = pd.DataFrame(
-                        {
-                            scheme: [],
-                        },
-                        index=filewise_index(),
-                        dtype='object',
-                    )
-                else:
-                    obj = self.get(
-                        scheme,
-                        strict=strict,
-                        original_column_names=original_column_names,
-                        aggregate_function=aggregate_function,
-                    )
-                objs.append(obj)
-            if len(objs) > 1:
-                obj = utils.concat(objs)
-                obj = obj.loc[index]
-                if len(obj) == 0:
-                    obj.index = filewise_index()
+        objs = [obj]
+        for scheme in additional_schemes:
+            if len(obj) == 0:
+                obj = pd.DataFrame(
+                    {
+                        scheme: [],
+                    },
+                    index=filewise_index(),
+                    dtype='object',
+                )
+            else:
+                obj = self.get(
+                    scheme,
+                    strict=strict,
+                    original_column_names=original_column_names,
+                    aggregate_function=aggregate_function,
+                )
+            objs.append(obj)
+        if len(objs) > 1:
+            obj = utils.concat(objs)
+            obj = obj.loc[index]
+            if len(obj) == 0:
+                obj.index = filewise_index()
 
         return obj
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -650,13 +650,19 @@ class Database(HeaderBase):
             wav/03a04Wc.wav      anger  boredom
             wav/03a05Aa.wav       fear  sadness
             ...
-            >>> db.get('emotion', aggregate_function=lambda y: y.mode())
-            ...
+            >>> db.get('emotion', aggregate_function=lambda y: y.mode()[0]).head()
+                               emotion
+            file
+            wav/03a01Fa.wav  happiness
+            wav/03a01Nc.wav    neutral
+            wav/03a01Wa.wav      anger
+            wav/03a02Fc.wav  happiness
+            wav/03a02Nc.wav    neutral
 
             Alternatively,
             use ``original_column_names`` to return column IDs.
 
-            >>> db.get('emotion', original_column_names=True)
+            >>> db.get('emotion', original_column_names=True).head()
                                emotion     random
             file
             wav/03a01Fa.wav  happiness  happiness

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -793,7 +793,9 @@ class Database(HeaderBase):
             for n, y in enumerate(ys_requested_scheme):
                 if not isinstance(y.dtype, pd.CategoricalDtype):
                     ys_requested_scheme[n] = y.astype(
-                        pd.CategoricalDtype(set(y.array.astype(dtype)))
+                        pd.CategoricalDtype(
+                            y.array.dropna().unique().astype(dtype)
+                        )
                     )
             # Find union of categorical data
             data = [y.array for y in ys_requested_scheme]

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -765,8 +765,11 @@ class Database(HeaderBase):
             ]
             if len(categorical_dtypes) > 0:
                 if len(set(dtypes_of_categories)) > 1:
-                    raise ValueError(
-                        'All categorical data must have the same dtype.'
+                    # Don't know if this can ever be triggered,
+                    # but make sure we raise the same error as
+                    # pd.api.types.union_categoricals
+                    raise TypeError(  # pragma: nocover
+                        'dtype of categories must be the same'
                     )
                 dtype = dtypes_of_categories[0]
                 # Convert everything to categorical data

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -762,7 +762,10 @@ class Database(HeaderBase):
                     for (scheme_id, mapping) in scheme_mappings:
                         if scheme_in_column(scheme_id, column, column_id):
                             if column.scheme_id is None:
-                                y = pd.Series(dtype='object')
+                                y = pd.Series(
+                                    index=filewise_index(),
+                                    dtype='object',
+                                )
                             else:
                                 y = self[table_id][column_id].get(map=mapping)
                             y.name = requested_scheme

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -448,10 +448,14 @@ class Database(HeaderBase):
                 typing.Any
             ] = None,
     ) -> pd.DataFrame:
-        r"""Get labels by scheme(s).
+        r"""Get labels by scheme.
 
         Return all labels
-        that match the requested schemes.
+        that match the requested scheme.
+        The request can be limited to selected tables
+        and/or splits
+        and annotated by additional schemes
+        drawn from the whole database.
 
         If ``strict`` is ``False``,
         a scheme is defined more broadly
@@ -478,8 +482,8 @@ class Database(HeaderBase):
                 for which additional labels should be returned.
                 The search is not affected
                 by the ``tables`` and ``splits`` arguments
-            tables: limit returned samples to selected tables
-            splits: limit returned samples to selected splits
+            tables: limit search for ``scheme`` to selected tables
+            splits: limit search for ``scheme`` to selected splits
             strict: if ``False``
                 not only values with the associated scheme(s)
                 are returned,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -702,9 +702,9 @@ class Database(HeaderBase):
         additional_schemes = audeer.to_list(additional_schemes)
 
         if tables is None:
-            tables = list(self.tables)
+            selected_tables = list(self.tables)
         else:
-            tables = audeer.to_list(tables)
+            selected_tables = audeer.to_list(tables)
         if splits is not None:
             splits = audeer.to_list(splits)
 
@@ -733,7 +733,7 @@ class Database(HeaderBase):
 
         # --- Get data for requested schemes
         ys_requested_scheme = []
-        for table_id in tables:
+        for table_id in selected_tables:
 
             # Handle non-existing tables
             if table_id not in self.tables:
@@ -832,29 +832,42 @@ class Database(HeaderBase):
             obj = obj.to_frame()
 
         # Append additional schemes
-        objs = [obj]
-        for scheme in additional_schemes:
-            if len(obj) == 0:
-                obj = pd.DataFrame(
-                    {
-                        scheme: [],
-                    },
-                    index=filewise_index(),
-                    dtype='object',
-                )
-            else:
-                obj = self.get(
-                    scheme,
-                    strict=strict,
-                    original_column_names=original_column_names,
-                    aggregate_function=aggregate_function,
-                )
-            objs.append(obj)
-        if len(objs) > 1:
-            obj = utils.concat(objs)
-            obj = obj.loc[index]
-            if len(obj) == 0:
-                obj.index = filewise_index()
+        if len(additional_schemes) > 0:
+
+            # Limit available index in database
+            if (
+                    (tables is not None or splits is not None)
+                    and len(obj) > 0
+            ):
+                for _, table in self.tables.items():
+                    table._df = table.get(
+                        utils.intersect([table.index, index]),
+                        copy=False,
+                    )
+
+            objs = [obj]
+            for scheme in additional_schemes:
+                if len(obj) == 0:
+                    obj = pd.DataFrame(
+                        {
+                            scheme: [],
+                        },
+                        index=filewise_index(),
+                        dtype='object',
+                    )
+                else:
+                    obj = self.get(
+                        scheme,
+                        strict=strict,
+                        original_column_names=original_column_names,
+                        aggregate_function=aggregate_function,
+                    )
+                objs.append(obj)
+            if len(objs) > 1:
+                obj = utils.concat(objs)
+                obj = obj.loc[index]
+                if len(obj) == 0:
+                    obj.index = filewise_index()
 
         return obj
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -455,6 +455,7 @@ class Database(HeaderBase):
                 [pd.Series],
                 typing.Any
             ] = None,
+            aggregate_strategy: str = 'mismatch',
     ) -> pd.DataFrame:
         r"""Get labels by scheme.
 
@@ -520,6 +521,14 @@ class Database(HeaderBase):
                 or to
                 ``tuple``
                 to return them as a tuple
+            aggregate_strategy: if ``aggregate_function`` is not ``None``,
+                ``aggregate_strategy`` decides
+                when ``aggregate_function`` is applied.
+                ``'overlap'``: apply to all samples
+                that have an overlapping index;
+                ``'mismatch'``: apply to all samples
+                that have an overlapping index
+                and a different value
 
         Returns:
             data frame with values
@@ -663,7 +672,7 @@ class Database(HeaderBase):
             wav/03a04Wc.wav      anger  boredom
             wav/03a05Aa.wav       fear  sadness
             ...
-            >>> db.get('emotion', aggregate_function=lambda y: y.mode()[0]).head()
+            >>> db.get('emotion', aggregate_function=lambda y: y[0]).head()
                                emotion
             file
             wav/03a01Fa.wav  happiness
@@ -850,12 +859,11 @@ class Database(HeaderBase):
 
         # --- Combine all labels
         index = utils.union([y.index for y in ys])
-
-        # Apply aggregate_function only if we cannot join labels
-        try:
-            obj = utils.concat(ys)
-        except ValueError:
-            obj = utils.concat(ys, aggregate_function=aggregate_function)
+        obj = utils.concat(
+            ys,
+            aggregate_function=aggregate_function,
+            aggregate_strategy=aggregate_strategy,
+        )
         obj = obj.loc[index]
 
         if len(obj) == 0:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -458,12 +458,11 @@ class Database(HeaderBase):
         r"""Get labels by scheme.
 
         Return all labels
-        that match the requested scheme.
-        The request can be limited to selected tables
-        and/or splits
-        and annotated by additional schemes
+        that match the requested ``scheme``.
+        The request can be limited to selected ``tables``
+        and/or ``splits``
+        and annotated by ``additional_schemes``
         drawn from the whole database.
-
         If ``strict`` is ``False``,
         a scheme is defined more broadly
         and does not only match
@@ -471,10 +470,8 @@ class Database(HeaderBase):
         but also columns with the same name
         or labels of a scheme
         with the requested name as key.
-
         If at least one returned label belongs to a segmented table,
         the returned data frame has a segmented index.
-
         An ``aggregate_function`` can be provided
         that specifies how values are combined
         if more than one value is returned
@@ -496,8 +493,8 @@ class Database(HeaderBase):
                 are returned,
                 but also values
                 from columns with a column ID matchting the scheme
-                and values from from scheme labels,
-                if for matching dictionary keys
+                and values from scheme labels,
+                for matching dictionary keys
             original_column_names: if ``True``
                 return the requested labels
                 under their original column names.

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -863,6 +863,7 @@ class Database(HeaderBase):
             objs.append(self.get(scheme))
         if len(objs) > 1:
             obj = utils.concat(objs)
+            obj = obj.loc[index]
 
         return obj
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -804,7 +804,11 @@ class Database(HeaderBase):
         # --- Combine all labels
         index = utils.union([y.index for y in ys])
 
-        obj = utils.concat(ys, aggregate_function=aggregate_function)
+        # Apply aggregate_function only if we cannot join labels
+        try:
+            obj = utils.concat(ys)
+        except ValueError:
+            obj = utils.concat(ys, aggregate_function=aggregate_function)
         obj = obj.loc[index]
 
         if len(obj) == 0:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -555,14 +555,6 @@ class Database(HeaderBase):
             wav/03a01Wa.wav      anger
             wav/03a02Fc.wav  happiness
             wav/03a02Nc.wav    neutral
-            >>> db.get('emotion', ['gender']).head()
-                               emotion gender
-            file
-            wav/03a01Fa.wav  happiness   male
-            wav/03a01Nc.wav    neutral   male
-            wav/03a01Wa.wav      anger   male
-            wav/03a02Fc.wav  happiness   male
-            wav/03a02Nc.wav    neutral   male
             >>> db.get('transcription').head()
                                                     transcription
             file
@@ -571,14 +563,14 @@ class Database(HeaderBase):
             wav/03a01Wa.wav  Der Lappen liegt auf dem Eisschrank.
             wav/03a02Fc.wav     Das will sie am Mittwoch abgeben.
             wav/03a02Nc.wav     Das will sie am Mittwoch abgeben.
-            >>> db.get('transcription', map=False).head()
-                            transcription
+            >>> db.get('emotion', ['transcription'], map=False).head()
+                               emotion transcription
             file
-            wav/03a01Fa.wav           a01
-            wav/03a01Nc.wav           a01
-            wav/03a01Wa.wav           a01
-            wav/03a02Fc.wav           a02
-            wav/03a02Nc.wav           a02
+            wav/03a01Fa.wav  happiness           a01
+            wav/03a01Nc.wav    neutral           a01
+            wav/03a01Wa.wav      anger           a01
+            wav/03a02Fc.wav  happiness           a02
+            wav/03a02Nc.wav    neutral           a02
 
             Non-existent schemes are ignored.
 
@@ -880,6 +872,7 @@ class Database(HeaderBase):
                 obj = self.get(
                     scheme,
                     strict=strict,
+                    map=map,
                     original_column_names=original_column_names,
                     aggregate_function=aggregate_function,
                 )

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -458,7 +458,7 @@ class Database(HeaderBase):
         r"""Get labels by scheme.
 
         Return all labels
-        from columns assigned to a 
+        from columns assigned to a
         :class:`audformat.Scheme`
         with name ``scheme``.
         The request can be limited to specific ``tables``

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -761,7 +761,10 @@ class Database(HeaderBase):
                 else:
                     for (scheme_id, mapping) in scheme_mappings:
                         if scheme_in_column(scheme_id, column, column_id):
-                            y = self[table_id][column_id].get(map=mapping)
+                            if column.scheme_id is None:
+                                y = pd.Series(dtype='object')
+                            else:
+                                y = self[table_id][column_id].get(map=mapping)
                             y.name = requested_scheme
                             append_series(
                                 ys_requested_scheme,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -683,6 +683,7 @@ class Database(HeaderBase):
             if y is not None:
                 if original_column_names:
                     y.name = column_id
+                y = y[~y.index.duplicated(keep='first')]
                 ys.append(y)
 
         def scheme_in_column(scheme_id, column, column_id):

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -94,11 +94,13 @@ class Database(HeaderBase):
         ...     format='wav',
         ...     sampling_rate=16000,
         ... )
-        >>> db['table'] = Table(media_id='audio')
+        >>> index = filewise_index(['f1.wav', 'f2.wav'])
+        >>> db['table'] = Table(index, media_id='audio')
         >>> db['table']['column'] = Column(
         ...     scheme_id='emotion',
         ...     rater_id='rater',
         ... )
+        >>> db['table']['column'].set(['neutral', 'positive'])
         >>> index = pd.Index([], dtype='string', name='idx')
         >>> db['misc-table'] = MiscTable(index)
         >>> db['misc-table']['column'] = Column(scheme_id='match')
@@ -129,6 +131,11 @@ class Database(HeaderBase):
               column: {scheme_id: match}
         >>> list(db)
         ['misc-table', 'table']
+        >>> db.get('emotion')
+                 emotion
+        file
+        f1.wav   neutral
+        f2.wav  positive
 
     """
     def __init__(

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -485,7 +485,7 @@ class Database(HeaderBase):
                 The search for the labels
                 can be limited
                 by the ``tables`` and ``splits`` arguments
-            additional_schemes: scheme ID or sequence of scheme ID
+            additional_schemes: scheme ID or sequence of scheme IDs
                 for which additional labels should be returned.
                 The search is not affected
                 by the ``tables`` and ``splits`` arguments

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -601,7 +601,7 @@ class Database(HeaderBase):
             f2       0.7 25
             >>> db.get(['rating', 'age'], strict=True)
             Empty DataFrame
-            Columns: []
+            Columns: [rating, age]
             Index: []
 
             If more then one value exists
@@ -795,7 +795,12 @@ class Database(HeaderBase):
         ).loc[index]
 
         if len(obj) == 0:
-            obj = pd.DataFrame()
+            obj = pd.DataFrame(
+                [],
+                index=filewise_index(),
+                columns=requested_schemes,
+                dtype='object',
+            )
 
         if isinstance(obj, pd.Series):
             obj = obj.to_frame()
@@ -843,6 +848,9 @@ class Database(HeaderBase):
                     obj = obj.set_index(index)
             else:
                 obj = obj.loc[index]
+
+        if len(obj) == 0:
+            obj.index = filewise_index()
 
         return obj
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -458,11 +458,15 @@ class Database(HeaderBase):
         r"""Get labels by scheme.
 
         Return all labels
-        that match the requested ``scheme``.
-        The request can be limited to selected ``tables``
-        and/or ``splits``
-        and annotated by ``additional_schemes``
-        drawn from the whole database.
+        from columns assigned to a 
+        :class:`audformat.Scheme`
+        with name ``scheme``.
+        The request can be limited to specific ``tables``
+        and/or ``splits``.
+        By providing ``additional_schemes``
+        the result can be enriched
+        with labels from other schemes
+        (searched in all tables).
         If ``strict`` is ``False``,
         a scheme is defined more broadly
         and does not only match
@@ -474,14 +478,16 @@ class Database(HeaderBase):
         the returned data frame has a segmented index.
         An ``aggregate_function`` can be provided
         that specifies how values are combined
-        if more than one value is returned
-        per index entry.
+        if more than one value is found
+        for the same file or segment.
 
         Args:
             scheme: scheme ID for which labels should be returned.
-                The search for the labels
-                can be limited
-                by the ``tables`` and ``splits`` arguments
+                The search can be restricted to specific tables and splits
+                by the ``tables`` and ``splits`` arguments.
+                Or extended to columns with that same name
+                or the name of a label in the scheme
+                using the `strict` argument
             additional_schemes: scheme ID or sequence of scheme IDs
                 for which additional labels should be returned.
                 The search is not affected
@@ -489,15 +495,12 @@ class Database(HeaderBase):
             tables: limit search for ``scheme`` to selected tables
             splits: limit search for ``scheme`` to selected splits
             strict: if ``False``
-                not only values with the associated scheme(s)
-                are returned,
-                but also values
-                from columns with a column ID matchting the scheme
-                and values from scheme labels,
-                for matching dictionary keys
+                the search is extended to columns
+                that match the name of the scheme
+                or the name of a label in the scheme
             original_column_names: if ``True``
-                return the requested labels
-                under their original column names.
+                keep the original column names
+                (possibly results in multiple columns).
                 For mapped schemes,
                 the column name before mapping is returned,
                 e.g. when requesting ``'gender'``

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -443,7 +443,10 @@ class Database(HeaderBase):
             tables: typing.Union[str, typing.Sequence] = None,
             splits: typing.Union[str, typing.Sequence] = None,
             strict: bool = False,
-            aggregate_function: typing.Callable[pd.Series, typing.Any] = None,
+            aggregate_function: typing.Callable[
+                [pd.Series],
+                typing.Any
+            ] = None,
             modify_function: typing.Callable[
                 [pd.Series, 'Database', str, str],
                 pd.Series

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -834,12 +834,21 @@ class Database(HeaderBase):
         # Append additional schemes
         objs = [obj]
         for scheme in additional_schemes:
-            obj = self.get(
-                scheme,
-                strict=strict,
-                original_column_names=original_column_names,
-                aggregate_function=aggregate_function,
-            )
+            if len(obj) == 0:
+                obj = pd.DataFrame(
+                    {
+                        scheme: [],
+                    },
+                    index=filewise_index(),
+                    dtype='object',
+                )
+            else:
+                obj = self.get(
+                    scheme,
+                    strict=strict,
+                    original_column_names=original_column_names,
+                    aggregate_function=aggregate_function,
+                )
             objs.append(obj)
         if len(objs) > 1:
             obj = utils.concat(objs)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -677,7 +677,6 @@ class Database(HeaderBase):
             if y is not None:
                 if original_column_names:
                     y.name = column_id
-                y = y[~y.index.duplicated(keep='first')]
                 ys.append(y)
 
         def empty_frame(name):

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -377,6 +377,7 @@ def concat(
             # drop NaN to avoid overwriting values from other column
             column = column.dropna()
         else:
+            # Adjust dtype and initialize empty column
             if pd.api.types.is_integer_dtype(column.dtype):
                 dtype = 'Int64'
             elif pd.api.types.is_bool_dtype(column.dtype):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audb
 audiofile >=1.1.0
 pandas >=2.0.0
 pytest

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -182,21 +182,17 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'gender',
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -253,174 +249,130 @@ def stereo_db(tmpdir):
                     ),
                 ],
                 axis=1,
-            )
+            ),
         ),
         (
             'mono_db',
             'age',
-            pd.concat(
-                [
-                    pd.Series(
-                        [23, np.NaN, 59],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[23.0, 59.0, 25.0, 34.0, 45.0],
-                            ordered=False,
-                        ),
-                        name='age',
-                    ),
-                    pd.Series(
-                        [25.0, 34.0, 45.0],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[23.0, 59.0, 25.0, 34.0, 45.0],
-                            ordered=False,
-                        ),
-                        name='perceived-age',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'age': [23, np.NaN, 59],
+                    'perceived-age': [25.0, 34.0, 45.0],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
+                    ordered=False,
+                ),
             ),
         ),
         (
             'mono_db',
             'height',
-            pd.concat(
-                [
-                    pd.Series(
-                        [1.12, 1.45, 1.01],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
-                            ordered=False,
-                        ),
-                        name='height-with-10y',
-                    ),
-                    pd.Series(
-                        [1.76, 1.95, 1.80],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
-                            ordered=False,
-                        ),
-                        name='current-height',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'height-with-10y': [1.12, 1.45, 1.01],
+                    'current-height': [1.76, 1.95, 1.80],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
+                    ordered=False,
+                ),
             ),
         ),
         (
             'mono_db',
             'winner',
-            pd.concat(
-                [
-                    pd.Series(
-                        ['w1', 'w1', 'w2', 'w1', 'w1', 'w1', 'w1'],
-                        index=audformat.utils.union(
-                            [
-                                audformat.filewise_index(
-                                    ['f1.wav', 'f2.wav', 'f3.wav']
-                                ),
-                                audformat.segmented_index(
-                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
-                                    [0, 0.1, 0.3, 0],
-                                    [0.2, 0.2, 0.5, 0.7],
-                                ),
-                            ]
+            pd.DataFrame(
+                {
+                    'winner': ['w1', 'w1', 'w2', 'w1', 'w1', 'w1', 'w1'],
+                },
+                index=audformat.utils.union(
+                    [
+                        audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
                         ),
-                        dtype=pd.CategoricalDtype(
-                            ['w1', 'w2', 'w3'],
-                            ordered=False,
+                        audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
                         ),
-                        name='winner',
-                    ),
-                ],
-                axis=1,
+                    ]
+                ),
+                dtype=pd.CategoricalDtype(
+                    ['w1', 'w2', 'w3'],
+                    ordered=False,
+                ),
             ),
         ),
         (
             'mono_db',
             'year',
-            pd.concat(
-                [
-                    pd.Series(
-                        [1995, 1995, 1996, 1995, 1995, 1995, 1995],
-                        index=audformat.utils.union(
-                            [
-                                audformat.filewise_index(
-                                    ['f1.wav', 'f2.wav', 'f3.wav']
-                                ),
-                                audformat.segmented_index(
-                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
-                                    [0, 0.1, 0.3, 0],
-                                    [0.2, 0.2, 0.5, 0.7],
-                                ),
-                            ]
+            pd.DataFrame(
+                {
+                    'year': [1995, 1995, 1996, 1995, 1995, 1995, 1995],
+                },
+                index=audformat.utils.union(
+                    [
+                        audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
                         ),
-                        dtype=pd.CategoricalDtype(
-                            [1995, 1996, 1997],
-                            ordered=False,
+                        audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
                         ),
-                        name='year',
-                    ),
-                ],
-                axis=1,
+                    ]
+                ),
+                dtype=pd.CategoricalDtype(
+                    [1995, 1996, 1997],
+                    ordered=False,
+                ),
             ),
         ),
         (
             'mono_db',
             'rating',
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 0, 1, 1, 1, 2, 2],
-                        index=audformat.utils.union(
-                            [
-                                audformat.filewise_index(
-                                    ['f3.wav', 'f1.wav', 'f2.wav']
-                                ),
-                                audformat.segmented_index(
-                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
-                                    [0, 0.1, 0.3, 0],
-                                    [0.2, 0.2, 0.5, 0.7],
-                                ),
-                            ]
+            pd.DataFrame(
+                {
+                    'rating': [1, 0, 1, 1, 1, 2, 2],
+                },
+                index=audformat.utils.union(
+                    [
+                        audformat.filewise_index(
+                            ['f3.wav', 'f1.wav', 'f2.wav']
                         ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
+                        audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
                         ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+                    ]
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
             'mono_db',
             'regression',
-            pd.concat(
-                [
-                    pd.Series(
-                        [0.3, 0.2, 0.6, 0.4],
-                        index=audformat.segmented_index(
-                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
-                            [0, 0.1, 0.3, 0],
-                            [0.2, 0.2, 0.5, 0.7],
-                        ),
-                        dtype='float',
-                        name='regression',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'regression': [0.3, 0.2, 0.6, 0.4],
+                },
+                index=audformat.segmented_index(
+                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                    [0, 0.1, 0.3, 0],
+                    [0.2, 0.2, 0.5, 0.7],
+                ),
+                dtype='float',
             ),
         ),
     ]
@@ -428,8 +380,6 @@ def stereo_db(tmpdir):
 def test_database_get(request, db, schemes, expected):
     db = request.getfixturevalue(db)
     df = db.get(schemes)
-    print(f'{df=}')
-    print(f'{expected=}')
     pd.testing.assert_frame_equal(df, expected)
 
 
@@ -440,8 +390,8 @@ def rename_column(y, db, table_id, column_id):
     y.name = f'{y.name}-{table_id}-{column_id}'
     return y
 
-def select_run1(y, db, table_id, column_id):
-    if table_id != 'run1':
+def select_column(y, db, table_id, column_id, column):
+    if column_id != column:
         if audformat.is_filewise_index(y.index):
             index = audformat.filewise_index()
         else:
@@ -449,8 +399,9 @@ def select_run1(y, db, table_id, column_id):
         y = pd.Series(index=index, name=y.name, dtype=y.dtype)
     return y
 
-def select_run2(y, db, table_id, column_id):
-    if table_id != 'run2':
+
+def select_table(y, db, table_id, column_id, table):
+    if table_id != table:
         if audformat.is_filewise_index(y.index):
             index = audformat.filewise_index()
         else:
@@ -491,239 +442,309 @@ def rename_sex_to_gender(y, db, table_id, column_id):
     return y
 
 @pytest.mark.parametrize(
-    'db, schemes, aggregate_function, expected',
+    'db, schemes, aggregate_function, modify_function, expected',
     [
+        # Tests based on `stereo_db` and `gender`,
+        # with the following tables, columns.
+        # All have [f1.wav, f2.wav, f3.wav] as index
+        #
+        # | table | column   | values                       |
+        # | ----- | -------- | ---------------------------- |
+        # | run1  | channel0 | ['female', '',       'male'] |
+        # | run1  | channel1 | ['male',   'female', ''    ] |
+        # | run2  | channel0 | ['female', '',       'male'] |
+        # | run2  | channel1 | ['female', '',       'male'] |
+        # | run3  | channel0 | ['',       'female', 'male'] |
+        # | run3  | channel1 | ['female', 'female', 'male'] |
+        #
         (
-            # Choose different names for each run and channel:
-            # run1, channel0: ['female', '', 'male']
-            # run1, channel1: ['male', 'female', '']
-            # run2, channel0: ['female', '', 'male']
-            # run2, channel1: ['female', '', 'male']
-            # run3, channel0: ['', 'female', 'male']
-            # run3, channel1: ['', 'female', 'male']
+            # maxvote
+            #
+            # gender: ['female', 'female', 'male']
+            #
             'stereo_db',
             'gender',
+            lambda y: y.mode()[0],
+            None,
+            pd.DataFrame(
+                {
+                    'gender': ['female', 'female', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            # Rename scheme column based on table and column
+            #
+            # gender-run1-channel0: ['female', '', 'male']
+            # gender-run1-channel1: ['male', 'female', '']
+            # gender-run2-channel0: ['female', '', 'male']
+            # gender-run2-channel1: ['female', '', 'male']
+            # gender-run3-channel0: ['', 'female', 'male']
+            # gender-run3-channel1: ['', 'female', 'male']
+            #
+            'stereo_db',
+            'gender',
+            None,
             rename_column,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run1-channel0',
-                    ),
-                    pd.Series(
-                        ['male', 'female', ''],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run1-channel1',
-                    ),
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run2-channel0',
-                    ),
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run2-channel1',
-                    ),
-                    pd.Series(
-                        ['', 'female', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run3-channel0',
-                    ),
-                    pd.Series(
-                        ['', 'female', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-run3-channel1',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'gender-run1-channel0': ['female', '', 'male'],
+                    'gender-run1-channel1': ['male', 'female', ''],
+                    'gender-run2-channel0': ['female', '', 'male'],
+                    'gender-run2-channel1': ['female', '', 'male'],
+                    'gender-run3-channel0': ['', 'female', 'male'],
+                    'gender-run3-channel1': ['', 'female', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
         pytest.param(
-            # Fail as we select runs with different labels:
+            # Fail as we select runs with different labels
+            #
             # run1, channel0: ['female', '', 'male']
             # run1, channel1: ['male', 'female', '']
+            #
+            # gender: ValueError
+            #
             'stereo_db',
             'gender',
-            select_run1,
+            None,
+            lambda *args: select_table(*args, 'run1'),
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
-            # Select run with identical labels:
+            # Select run with identical labels
+            #
             # run2, channel0: ['female', '', 'male']
             # run2, channel1: ['female', '', 'male']
+            #
+            # gender: ['female', '', 'male']
+            #
             'stereo_db',
             'gender',
-            select_run2,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender',
-                    ),
-                ],
-                axis=1,
+            None,
+            lambda y, db, table_id, column_id:
+            select_table(y, db, table_id, column_id, 'run2'),
+            pd.DataFrame(
+                {
+                    'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
         (
-            # Select segments table
+            # Select channel0 and return maxvote over runs
+            #
+            # run1, channel0: ['female', '',       'male']
+            # run2, channel0: ['female', '',       'male']
+            # run3, channel0: ['',       'female', 'male']
+            #
+            # gender: ['female', '', 'male']
+            #
+            'stereo_db',
+            'gender',
+            lambda y: y.mode()[0],
+            lambda *args: select_column(*args, 'channel0'),
+            pd.DataFrame(
+                {
+                    'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+
+        # Tests based on `mono_db` and scheme `rating`,
+        # stored in the following tables and columns.
+        #
+        # `rating.train`
+        # | file   | rating |
+        # | ------ | ------ |
+        # | f1.wav |      0 |
+        # | f2.wav |      1 |
+        #
+        # `rating.test`
+        # | file   | rating |
+        # | ------ | ------ |
+        # | f3.wav |      1 |
+        #
+        # `segments`
+        # | file   | start |   end | rating |
+        # | ------ | ----- | ----- | ------ |
+        # | f1.wav |   0.0 |   0.2 |      1 |
+        # | f1.wav |   0.1 |   0.2 |      1 |
+        # | f1.wav |   0.3 |   0.5 |      2 |
+        # | f2.wav |   0.0 |   0.7 |      2 |
+        #
+        (
+            # Select `segments` table
             # and return maxvote for each file
-            # f1: 1, 1, 2
-            # f2: 2
+            #
+            # rating: [1, 2]
+            #
             'mono_db',
             'rating',
+            None,
             average_rating_segments,
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 2],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [1, 2],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
+
+        # Tests based on `mono_db` and schemes `gender` and `sex`,
+        # stored in the following tables and columns
+        # (considering scheme mappings and column names).
+        #
+        # `files`
+        # | file   | gender |
+        # | ------ | ------ |
+        # | f1.wav | female |
+        # | f2.wav |        |
+        # | f3.wav | male   |
+        #
+        # `files.sub`
+        # | file   | gender |
+        # | ------ | ------ |
+        # | f1.wav | female |
+        #
+        # `gender`
+        # | file   | sex    |
+        # | ------ | ------ |
+        # | f1.wav | female |
+        # | f3.wav | male   |
+        #
         (
             # Add name of database to column name
+            #
+            # gender-mono-db: ['female', '', 'male']
+            #
             'mono_db',
             'gender',
+            None,
             add_db_name,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender-mono-db',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'gender-mono-db': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
         pytest.param(
-            # Rename sex scheme to gender,
-            # however as we don't fix the dtype
+            # Rename sex scheme to gender
+            #
+            # As we don't fix the dtype
             # it will raise an error
+            #
             'mono_db',
             ['sex', 'gender'],
+            None,
             rename_sex_to_gender_without_dtype_adjustment,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
             # Rename sex scheme to gender
+            #
+            # gender: ['female', '', 'male']
+            #
             'mono_db',
             ['gender', 'sex'],
+            None,
             rename_sex_to_gender,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
         (
-            # Rename sex scheme to gender,
-            # the order how we collect schemes
-            # influences the order of the inex
+            # Rename sex scheme to gender
+            #
+            # The order how we collect schemes
+            # influences the order of the index.
+            #
+            # gender: ['female', 'male', '']
+            #
             'mono_db',
             ['sex', 'gender'],
+            None,
             rename_sex_to_gender,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', 'male', ''],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f3.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
-                        name='gender',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'gender': ['female', 'male', ''],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f3.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
             ),
         ),
     ]
 )
-def test_database_get_aggregate_function(
+def test_database_get_aggregate_and_modify_function(
         request,
         db,
         schemes,
         aggregate_function,
+        modify_function,
         expected,
 ):
     db = request.getfixturevalue(db)
-    df = db.get(schemes, aggregate_function=aggregate_function)
+    df = db.get(
+        schemes,
+        aggregate_function=aggregate_function,
+        modify_function=modify_function,
+    )
     print(f'{df=}')
     print(f'{expected=}')
     pd.testing.assert_frame_equal(df, expected)
@@ -738,8 +759,9 @@ def test_database_get_aggregate_function(
             [],
             None,
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -753,8 +775,9 @@ def test_database_get_aggregate_function(
             None,
             [],
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -768,8 +791,9 @@ def test_database_get_aggregate_function(
             [],
             [],
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -783,8 +807,9 @@ def test_database_get_aggregate_function(
             'non-existing',
             None,
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -798,8 +823,9 @@ def test_database_get_aggregate_function(
             None,
             'non-existing',
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -809,12 +835,39 @@ def test_database_get_aggregate_function(
         ),
         (
             'mono_db',
+            ['gender', 'sex'],
+            None,
+            'non-existing',
+            pd.concat(
+                [
+                    pd.Series(
+                        [],
+                        index=pd.Index([], dtype='string'),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                    pd.Series(
+                        [],
+                        index=pd.Index([], dtype='string'),
+                        dtype='object',
+                        name='sex',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
             'gender',
             'non-existing',
             'non-existing',
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -828,8 +881,9 @@ def test_database_get_aggregate_function(
             ['gender'],
             ['train'],
             pd.DataFrame(
-                [],
-                columns=['gender'],
+                {
+                    'gender': [],
+                },
                 index=pd.Index([], dtype='string'),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -843,8 +897,9 @@ def test_database_get_aggregate_function(
             ['gender'],
             None,
             pd.DataFrame(
-                ['female', 'male'],
-                columns=['gender'],
+                {
+                    'gender': ['female', 'male'],
+                },
                 index=audformat.filewise_index(['f1.wav', 'f3.wav']),
                 dtype=pd.CategoricalDtype(
                     categories=['female', '', 'male'],
@@ -857,23 +912,19 @@ def test_database_get_aggregate_function(
             'rating',
             'segments',
             None,
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 1, 2, 2],
-                        index=audformat.segmented_index(
-                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
-                            [0, 0.1, 0.3, 0],
-                            [0.2, 0.2, 0.5, 0.7],
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [1, 1, 2, 2],
+                },
+                index=audformat.segmented_index(
+                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                    [0, 0.1, 0.3, 0],
+                    [0.2, 0.2, 0.5, 0.7],
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -881,21 +932,17 @@ def test_database_get_aggregate_function(
             'rating',
             None,
             'train',
-            pd.concat(
-                [
-                    pd.Series(
-                        [0, 1],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [0, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -903,21 +950,17 @@ def test_database_get_aggregate_function(
             'rating',
             ['rating.train', 'rating.test'],
             'train',
-            pd.concat(
-                [
-                    pd.Series(
-                        [0, 1],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [0, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -925,21 +968,17 @@ def test_database_get_aggregate_function(
             'rating',
             None,
             ['train', 'test'],
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 0, 1],
-                        index=audformat.filewise_index(
-                            ['f3.wav', 'f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [1, 0, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f3.wav', 'f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -947,21 +986,17 @@ def test_database_get_aggregate_function(
             'rating',
             ['rating.train', 'rating.test'],
             None,
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 0, 1],
-                        index=audformat.filewise_index(
-                            ['f3.wav', 'f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [1, 0, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f3.wav', 'f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
         (
@@ -969,21 +1004,17 @@ def test_database_get_aggregate_function(
             'rating',
             ['rating.train', 'rating.test'],
             ['train', 'test'],
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 0, 1],
-                        index=audformat.filewise_index(
-                            ['f3.wav', 'f1.wav', 'f2.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            [0, 1, 2],
-                            ordered=False,
-                        ),
-                        name='rating',
-                    ),
-                ],
-                axis=1,
+            pd.DataFrame(
+                {
+                    'rating': [1, 0, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f3.wav', 'f1.wav', 'f2.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [0, 1, 2],
+                    ordered=False,
+                ),
             ),
         ),
     ]

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -41,6 +41,10 @@ def mono_db(tmpdir):
         'str',
         labels=['cloudy', 'rainy', 'sunny'],
     )
+    db.schemes['text'] = audformat.Scheme(
+        'str',
+        labels={'a': 'A text', 'b': 'B text'},
+    )
 
     # --- Misc tables
     index = pd.Index(['s1', 's2', 's3'], name='speaker', dtype='string')
@@ -75,11 +79,15 @@ def mono_db(tmpdir):
     db['files']['winner'].set(['w1', 'w1', 'w2'])
     db['files']['perceived-age'] = audformat.Column(scheme_id='age')
     db['files']['perceived-age'].set([25, 34, 45])
+    db['files']['text'] = audformat.Column(scheme_id='text')
+    db['files']['text'].set(['a', 'a', 'b'])
 
     index = audformat.filewise_index(['f1.wav'])
     db['files.sub'] = audformat.Table(index)
     db['files.sub']['speaker'] = audformat.Column(scheme_id='speaker')
     db['files.sub']['speaker'].set('s1')
+    db['files.sub']['text'] = audformat.Column()
+    db['files.sub']['text'].set('a')
 
     index = audformat.filewise_index(['f1.wav', 'f3.wav'])
     db['other'] = audformat.Table(index)
@@ -747,6 +755,22 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             pd.DataFrame(
                 {
                     'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype='string',
+            ),
+        ),
+        (
+            'mono_db',
+            'text',
+            [],
+            False,
+            lambda y: y[0],
+            pd.DataFrame(
+                {
+                    'text': ['A text', 'A text', 'B text'],
                 },
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -217,21 +217,35 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'sex',
+            [],
+            pd.DataFrame(
+                {
+                    'sex': ['female', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f3.wav']
+                ),
+                dtype='object',
+            ),
+        ),
+        (
+            'mono_db',
+            'sex',
             ['gender'],
             pd.concat(
                 [
                     pd.Series(
-                        ['female', 'male', np.NaN],
+                        ['female', 'male'],
                         index=audformat.filewise_index(
-                            ['f1.wav', 'f3.wav', 'f2.wav']
+                            ['f1.wav', 'f3.wav']
                         ),
                         dtype='object',
                         name='sex',
                     ),
                     pd.Series(
-                        ['female', '', 'male'],
+                        ['female', 'male'],
                         index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
+                            ['f1.wav', 'f3.wav']
                         ),
                         dtype='string',
                         name='gender',

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -263,49 +263,6 @@ def wrong_scheme_labels_db(tmpdir):
     return db
 
 
-@pytest.fixture(scope='function')
-def duplicated_index_db(tmpdir):
-    r"""Database with duplicated segmented index.
-
-    Note, not every database that stores labels
-    with a duplicated index results in an error
-    with `audformat.utils.concat()`,
-    but this one does.
-
-    """
-    name = 'duplicated_index_db'
-    path = audeer.mkdir(audeer.path(tmpdir, name))
-    db = audformat.Database(name)
-
-    # --- Schemes
-    db.schemes['speaker'] = audformat.Scheme(
-        'int',
-        labels={
-            0: {'gender': 'female'},
-            1: {'gender': 'male'},
-        },
-    )
-    db.schemes['gender'] = audformat.Scheme('str', labels=['female', 'male'])
-
-    # --- Tables
-    index = audformat.segmented_index(
-        ['f1.wav', 'f1.wav', 'f2.wav'],
-        [0, 0, 0],
-        [1, 1, 1],
-    )
-    db['files'] = audformat.Table(index)
-    db['files']['speaker'] = audformat.Column(scheme_id='speaker')
-    db['files'].df['speaker'] = [0, 0, 1]
-    db['files']['gender'] = audformat.Column(scheme_id='gender')
-    db['files'].df['gender'] = ['female', np.NaN, 'male']
-    db['files'].df['gender'] = db['files'].df['gender'].astype('string')
-
-    db.save(path)
-    audformat.testing.create_audio_files(db, channels=1, file_duration='1s')
-
-    return db
-
-
 @pytest.mark.parametrize(
     'db, scheme, additional_schemes, expected',
     [
@@ -590,22 +547,6 @@ def duplicated_index_db(tmpdir):
                 },
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav']
-                ),
-                dtype='string',
-            ),
-        ),
-        (
-            'duplicated_index_db',
-            'gender',
-            [],
-            pd.DataFrame(
-                {
-                    'gender': ['female', 'male'],
-                },
-                index=audformat.segmented_index(
-                    ['f1.wav', 'f2.wav'],
-                    [0, 0],
-                    [1, 1],
                 ),
                 dtype='string',
             ),

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -263,6 +263,49 @@ def wrong_scheme_labels_db(tmpdir):
     return db
 
 
+@pytest.fixture(scope='function')
+def duplicated_index_db(tmpdir):
+    r"""Database with duplicated segmented index.
+
+    Note, not every database that stores labels
+    with a duplicated index results in an error
+    with `audformat.utils.concat()`,
+    but this one does.
+
+    """
+    name = 'duplicated_index_db'
+    path = audeer.mkdir(audeer.path(tmpdir, name))
+    db = audformat.Database(name)
+
+    # --- Schemes
+    db.schemes['speaker'] = audformat.Scheme(
+        'int',
+        labels={
+            0: {'gender': 'female'},
+            1: {'gender': 'male'},
+        },
+    )
+    db.schemes['gender'] = audformat.Scheme('str', labels=['female', 'male'])
+
+    # --- Tables
+    index = audformat.segmented_index(
+        ['f1.wav', 'f1.wav', 'f2.wav'],
+        [0, 0, 0],
+        [1, 1, 1],
+    )
+    db['files'] = audformat.Table(index)
+    db['files']['speaker'] = audformat.Column(scheme_id='speaker')
+    db['files'].df['speaker'] = [0, 0, 1]
+    db['files']['gender'] = audformat.Column(scheme_id='gender')
+    db['files'].df['gender'] = ['female', np.NaN, 'male']
+    db['files'].df['gender'] = db['files'].df['gender'].astype('string')
+
+    db.save(path)
+    audformat.testing.create_audio_files(db, channels=1, file_duration='1s')
+
+    return db
+
+
 @pytest.mark.parametrize(
     'db, scheme, additional_schemes, expected',
     [
@@ -547,6 +590,22 @@ def wrong_scheme_labels_db(tmpdir):
                 },
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav']
+                ),
+                dtype='string',
+            ),
+        ),
+        (
+            'duplicated_index_db',
+            'gender',
+            [],
+            pd.DataFrame(
+                {
+                    'gender': ['female', 'male'],
+                },
+                index=audformat.segmented_index(
+                    ['f1.wav', 'f2.wav'],
+                    [0, 0],
+                    [1, 1],
                 ),
                 dtype='string',
             ),

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -961,33 +961,6 @@ def test_database_get_aggregate_and_modify_function(
         ),
         (
             'mono_db',
-            'gender',
-            ['speaker'],
-            ['files.sub'],
-            None,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female'],
-                        index=audformat.filewise_index(['f1.wav']),
-                        dtype='string',
-                        name='gender',
-                    ),
-                    pd.Series(
-                        ['s1'],
-                        index=audformat.filewise_index(['f1.wav']),
-                        dtype=pd.CategoricalDtype(
-                            ['s1', 's2', 's3'],
-                            ordered=False,
-                        ),
-                        name='speaker',
-                    ),
-                ],
-                axis=1,
-            ),
-        ),
-        (
-            'mono_db',
             'sex',
             [],
             ['other'],

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -257,6 +257,12 @@ def stereo_db(tmpdir):
                         dtype='object',
                         name='sex',
                     ),
+                    pd.Series(
+                        [],
+                        index=audformat.filewise_index(),
+                        dtype='object',
+                        name='non-existing',
+                    ),
                 ],
                 axis=1,
             ),

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -1,0 +1,1023 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import audeer
+
+import audformat
+import audformat.testing
+
+
+@pytest.fixture(scope='function')
+def mono_db(tmpdir):
+    r"""Database with ..."""
+    name = 'mono-db'
+    path = audeer.mkdir(audeer.path(tmpdir, name))
+    db = audformat.Database(name)
+
+    # --- Splits
+    db.splits['train'] = audformat.Split('train')
+    db.splits['test'] = audformat.Split('test')
+
+    # --- Schemes
+    db.schemes['age'] = audformat.Scheme('int', minimum=0)
+    db.schemes['height'] = audformat.Scheme('float')
+    db.schemes['rating'] = audformat.Scheme('int', labels=[0, 1, 2])
+    db.schemes['regression'] = audformat.Scheme('float')
+    db.schemes['speaker.weight'] = audformat.Scheme(
+        'str',
+        labels=['low', 'normal', 'high'],
+    )
+    db.schemes['winner'] = audformat.Scheme(
+        'str',
+        labels={
+            'w1': {'year': 1995},
+            'w2': {'year': 1996},
+            'w3': {'year': 1997},
+        },
+    )
+    db.schemes['weather'] = audformat.Scheme(
+        'str',
+        labels=['cloudy', 'rainy', 'sunny'],
+    )
+
+    # --- Misc tables
+    index = pd.Index(['s1', 's2', 's3'], name='speaker', dtype='string')
+    db['speaker'] = audformat.MiscTable(index)
+    db['speaker']['age'] = audformat.Column(scheme_id='age')
+    db['speaker']['gender'] = audformat.Column()
+    db['speaker']['age'].set([23, np.NaN, 59])
+    db['speaker']['gender'].set(['female', '', 'male'])
+    db['speaker']['height-with-10y'] = audformat.Column(scheme_id='height')
+    db['speaker']['height-with-10y'].set([1.12, 1.45, 1.01])
+    db['speaker']['current-height'] = audformat.Column(scheme_id='height')
+    db['speaker']['current-height'].set([1.76, 1.95, 1.80])
+    db['speaker']['weight'] = audformat.Column(scheme_id='speaker.weight')
+    db['speaker']['weight'].set(['normal', 'high', 'low'])
+
+    index = pd.Index(['today', 'yesterday'], name='day', dtype='string')
+    db['weather'] = audformat.MiscTable(index)
+    db['weather']['weather'] = audformat.Column(scheme_id='weather')
+    db['weather']['weather'].set(['cloudy', 'sunny'])
+
+    # --- Schemes with misc tables
+    db.schemes['speaker'] = audformat.Scheme('str', labels='speaker')
+
+    # --- Filewise tables
+    index = audformat.filewise_index(['f1.wav', 'f2.wav', 'f3.wav'])
+    db['files'] = audformat.Table(index)
+    db['files']['channel0'] = audformat.Column(scheme_id='speaker')
+    db['files']['channel0'].set(['s1', 's2', 's3'])
+    db['files']['winner'] = audformat.Column(scheme_id='winner')
+    db['files']['winner'].set(['w1', 'w1', 'w2'])
+    db['files']['perceived-age'] = audformat.Column(scheme_id='age')
+    db['files']['perceived-age'].set([25, 34, 45])
+
+    index = audformat.filewise_index(['f1.wav'])
+    db['files.sub'] = audformat.Table(index)
+    db['files.sub']['speaker'] = audformat.Column(scheme_id='speaker')
+    db['files.sub']['speaker'].set('s1')
+
+    index = audformat.filewise_index(['f1.wav', 'f3.wav'])
+    db['gender'] = audformat.Table(index)
+    db['gender']['sex'] = audformat.Column()
+    db['gender']['sex'].set(['female', 'male'])
+
+    index = audformat.filewise_index(['f1.wav', 'f2.wav'])
+    db['rating.train'] = audformat.Table(index, split_id='train')
+    db['rating.train']['rating'] = audformat.Column(scheme_id='rating')
+    db['rating.train']['rating'].set([0, 1])
+
+    index = audformat.filewise_index(['f3.wav'])
+    db['rating.test'] = audformat.Table(index, split_id='test')
+    db['rating.test']['rating'] = audformat.Column(scheme_id='rating')
+    db['rating.test']['rating'].set([1])
+
+    # --- Segmented tables
+    index = audformat.segmented_index(
+        ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+        [0, 0.1, 0.3, 0],
+        [0.2, 0.2, 0.5, 0.7],
+    )
+    db['segments'] = audformat.Table(index)
+    db['segments']['rating'] = audformat.Column(scheme_id='rating')
+    db['segments']['rating'].set([1, 1, 2, 2])
+    db['segments']['winner'] = audformat.Column(scheme_id='winner')
+    db['segments']['winner'].set(['w1', 'w1', 'w1', 'w1'])
+    db['segments']['regression'] = audformat.Column(scheme_id='regression')
+    db['segments']['regression'].set([0.3, 0.2, 0.6, 0.4])
+
+    db.save(path)
+    audformat.testing.create_audio_files(db, channels=1, file_duration='1s')
+
+    return db
+
+
+@pytest.fixture(scope='function')
+def stereo_db(tmpdir):
+    r"""Database with stereo files and same scheme for both channels.
+
+    It contains two tables,
+    in one the same labels are used for both channels,
+    and in the other different labels are used.
+
+    """
+    name = 'stereo-db'
+    path = audeer.mkdir(audeer.path(tmpdir, name))
+    db = audformat.Database(name)
+
+    # --- Schemes
+    db.schemes['age'] = audformat.Scheme('int', minimum=0)
+
+    # --- Misc tables
+    index = pd.Index(['s1', 's2', 's3'], name='speaker', dtype='string')
+    db['speaker'] = audformat.MiscTable(index)
+    db['speaker']['age'] = audformat.Column(scheme_id='age')
+    db['speaker']['gender'] = audformat.Column()
+    db['speaker']['age'].set([23, np.NaN, 59])
+    db['speaker']['gender'].set(['female', '', 'male'])
+
+    # --- Schemes with misc tables
+    db.schemes['speaker'] = audformat.Scheme('str', labels='speaker')
+
+    # --- Filewise tables
+    index = audformat.filewise_index(['f1.wav', 'f2.wav', 'f3.wav'])
+    db['run1'] = audformat.Table(index)
+    db['run1']['channel0'] = audformat.Column(scheme_id='speaker')
+    db['run1']['channel1'] = audformat.Column(scheme_id='speaker')
+    db['run1']['channel0'].set(['s1', 's2', 's3'])
+    db['run1']['channel1'].set(['s3', 's1', 's2'])
+
+    db['run2'] = audformat.Table(index)
+    db['run2']['channel0'] = audformat.Column(scheme_id='speaker')
+    db['run2']['channel1'] = audformat.Column(scheme_id='speaker')
+    db['run2']['channel0'].set(['s1', 's2', 's3'])
+    db['run2']['channel1'].set(['s1', 's2', 's3'])
+
+    db['run3'] = audformat.Table(index)
+    db['run3']['channel0'] = audformat.Column(scheme_id='speaker')
+    db['run3']['channel1'] = audformat.Column(scheme_id='speaker')
+    db['run3']['channel0'].set(['s2', 's1', 's3'])
+    db['run3']['channel1'].set(['s2', 's1', 's3'])
+
+    db.save(path)
+    audformat.testing.create_audio_files(db, channels=2, file_duration='1s')
+
+    return db
+
+
+@pytest.mark.parametrize(
+    'db, schemes, expected',
+    [
+        (
+            'mono_db',
+            'non-existing',
+            pd.DataFrame([]),
+        ),
+        (
+            'mono_db',
+            'weather',
+            pd.DataFrame([]),
+        ),
+        (
+            'mono_db',
+            'gender',
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            ['sex', 'gender'],
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', 'male', np.NaN],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f3.wav', 'f2.wav']
+                        ),
+                        dtype='object',
+                        name='sex',
+                    ),
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            )
+        ),
+        (
+            'mono_db',
+            ['gender', 'sex', 'non-existing'],
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                    pd.Series(
+                        ['female', np.NaN, 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype='object',
+                        name='sex',
+                    ),
+                ],
+                axis=1,
+            )
+        ),
+        (
+            'mono_db',
+            'age',
+            pd.concat(
+                [
+                    pd.Series(
+                        [23, np.NaN, 59],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[23.0, 59.0, 25.0, 34.0, 45.0],
+                            ordered=False,
+                        ),
+                        name='age',
+                    ),
+                    pd.Series(
+                        [25.0, 34.0, 45.0],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[23.0, 59.0, 25.0, 34.0, 45.0],
+                            ordered=False,
+                        ),
+                        name='perceived-age',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'height',
+            pd.concat(
+                [
+                    pd.Series(
+                        [1.12, 1.45, 1.01],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
+                            ordered=False,
+                        ),
+                        name='height-with-10y',
+                    ),
+                    pd.Series(
+                        [1.76, 1.95, 1.80],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
+                            ordered=False,
+                        ),
+                        name='current-height',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'winner',
+            pd.concat(
+                [
+                    pd.Series(
+                        ['w1', 'w1', 'w2', 'w1', 'w1', 'w1', 'w1'],
+                        index=audformat.utils.union(
+                            [
+                                audformat.filewise_index(
+                                    ['f1.wav', 'f2.wav', 'f3.wav']
+                                ),
+                                audformat.segmented_index(
+                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                                    [0, 0.1, 0.3, 0],
+                                    [0.2, 0.2, 0.5, 0.7],
+                                ),
+                            ]
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            ['w1', 'w2', 'w3'],
+                            ordered=False,
+                        ),
+                        name='winner',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'year',
+            pd.concat(
+                [
+                    pd.Series(
+                        [1995, 1995, 1996, 1995, 1995, 1995, 1995],
+                        index=audformat.utils.union(
+                            [
+                                audformat.filewise_index(
+                                    ['f1.wav', 'f2.wav', 'f3.wav']
+                                ),
+                                audformat.segmented_index(
+                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                                    [0, 0.1, 0.3, 0],
+                                    [0.2, 0.2, 0.5, 0.7],
+                                ),
+                            ]
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [1995, 1996, 1997],
+                            ordered=False,
+                        ),
+                        name='year',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 0, 1, 1, 1, 2, 2],
+                        index=audformat.utils.union(
+                            [
+                                audformat.filewise_index(
+                                    ['f3.wav', 'f1.wav', 'f2.wav']
+                                ),
+                                audformat.segmented_index(
+                                    ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                                    [0, 0.1, 0.3, 0],
+                                    [0.2, 0.2, 0.5, 0.7],
+                                ),
+                            ]
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'regression',
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype='float',
+                        name='regression',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+    ]
+)
+def test_database_get(request, db, schemes, expected):
+    db = request.getfixturevalue(db)
+    df = db.get(schemes)
+    print(f'{df=}')
+    print(f'{expected=}')
+    pd.testing.assert_frame_equal(df, expected)
+
+
+# Aggregate functions
+# that define how to store the labels in the data frame
+
+def rename_column(y, db, table_id, column_id):
+    y.name = f'{y.name}-{table_id}-{column_id}'
+    return y
+
+def select_run1(y, db, table_id, column_id):
+    if table_id != 'run1':
+        if audformat.is_filewise_index(y.index):
+            index = audformat.filewise_index()
+        else:
+            index = audformat.segmented_index()
+        y = pd.Series(index=index, name=y.name, dtype=y.dtype)
+    return y
+
+def select_run2(y, db, table_id, column_id):
+    if table_id != 'run2':
+        if audformat.is_filewise_index(y.index):
+            index = audformat.filewise_index()
+        else:
+            index = audformat.segmented_index()
+        y = pd.Series(index=index, name=y.name, dtype=y.dtype)
+    return y
+
+def average_rating_segments(y, db, table_id, column_id):
+    name = y.name
+    dtype = y.dtype
+    if table_id == 'segments':
+        files = y.index.get_level_values('file').unique()
+        data = [y.loc[file].mode().values[0] for file in files]
+        index = audformat.filewise_index(files)
+    else:
+        data = []
+        index = audformat.filewise_index()
+    return pd.Series(data, index=index, name=name, dtype=dtype)
+
+def add_db_name(y, db, table_id, column_id):
+    y.name = f'{y.name}-{db.name}'
+    return y
+
+def rename_sex_to_gender_without_dtype_adjustment(y, db, table_id, column_id):
+    if y.name == 'sex':
+        y.name = 'gender'
+    return y
+
+def rename_sex_to_gender(y, db, table_id, column_id):
+    if y.name == 'sex':
+        y.name = 'gender'
+        # Make sure it uses the correct dtype as well
+        dtype = pd.CategoricalDtype(
+            categories=['female', '', 'male'],
+            ordered=False,
+        )
+        y = y.astype(dtype)
+    return y
+
+@pytest.mark.parametrize(
+    'db, schemes, aggregate_function, expected',
+    [
+        (
+            # Choose different names for each run and channel:
+            # run1, channel0: ['female', '', 'male']
+            # run1, channel1: ['male', 'female', '']
+            # run2, channel0: ['female', '', 'male']
+            # run2, channel1: ['female', '', 'male']
+            # run3, channel0: ['', 'female', 'male']
+            # run3, channel1: ['', 'female', 'male']
+            'stereo_db',
+            'gender',
+            rename_column,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run1-channel0',
+                    ),
+                    pd.Series(
+                        ['male', 'female', ''],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run1-channel1',
+                    ),
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run2-channel0',
+                    ),
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run2-channel1',
+                    ),
+                    pd.Series(
+                        ['', 'female', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run3-channel0',
+                    ),
+                    pd.Series(
+                        ['', 'female', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-run3-channel1',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        pytest.param(
+            # Fail as we select runs with different labels:
+            # run1, channel0: ['female', '', 'male']
+            # run1, channel1: ['male', 'female', '']
+            'stereo_db',
+            'gender',
+            select_run1,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        (
+            # Select run with identical labels:
+            # run2, channel0: ['female', '', 'male']
+            # run2, channel1: ['female', '', 'male']
+            'stereo_db',
+            'gender',
+            select_run2,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            # Select segments table
+            # and return maxvote for each file
+            # f1: 1, 1, 2
+            # f2: 2
+            'mono_db',
+            'rating',
+            average_rating_segments,
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 2],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            # Add name of database to column name
+            'mono_db',
+            'gender',
+            add_db_name,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender-mono-db',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        pytest.param(
+            # Rename sex scheme to gender,
+            # however as we don't fix the dtype
+            # it will raise an error
+            'mono_db',
+            ['sex', 'gender'],
+            rename_sex_to_gender_without_dtype_adjustment,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        (
+            # Rename sex scheme to gender
+            'mono_db',
+            ['gender', 'sex'],
+            rename_sex_to_gender,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            # Rename sex scheme to gender,
+            # the order how we collect schemes
+            # influences the order of the inex
+            'mono_db',
+            ['sex', 'gender'],
+            rename_sex_to_gender,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', 'male', ''],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f3.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=['female', '', 'male'],
+                            ordered=False,
+                        ),
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+    ]
+)
+def test_database_get_aggregate_function(
+        request,
+        db,
+        schemes,
+        aggregate_function,
+        expected,
+):
+    db = request.getfixturevalue(db)
+    df = db.get(schemes, aggregate_function=aggregate_function)
+    print(f'{df=}')
+    print(f'{expected=}')
+    pd.testing.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize(
+    'db, schemes, tables, splits, expected',
+    [
+        (
+            'mono_db',
+            'gender',
+            [],
+            None,
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            None,
+            [],
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            [],
+            [],
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            'non-existing',
+            None,
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            None,
+            'non-existing',
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            'non-existing',
+            'non-existing',
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            ['gender'],
+            ['train'],
+            pd.DataFrame(
+                [],
+                columns=['gender'],
+                index=pd.Index([], dtype='string'),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            ['gender'],
+            None,
+            pd.DataFrame(
+                ['female', 'male'],
+                columns=['gender'],
+                index=audformat.filewise_index(['f1.wav', 'f3.wav']),
+                dtype=pd.CategoricalDtype(
+                    categories=['female', '', 'male'],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            'segments',
+            None,
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 1, 2, 2],
+                        index=audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            None,
+            'train',
+            pd.concat(
+                [
+                    pd.Series(
+                        [0, 1],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            ['rating.train', 'rating.test'],
+            'train',
+            pd.concat(
+                [
+                    pd.Series(
+                        [0, 1],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            None,
+            ['train', 'test'],
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 0, 1],
+                        index=audformat.filewise_index(
+                            ['f3.wav', 'f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            ['rating.train', 'rating.test'],
+            None,
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 0, 1],
+                        index=audformat.filewise_index(
+                            ['f3.wav', 'f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'rating',
+            ['rating.train', 'rating.test'],
+            ['train', 'test'],
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 0, 1],
+                        index=audformat.filewise_index(
+                            ['f3.wav', 'f1.wav', 'f2.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            [0, 1, 2],
+                            ordered=False,
+                        ),
+                        name='rating',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+    ]
+)
+def test_database_get_limit_search(
+        request,
+        db,
+        schemes,
+        tables,
+        splits,
+        expected,
+):
+    db = request.getfixturevalue(db)
+    df = db.get(schemes, tables=tables, splits=splits)
+    pd.testing.assert_frame_equal(df, expected)
+
+
+def test_database_get_errors():
+
+    # Scheme with different categorical dtypes
+    db = audformat.Database('db')
+    db.schemes['label'] = audformat.Scheme('int', labels=[0, 1])
+    db['speaker'] = audformat.MiscTable(
+        pd.Index(['s1', 's2'], dtype='string', name='speaker')
+    )
+    db['speaker']['label'] = audformat.Column()
+    db['speaker']['label'].set([1.0, 1.0])
+    db['files'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
+    db['files']['label'] = audformat.Column(scheme_id='label')
+    db['files']['label'].set([0, 1])
+    db['other'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
+    db.schemes['speaker'] = audformat.Scheme('str', labels='speaker')
+    db['other']['speaker'] = audformat.Column(scheme_id='speaker')
+    db['other']['speaker'].set(['s1', 's2'])
+    error_msg = 'All categorical data must have the same dtype.'
+    with pytest.raises(ValueError, match=error_msg):
+        db.get('label')

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -174,11 +174,12 @@ def stereo_db(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'db, schemes, expected',
+    'db, scheme, additional_schemes, expected',
     [
         (
             'mono_db',
             'non-existing',
+            [],
             pd.DataFrame(
                 {
                     'non-existing': [],
@@ -190,6 +191,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'weather',
+            [],
             pd.DataFrame(
                 {
                     'weather': [],
@@ -201,6 +203,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'gender',
+            [],
             pd.DataFrame(
                 {
                     'gender': ['female', '', 'male'],
@@ -213,7 +216,8 @@ def stereo_db(tmpdir):
         ),
         (
             'mono_db',
-            ['sex', 'gender'],
+            'sex',
+            ['gender'],
             pd.concat(
                 [
                     pd.Series(
@@ -238,7 +242,8 @@ def stereo_db(tmpdir):
         ),
         (
             'mono_db',
-            ['gender', 'sex', 'non-existing'],
+            'gender',
+            ['sex', 'non-existing'],
             pd.concat(
                 [
                     pd.Series(
@@ -270,6 +275,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'winner',
+            [],
             pd.DataFrame(
                 {
                     'winner': ['w1', 'w1', 'w2', 'w1', 'w1', 'w1', 'w1'],
@@ -295,6 +301,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'year',
+            [],
             pd.DataFrame(
                 {
                     'year': [1995, 1995, 1996, 1995, 1995, 1995, 1995],
@@ -317,6 +324,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'rating',
+            [],
             pd.DataFrame(
                 {
                     'rating': [1, 0, 1, 1, 1, 2, 2],
@@ -342,6 +350,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'regression',
+            [],
             pd.DataFrame(
                 {
                     'regression': [0.3, 0.2, 0.6, 0.4],
@@ -357,6 +366,7 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'selection',
+            [],
             pd.DataFrame(
                 {
                     'selection': [1, 1, 1],
@@ -372,9 +382,9 @@ def stereo_db(tmpdir):
         ),
     ]
 )
-def test_database_get(request, db, schemes, expected):
+def test_database_get(request, db, scheme, additional_schemes, expected):
     db = request.getfixturevalue(db)
-    df = db.get(schemes)
+    df = db.get(scheme, additional_schemes)
     pd.testing.assert_frame_equal(df, expected)
 
 

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -140,8 +140,8 @@ def stereo_db(tmpdir):
     index = pd.Index(['s1', 's2', 's3'], name='speaker', dtype='string')
     db['speaker'] = audformat.MiscTable(index)
     db['speaker']['age'] = audformat.Column(scheme_id='age')
-    db['speaker']['gender'] = audformat.Column()
     db['speaker']['age'].set([23, np.NaN, 59])
+    db['speaker']['gender'] = audformat.Column()
     db['speaker']['gender'].set(['female', '', 'male'])
 
     # --- Schemes with misc tables
@@ -165,7 +165,7 @@ def stereo_db(tmpdir):
     db['run3']['channel0'] = audformat.Column(scheme_id='speaker')
     db['run3']['channel1'] = audformat.Column(scheme_id='speaker')
     db['run3']['channel0'].set(['s2', 's1', 's3'])
-    db['run3']['channel1'].set(['s2', 's1', 's3'])
+    db['run3']['channel1'].set(['s2', 's2', 's3'])
 
     db.save(path)
     audformat.testing.create_audio_files(db, channels=2, file_duration='1s')
@@ -196,10 +196,7 @@ def stereo_db(tmpdir):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -220,10 +217,7 @@ def stereo_db(tmpdir):
                         index=audformat.filewise_index(
                             ['f1.wav', 'f2.wav', 'f3.wav']
                         ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
+                        dtype='string',
                         name='gender',
                     ),
                 ],
@@ -240,10 +234,7 @@ def stereo_db(tmpdir):
                         index=audformat.filewise_index(
                             ['f1.wav', 'f2.wav', 'f3.wav']
                         ),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
+                        dtype='string',
                         name='gender',
                     ),
                     pd.Series(
@@ -302,10 +293,7 @@ def stereo_db(tmpdir):
                         ),
                     ]
                 ),
-                dtype=pd.CategoricalDtype(
-                    [1995, 1996, 1997],
-                    ordered=False,
-                ),
+                dtype='Int64',
             ),
         ),
         (
@@ -348,11 +336,28 @@ def stereo_db(tmpdir):
                 dtype='float',
             ),
         ),
+        (
+            'mono_db',
+            'selection',
+            pd.DataFrame(
+                {
+                    'selection': [1, 1, 1],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    [1, 0],
+                    ordered=False,
+                ),
+            ),
+        ),
     ]
 )
 def test_database_get(request, db, schemes, expected):
     db = request.getfixturevalue(db)
     df = db.get(schemes)
+    print(f'{df=}')
     pd.testing.assert_frame_equal(df, expected)
 
 
@@ -387,11 +392,7 @@ def rename_sex_to_gender(y, *args):
     if y.name == 'sex':
         y.name = 'gender'
         # Make sure it uses the correct dtype as well
-        dtype = pd.CategoricalDtype(
-            categories=['female', '', 'male'],
-            ordered=False,
-        )
-        y = y.astype(dtype)
+        y = y.astype('string')
     return y
 
 def rename_sex_to_gender_without_dtype_adjustment(y, *args):
@@ -453,10 +454,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
-                    ordered=False,
-                ),
+                dtype='Int64',
             ),
         ),
         (
@@ -474,10 +472,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
-                    ordered=False,
-                ),
+                dtype='Int64',
             ),
         ),
         (
@@ -499,10 +494,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
-                    ordered=False,
-                ),
+                dtype='Int64',
             ),
         ),
 
@@ -529,10 +521,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=[1.12, 1.45, 1.01, 1.76, 1.95, 1.8],
-                    ordered=False,
-                ),
+                dtype='float',
             ),
         ),
 
@@ -622,10 +611,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         pytest.param(
@@ -657,10 +643,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -682,10 +665,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f3.wav', 'f2.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
 
@@ -701,12 +681,12 @@ def select_table(y, db, table_id, column_id, label_id, table):
         # | run2  | channel0 | ['female', '',       'male'] |
         # | run2  | channel1 | ['female', '',       'male'] |
         # | run3  | channel0 | ['',       'female', 'male'] |
-        # | run3  | channel1 | ['female', 'female', 'male'] |
+        # | run3  | channel1 | ['',       '',       'male'] |
         #
         (
             # maxvote
             #
-            # gender: ['female', 'female', 'male']
+            # gender: ['female', '', 'male']
             #
             'stereo_db',
             'gender',
@@ -714,15 +694,12 @@ def select_table(y, db, table_id, column_id, label_id, table):
             None,
             pd.DataFrame(
                 {
-                    'gender': ['female', 'female', 'male'],
+                    'gender': ['female', '', 'male'],
                 },
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -733,7 +710,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
             # gender-run2-channel0: ['female', '', 'male']
             # gender-run2-channel1: ['female', '', 'male']
             # gender-run3-channel0: ['', 'female', 'male']
-            # gender-run3-channel1: ['', 'female', 'male']
+            # gender-run3-channel1: ['', '', 'male']
             #
             'stereo_db',
             'gender',
@@ -746,15 +723,12 @@ def select_table(y, db, table_id, column_id, label_id, table):
                     'gender-run2-channel0': ['female', '', 'male'],
                     'gender-run2-channel1': ['female', '', 'male'],
                     'gender-run3-channel0': ['', 'female', 'male'],
-                    'gender-run3-channel1': ['', 'female', 'male'],
+                    'gender-run3-channel1': ['', '', 'male'],
                 },
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         pytest.param(
@@ -791,10 +765,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -817,10 +788,7 @@ def select_table(y, db, table_id, column_id, label_id, table):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav', 'f3.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
 
@@ -840,6 +808,8 @@ def test_database_get_aggregate_and_modify_function(
         aggregate_function=aggregate_function,
         modify_function=modify_function,
     )
+    print(f'{df=}')
+    print(f'{expected=}')
     pd.testing.assert_frame_equal(df, expected)
 
 
@@ -856,10 +826,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -872,10 +839,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -888,10 +852,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -904,10 +865,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -920,10 +878,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -936,10 +891,7 @@ def test_database_get_aggregate_and_modify_function(
                     pd.Series(
                         [],
                         index=pd.Index([], dtype='string'),
-                        dtype=pd.CategoricalDtype(
-                            categories=['female', '', 'male'],
-                            ordered=False,
-                        ),
+                        dtype='string',
                         name='gender',
                     ),
                     pd.Series(
@@ -962,10 +914,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -978,10 +927,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': [],
                 },
                 index=pd.Index([], dtype='string'),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -994,10 +940,7 @@ def test_database_get_aggregate_and_modify_function(
                     'gender': ['female', 'male'],
                 },
                 index=audformat.filewise_index(['f1.wav', 'f3.wav']),
-                dtype=pd.CategoricalDtype(
-                    categories=['female', '', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
         (
@@ -1168,10 +1111,7 @@ def test_database_get_limit_search(
                         ),
                     ]
                 ),
-                dtype=pd.CategoricalDtype(
-                    [1995, 1996, 1997],
-                    ordered=False,
-                ),
+                dtype='Int64',
             ),
         ),
         (
@@ -1209,10 +1149,10 @@ def test_database_get_strict(request, db, schemes, strict, expected):
             ValueError,
             (
                 "Found overlapping data in column 'age':\n"
-                "        left right\n"
-                "file              \n"
-                "f1.wav  23.0  25.0\n"
-                "f3.wav  59.0  45.0"
+                "        left  right\n"
+                "file               \n"
+                "f1.wav    23     25\n"
+                "f3.wav    59     45"
             ),
         ),
         (
@@ -1221,11 +1161,11 @@ def test_database_get_strict(request, db, schemes, strict, expected):
             ValueError,
             (
                 "Found overlapping data in column 'height':\n"
-                "        left right\n"
-                "file              \n"
-                "f1.wav  1.12  1.76\n"
-                "f2.wav  1.45  1.95\n"
-                "f3.wav  1.01  1.80"
+                "        left  right\n"
+                "file               \n"
+                "f1.wav  1.12   1.76\n"
+                "f2.wav  1.45   1.95\n"
+                "f3.wav  1.01   1.80"
             ),
         ),
         (
@@ -1233,12 +1173,6 @@ def test_database_get_strict(request, db, schemes, strict, expected):
             'weight',
             TypeError,
             "dtype of categories must be the same",
-        ),
-        (
-            'mono_db',
-            'selection',
-            ValueError,
-            "All categorical data must have the same dtype."
         ),
     ]
 )

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -961,6 +961,33 @@ def test_database_get_aggregate_and_modify_function(
         ),
         (
             'mono_db',
+            'gender',
+            ['speaker'],
+            ['files.sub'],
+            None,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female'],
+                        index=audformat.filewise_index(['f1.wav']),
+                        dtype='string',
+                        name='gender',
+                    ),
+                    pd.Series(
+                        ['s1'],
+                        index=audformat.filewise_index(['f1.wav']),
+                        dtype=pd.CategoricalDtype(
+                            ['s1', 's2', 's3'],
+                            ordered=False,
+                        ),
+                        name='speaker',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
             'sex',
             [],
             ['other'],

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -521,10 +521,7 @@ def wrong_scheme_labels_db(tmpdir):
                 index=audformat.filewise_index(
                     ['f1.wav', 'f2.wav']
                 ),
-                dtype=pd.CategoricalDtype(
-                    ['female', 'male'],
-                    ordered=False,
-                ),
+                dtype='string',
             ),
         ),
     ]

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -179,12 +179,24 @@ def stereo_db(tmpdir):
         (
             'mono_db',
             'non-existing',
-            pd.DataFrame([]),
+            pd.DataFrame(
+                {
+                    'non-existing': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
         (
             'mono_db',
             'weather',
-            pd.DataFrame([]),
+            pd.DataFrame(
+                {
+                    'weather': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
         (
             'mono_db',
@@ -357,7 +369,6 @@ def stereo_db(tmpdir):
 def test_database_get(request, db, schemes, expected):
     db = request.getfixturevalue(db)
     df = db.get(schemes)
-    print(f'{df=}')
     pd.testing.assert_frame_equal(df, expected)
 
 
@@ -808,8 +819,6 @@ def test_database_get_aggregate_and_modify_function(
         aggregate_function=aggregate_function,
         modify_function=modify_function,
     )
-    print(f'{df=}')
-    print(f'{expected=}')
     pd.testing.assert_frame_equal(df, expected)
 
 
@@ -825,7 +834,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -838,7 +847,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -851,7 +860,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -864,7 +873,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -877,7 +886,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -890,13 +899,13 @@ def test_database_get_aggregate_and_modify_function(
                 [
                     pd.Series(
                         [],
-                        index=pd.Index([], dtype='string'),
+                        index=audformat.filewise_index(),
                         dtype='string',
                         name='gender',
                     ),
                     pd.Series(
                         [],
-                        index=pd.Index([], dtype='string'),
+                        index=audformat.filewise_index(),
                         dtype='object',
                         name='sex',
                     ),
@@ -913,7 +922,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -926,7 +935,7 @@ def test_database_get_aggregate_and_modify_function(
                 {
                     'gender': [],
                 },
-                index=pd.Index([], dtype='string'),
+                index=audformat.filewise_index(),
                 dtype='string',
             ),
         ),
@@ -1089,7 +1098,13 @@ def test_database_get_limit_search(
             'mono_db',
             'sex',
             True,
-            pd.DataFrame(),
+            pd.DataFrame(
+                {
+                    'sex': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
         (
             'mono_db',
@@ -1118,19 +1133,40 @@ def test_database_get_limit_search(
             'mono_db',
             'year',
             True,
-            pd.DataFrame(),
+            pd.DataFrame(
+                {
+                    'year': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
         (
             'mono_db',
             ['sex', 'year'],
             True,
-            pd.DataFrame(),
+            pd.DataFrame(
+                {
+                    'sex': [],
+                    'year': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
         (
             'mono_db',
             ['gender', 'sex', 'year'],
             True,
-            pd.DataFrame(),
+            pd.DataFrame(
+                {
+                    'gender': [],
+                    'sex': [],
+                    'year': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
         ),
     ]
 )

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -219,12 +219,15 @@ def scheme_not_assigned_db(tmpdir):
         'int',
         labels={0: {'gender': 'female'}},
     )
+    db.schemes['rating'] = audformat.Scheme('int')
 
     # --- Tables
     index = audformat.filewise_index(['f1.wav'])
     db['files'] = audformat.Table(index)
     db['files']['speaker'] = audformat.Column()
     db['files']['speaker'].set([0])
+    db['files']['rater1'] = audformat.Column()
+    db['files']['rater1'].set([1])
 
     db.save(path)
     audformat.testing.create_audio_files(db, channels=1, file_duration='1s')
@@ -507,6 +510,30 @@ def wrong_scheme_labels_db(tmpdir):
                     'gender': [],
                 },
                 index=audformat.filewise_index(),
+                dtype='object',
+            ),
+        ),
+        (
+            'scheme_not_assigned_db',
+            'rating',
+            [],
+            pd.DataFrame(
+                {
+                    'rating': [],
+                },
+                index=audformat.filewise_index(),
+                dtype='object',
+            ),
+        ),
+        (
+            'scheme_not_assigned_db',
+            'rater1',
+            [],
+            pd.DataFrame(
+                {
+                    'rater1': [1],
+                },
+                index=audformat.filewise_index(['f1.wav']),
                 dtype='object',
             ),
         ),

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -1032,6 +1032,117 @@ def test_database_get_limit_search(
     pd.testing.assert_frame_equal(df, expected)
 
 
+@pytest.mark.parametrize(
+    'db, schemes, strict, expected',
+    [
+        (
+            'mono_db',
+            'sex',
+            False,
+            pd.DataFrame(
+                {
+                    'sex': ['female', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f3.wav'],
+                ),
+                dtype='object',
+            ),
+        ),
+        (
+            'mono_db',
+            'sex',
+            True,
+            pd.DataFrame(),
+        ),
+        (
+            'mono_db',
+            'year',
+            False,
+            pd.DataFrame(
+                {
+                    'year': [1995, 1995, 1996, 1995, 1995, 1995, 1995],
+                },
+                index=audformat.utils.union(
+                    [
+                        audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        audformat.segmented_index(
+                            ['f1.wav', 'f1.wav', 'f1.wav', 'f2.wav'],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                    ]
+                ),
+                dtype=pd.CategoricalDtype(
+                    [1995, 1996, 1997],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'year',
+            True,
+            pd.DataFrame(),
+        ),
+        (
+            'mono_db',
+            ['sex', 'year'],
+            True,
+            pd.DataFrame(),
+        ),
+        (
+            'mono_db',
+            ['gender', 'sex', 'year'],
+            True,
+            pd.DataFrame(),
+        ),
+        (
+            'mono_db',
+            ['age', 'year', 'gender'],
+            True,
+            pd.DataFrame(
+                {
+                    'age': [23, np.NaN, 59],
+                    'perceived-age': [25.0, 34.0, 45.0],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            ['year', 'gender', 'age'],
+            True,
+            pd.DataFrame(
+                {
+                    'age': [23, np.NaN, 59],
+                    'perceived-age': [25.0, 34.0, 45.0],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[23.0, 59.0, 25.0, 34.0, 45.0],
+                    ordered=False,
+                ),
+            ),
+        ),
+    ]
+)
+def test_database_get_strict(request, db, schemes, strict, expected):
+    db = request.getfixturevalue(db)
+    df = db.get(schemes, strict=strict)
+    pd.testing.assert_frame_equal(df, expected)
+
+
 def test_database_get_errors():
 
     # Scheme with different categorical dtypes

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -597,149 +597,6 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
 
 
 @pytest.mark.parametrize(
-    'db, scheme, additional_schemes, map, expected',
-    [
-        (
-            'mono_db',
-            'month',
-            [],
-            True,
-            pd.DataFrame(
-                {
-                    'month': ['jan', 'feb', 'mar'],
-                },
-                index=audformat.filewise_index(
-                    ['f1.wav', 'f2.wav', 'f3.wav']
-                ),
-                dtype='string',
-            ),
-        ),
-        (
-            'mono_db',
-            'month',
-            [],
-            False,
-            pd.DataFrame(
-                {
-                    'month': [1, 2, 3],
-                },
-                index=audformat.filewise_index(
-                    ['f1.wav', 'f2.wav', 'f3.wav']
-                ),
-                dtype=pd.CategoricalDtype(
-                    categories=[1, 2, 3],
-                    ordered=False,
-                ),
-            ),
-        ),
-        (
-            'mono_db',
-            'month',
-            ['gender'],
-            True,
-            pd.DataFrame(
-                {
-                    'month': ['jan', 'feb', 'mar'],
-                    'gender': ['female', '', 'male'],
-                },
-                index=audformat.filewise_index(
-                    ['f1.wav', 'f2.wav', 'f3.wav']
-                ),
-                dtype='string',
-            ),
-        ),
-        (
-            'mono_db',
-            'month',
-            ['gender'],
-            False,
-            pd.concat(
-                [
-                    pd.Series(
-                        [1, 2, 3],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[1, 2, 3],
-                            ordered=False,
-                        ),
-                        name='month',
-                    ),
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype='string',
-                        name='gender',
-                    ),
-                ],
-                axis=1,
-            ),
-        ),
-        (
-            'mono_db',
-            'gender',
-            ['month'],
-            True,
-            pd.DataFrame(
-                {
-                    'gender': ['female', '', 'male'],
-                    'month': ['jan', 'feb', 'mar'],
-                },
-                index=audformat.filewise_index(
-                    ['f1.wav', 'f2.wav', 'f3.wav']
-                ),
-                dtype='string',
-            ),
-        ),
-        (
-            'mono_db',
-            'gender',
-            ['month'],
-            False,
-            pd.concat(
-                [
-                    pd.Series(
-                        ['female', '', 'male'],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype='string',
-                        name='gender',
-                    ),
-                    pd.Series(
-                        [1, 2, 3],
-                        index=audformat.filewise_index(
-                            ['f1.wav', 'f2.wav', 'f3.wav']
-                        ),
-                        dtype=pd.CategoricalDtype(
-                            categories=[1, 2, 3],
-                            ordered=False,
-                        ),
-                        name='month',
-                    ),
-                ],
-                axis=1,
-            ),
-        ),
-    ],
-)
-def test_database_get_map(
-        request,
-        db,
-        scheme,
-        additional_schemes,
-        map,
-        expected,
-):
-    db = request.getfixturevalue(db)
-    df = db.get(scheme, additional_schemes, map=map)
-    pd.testing.assert_frame_equal(df, expected)
-
-
-@pytest.mark.parametrize(
     'db, scheme, additional_schemes, '
     'original_column_names, aggregate_function, expected',
     [
@@ -1315,6 +1172,149 @@ def test_database_get_limit_search(
         tables=tables,
         splits=splits,
     )
+    pd.testing.assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize(
+    'db, scheme, additional_schemes, map, expected',
+    [
+        (
+            'mono_db',
+            'month',
+            [],
+            True,
+            pd.DataFrame(
+                {
+                    'month': ['jan', 'feb', 'mar'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype='string',
+            ),
+        ),
+        (
+            'mono_db',
+            'month',
+            [],
+            False,
+            pd.DataFrame(
+                {
+                    'month': [1, 2, 3],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype=pd.CategoricalDtype(
+                    categories=[1, 2, 3],
+                    ordered=False,
+                ),
+            ),
+        ),
+        (
+            'mono_db',
+            'month',
+            ['gender'],
+            True,
+            pd.DataFrame(
+                {
+                    'month': ['jan', 'feb', 'mar'],
+                    'gender': ['female', '', 'male'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype='string',
+            ),
+        ),
+        (
+            'mono_db',
+            'month',
+            ['gender'],
+            False,
+            pd.concat(
+                [
+                    pd.Series(
+                        [1, 2, 3],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[1, 2, 3],
+                            ordered=False,
+                        ),
+                        name='month',
+                    ),
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype='string',
+                        name='gender',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            ['month'],
+            True,
+            pd.DataFrame(
+                {
+                    'gender': ['female', '', 'male'],
+                    'month': ['jan', 'feb', 'mar'],
+                },
+                index=audformat.filewise_index(
+                    ['f1.wav', 'f2.wav', 'f3.wav']
+                ),
+                dtype='string',
+            ),
+        ),
+        (
+            'mono_db',
+            'gender',
+            ['month'],
+            False,
+            pd.concat(
+                [
+                    pd.Series(
+                        ['female', '', 'male'],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype='string',
+                        name='gender',
+                    ),
+                    pd.Series(
+                        [1, 2, 3],
+                        index=audformat.filewise_index(
+                            ['f1.wav', 'f2.wav', 'f3.wav']
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            categories=[1, 2, 3],
+                            ordered=False,
+                        ),
+                        name='month',
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+    ],
+)
+def test_database_get_map(
+        request,
+        db,
+        scheme,
+        additional_schemes,
+        map,
+        expected,
+):
+    db = request.getfixturevalue(db)
+    df = db.get(scheme, additional_schemes, map=map)
     pd.testing.assert_frame_equal(df, expected)
 
 

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -392,21 +392,13 @@ def rename_column(y, db, table_id, column_id):
 
 def select_column(y, db, table_id, column_id, column):
     if column_id != column:
-        if audformat.is_filewise_index(y.index):
-            index = audformat.filewise_index()
-        else:
-            index = audformat.segmented_index()
-        y = pd.Series(index=index, name=y.name, dtype=y.dtype)
+        y = y[0:0]
     return y
 
 
 def select_table(y, db, table_id, column_id, table):
     if table_id != table:
-        if audformat.is_filewise_index(y.index):
-            index = audformat.filewise_index()
-        else:
-            index = audformat.segmented_index()
-        y = pd.Series(index=index, name=y.name, dtype=y.dtype)
+        y = y[0:0]
     return y
 
 def average_rating_segments(y, db, table_id, column_id):

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -1274,7 +1274,10 @@ def test_database_get_strict(
             None,
             False,
             TypeError,
-            "dtype of categories must be the same",
+            (
+                "Cannot join labels for scheme 'weight' "
+                "with different data types: int64, object"
+            ),
         ),
         (
             # Fail as both schemes result in same original column name,

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -598,7 +598,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
 
 @pytest.mark.parametrize(
     'db, scheme, additional_schemes, '
-    'original_column_names, aggregate_function, expected',
+    'original_column_names, aggregate_function, aggregate_strategy, expected',
     [
 
         # Tests based on `mono_db`,
@@ -626,12 +626,9 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             [],
             False,
             lambda y: y[0],
+            'mismatch',
             pd.DataFrame(
                 {
-                    # NOTE: 34 as second value might not be
-                    # what a user expects.
-                    # Using a modifier to select a column
-                    # is the safer choice.
                     'age': [23, 34, 59],
                 },
                 index=audformat.filewise_index(
@@ -649,6 +646,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             [],
             False,
             lambda y: y[1],
+            'mismatch',
             pd.DataFrame(
                 {
                     'age': [25, 34, 45],
@@ -670,6 +668,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             [],
             True,
             None,
+            'mismatch',
             pd.DataFrame(
                 {
                     'channel0': [23, np.NaN, 59],
@@ -718,6 +717,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             ['age'],
             True,
             None,
+            'mismatch',
             pd.concat(
                 [
                     pd.Series(
@@ -781,6 +781,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
             [],
             False,
             lambda y: y.mode()[0],
+            'overlap',
             pd.DataFrame(
                 {
                     'gender': ['female', '', 'male'],
@@ -800,6 +801,7 @@ def test_database_get_aggregate_and_modify_function(
         additional_schemes,
         original_column_names,
         aggregate_function,
+        aggregate_strategy,
         expected,
 ):
     db = request.getfixturevalue(db)
@@ -808,6 +810,7 @@ def test_database_get_aggregate_and_modify_function(
         additional_schemes,
         original_column_names=original_column_names,
         aggregate_function=aggregate_function,
+        aggregate_strategy=aggregate_strategy,
     )
     pd.testing.assert_frame_equal(df, expected)
 


### PR DESCRIPTION
Closes #398 

Adds `audformat.Database.get()` to request a data frame containing columns with  labels based on a scheme, limited by selected tables and/or splits and additional schemes drawn from the whole database.

To also support databases that did not used schemes, forgot to assign it to a column or use dictionaries to provide scheme labels, I added the `strict=False` argument.

For schemes that have a simple mapping,  e.g. transcriptions with `{'a0': 'some text'}` the label is expanded unless the user explicitly disables it with `map=False`.

For example:

```python
import audb
import audformat

db = audb.load('emodb', version='1.4.1', only_metadata=True, full_path=False)
db.get('emotion', ['gender'])
```
returns
```
                   emotion  gender
file                              
wav/03a01Fa.wav  happiness    male
wav/03a01Nc.wav    neutral    male
wav/03a01Wa.wav      anger    male
wav/03a02Fc.wav  happiness    male
wav/03a02Nc.wav    neutral    male
...                    ...     ...
wav/16b10Lb.wav    boredom  female
wav/16b10Tb.wav    sadness  female
wav/16b10Td.wav    sadness  female
wav/16b10Wa.wav      anger  female
wav/16b10Wb.wav      anger  female

[535 rows x 2 columns]

```

![image](https://github.com/audeering/audformat/assets/173624/5956496a-b5f7-4150-80bf-53e2b02dfec3)

---

I also updated the docstring example for the `audformat.Database` class:

![image](https://github.com/audeering/audformat/assets/173624/7d50201d-d840-4a82-9736-f8352f56ae71)
