### PR TITLE
Column.get(map=) now returns dtype of labels

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -286,16 +286,13 @@ class Column(HeaderBase):
                 dtype = pd.api.types.infer_dtype(list(result.values))
                 if dtype in ['integer']:
                     dtype = 'Int64'
-                elif dtype in ['floating', 'decimal']:
+                elif dtype in ['floating', 'decimal', 'mixed-integer-float']:
                     dtype = 'float'
                 elif dtype in ['datetime64', 'datetime', 'date']:
                     dtype = 'datetime64[ns]'
-                elif dtype in [
-                        'mixed',
-                        'mixed-integer',
-                        'mixed-integer-float',
-                        'unknown-array',
-                ]:
+                elif dtype in ['timedelta64', 'timedelta', 'time']:
+                    dtype = 'timedelta64[ns]'
+                elif dtype in ['mixed', 'mixed-integer', 'unknown-array']:
                     dtype = 'object'
             result = result.astype(dtype)
 

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -8,6 +8,8 @@ import pandas as pd
 
 from audformat.core import define
 from audformat.core.common import HeaderBase
+from audformat.core.common import to_audformat_dtype
+from audformat.core.common import to_pandas_dtype
 from audformat.core.index import index_type
 from audformat.core.index import is_scalar
 from audformat.core.index import to_array
@@ -284,20 +286,8 @@ class Column(HeaderBase):
             else:
                 # Infer dtype from actual labels
                 dtype = pd.api.types.infer_dtype(list(result.values))
-                if dtype == 'string':
-                    dtype = 'string'
-                elif dtype == 'integer':
-                    dtype = 'Int64'
-                elif dtype == 'boolean':
-                    dtype = 'boolean'
-                elif dtype in ['floating', 'decimal', 'mixed-integer-float']:
-                    dtype = 'float'
-                elif dtype in ['datetime64', 'datetime', 'date']:
-                    dtype = 'datetime64[ns]'
-                elif dtype in ['timedelta64', 'timedelta', 'time']:
-                    dtype = 'timedelta64[ns]'
-                else:
-                    dtype = 'object'
+                dtype = to_pandas_dtype(to_audformat_dtype(dtype))
+
             result = result.astype(dtype)
 
         return result.copy() if copy else result

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -284,15 +284,19 @@ class Column(HeaderBase):
             else:
                 # Infer dtype from actual labels
                 dtype = pd.api.types.infer_dtype(list(result.values))
-                if dtype in ['integer']:
+                if dtype == 'string':
+                    dtype = 'string'
+                elif dtype == 'integer':
                     dtype = 'Int64'
+                elif dtype == 'boolean':
+                    dtype = 'boolean'
                 elif dtype in ['floating', 'decimal', 'mixed-integer-float']:
                     dtype = 'float'
                 elif dtype in ['datetime64', 'datetime', 'date']:
                     dtype = 'datetime64[ns]'
                 elif dtype in ['timedelta64', 'timedelta', 'time']:
                     dtype = 'timedelta64[ns]'
-                elif dtype in ['mixed', 'mixed-integer', 'unknown-array']:
+                else:
                     dtype = 'object'
             result = result.astype(dtype)
 

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -288,6 +288,8 @@ class Column(HeaderBase):
                     dtype = 'Int64'
                 elif dtype in ['floating', 'decimal']:
                     dtype = 'float'
+                elif dtype in ['datetime64', 'datetime', 'date']:
+                    dtype = 'datetime64[ns]'
                 elif dtype in [
                         'mixed',
                         'mixed-integer',

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -271,8 +271,6 @@ class Column(HeaderBase):
             result = result.map(mapping)
             result.name = map
 
-            print(f'{mapping=}')
-            print(f'{scheme.uses_table=}')
             if (
                     scheme.uses_table
                     and self._table._db[scheme.labels][map].scheme is not None
@@ -286,21 +284,18 @@ class Column(HeaderBase):
             else:
                 # Infer dtype from actual labels
                 dtype = pd.api.types.infer_dtype(list(result.values))
-                if dtype in ['integer', 'mixed-integer']:
+                if dtype in ['integer']:
                     dtype = 'Int64'
-                elif dtype in ['floating', 'mixed-integer-float', 'decimal']:
+                elif dtype in ['floating', 'decimal']:
                     dtype = 'float'
-                elif dtype in ['mixed', 'unknown-array']:
+                elif dtype in [
+                        'mixed',
+                        'mixed-integer',
+                        'mixed-integer-float',
+                        'unknown-array',
+                ]:
                     dtype = 'object'
-                # df = pd.DataFrame(list(result.values), columns=[result.name])
-                # print(f'{df=}')
-                # dtype = df.infer_objects().dtypes[result.name]
-                print('dtype from labels')
-                print(f'{dtype=}')
-                # dtype = pd.Series(result.values).dtype
             result = result.astype(dtype)
-            # result = result.map(mapping).astype('category')
-            print(f'{result=}')
 
         return result.copy() if copy else result
 

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -333,7 +333,7 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
     # date
     elif (
             pd.api.types.is_datetime64_dtype(dtype)
-            or dtype in ['datetime64', 'datetime', 'date']
+            or dtype in ['datetime', 'date']
     ):
         return define.DataType.DATE
     # float
@@ -351,7 +351,7 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
     # time
     elif (
             pd.api.types.is_timedelta64_dtype(dtype)
-            or dtype in ['timedelta64', 'timedelta', 'time']
+            or dtype in ['timedelta', 'time']
     ):
         return define.DataType.TIME
     # string

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -327,22 +327,40 @@ def series_to_html(self):  # pragma: no cover
 
 def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
     r"""Convert pandas to audformat dtype."""
+    # bool
     if pd.api.types.is_bool_dtype(dtype):
         return define.DataType.BOOL
-    elif pd.api.types.is_datetime64_dtype(dtype):
+    # date
+    elif (
+            pd.api.types.is_datetime64_dtype(dtype)
+            or dtype in ['datetime64', 'datetime', 'date']
+    ):
         return define.DataType.DATE
-    elif pd.api.types.is_float_dtype(dtype):
+    # float
+    elif (
+            pd.api.types.is_float_dtype(dtype)
+            or dtype in ['floating', 'decimal', 'mixed-integer-float']
+    ):
         return define.DataType.FLOAT
-    elif pd.api.types.is_integer_dtype(dtype):
+    # int
+    elif (
+            pd.api.types.is_integer_dtype(dtype)
+            or dtype == 'integer'
+    ):
         return define.DataType.INTEGER
-    elif pd.api.types.is_timedelta64_dtype(dtype):
+    # time
+    elif (
+            pd.api.types.is_timedelta64_dtype(dtype)
+            or dtype in ['timedelta64', 'timedelta', 'time']
+    ):
         return define.DataType.TIME
+    # string
     # We cannot use pd.api.types.is_string_dtype()
     # as it returns `True` for list, object, etc.
     elif dtype in [str, 'str', 'string']:
         return define.DataType.STRING
+    # object
     else:
-        # default to object
         return define.DataType.OBJECT
 
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -210,6 +210,7 @@ def db_scheme_with_labels():
                 'mixed': b'abc',
                 'date': pd.to_datetime('2018-10-26'),
                 'time': pd.to_timedelta(300, unit='s'),
+                'bool': True,
             },
             'b': {
                 'alias': 'B',
@@ -218,6 +219,7 @@ def db_scheme_with_labels():
                 'mixed': 2,
                 'date': pd.to_datetime('2018-10-27'),
                 'time': pd.to_timedelta(301, unit='s'),
+                'bool': False,
             },
             'c': {
                 'alias': 'C',
@@ -226,6 +228,7 @@ def db_scheme_with_labels():
                 'mixed': 'abc',
                 'date': pd.to_datetime('2018-10-28'),
                 'time': pd.to_timedelta(302, unit='s'),
+                'bool': False,
             },
         },
     )
@@ -249,6 +252,7 @@ def db_scheme_with_misc_table():
     db.schemes['name'] = audformat.Scheme('str')
     db.schemes['date'] = audformat.Scheme('date')
     db.schemes['time'] = audformat.Scheme('time')
+    db.schemes['bool'] = audformat.Scheme('bool')
     db['misc'] = audformat.MiscTable(
         pd.Index(
             ['a', 'b', 'c'],
@@ -282,6 +286,8 @@ def db_scheme_with_misc_table():
             pd.to_timedelta(302, unit='s'),
         ]
     )
+    db['misc']['bool'] = audformat.Column(scheme_id='bool')
+    db['misc']['bool'].set([True, False, False])
     db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
     db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
     db['table']['column'] = audformat.Column(scheme_id='scheme')
@@ -372,6 +378,15 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='time',
                 dtype='timedelta64[ns]',
+            ),
+        ),
+        (
+            'db_scheme_with_labels',
+            'bool',
+            pd.Series([True, False, False],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='bool',
+                dtype='boolean',
             ),
         ),
         (
@@ -469,6 +484,15 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='time',
                 dtype='timedelta64[ns]',
+            ),
+        ),
+        (
+            'db_scheme_with_misc_table',
+            'bool',
+            pd.Series([True, False, False],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='bool',
+                dtype='boolean',
             ),
         ),
     ]

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -209,6 +209,7 @@ def db_scheme_with_labels():
                 'location': 0,
                 'mixed': b'abc',
                 'date': pd.to_datetime('2018-10-26'),
+                'time': pd.to_timedelta(300, unit='s'),
             },
             'b': {
                 'alias': 'B',
@@ -216,6 +217,7 @@ def db_scheme_with_labels():
                 'location': 0,
                 'mixed': 2,
                 'date': pd.to_datetime('2018-10-27'),
+                'time': pd.to_timedelta(301, unit='s'),
             },
             'c': {
                 'alias': 'C',
@@ -223,6 +225,7 @@ def db_scheme_with_labels():
                 'location': 1,
                 'mixed': 'abc',
                 'date': pd.to_datetime('2018-10-28'),
+                'time': pd.to_timedelta(302, unit='s'),
             },
         },
     )
@@ -245,6 +248,7 @@ def db_scheme_with_misc_table():
     db.schemes['age'] = audformat.Scheme('float', minimum=0)
     db.schemes['name'] = audformat.Scheme('str')
     db.schemes['date'] = audformat.Scheme('date')
+    db.schemes['time'] = audformat.Scheme('time')
     db['misc'] = audformat.MiscTable(
         pd.Index(
             ['a', 'b', 'c'],
@@ -268,6 +272,14 @@ def db_scheme_with_misc_table():
             pd.to_datetime('2018-10-26'),
             pd.to_datetime('2018-10-27'),
             pd.to_datetime('2018-10-28'),
+        ]
+    )
+    db['misc']['time'] = audformat.Column(scheme_id='time')
+    db['misc']['time'].set(
+        [
+            pd.to_timedelta(300, unit='s'),
+            pd.to_timedelta(301, unit='s'),
+            pd.to_timedelta(302, unit='s'),
         ]
     )
     db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
@@ -346,6 +358,20 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='date',
                 dtype='datetime64[ns]',
+            ),
+        ),
+        (
+            'db_scheme_with_labels',
+            'time',
+            pd.Series(
+                [
+                    pd.to_timedelta(300, unit='s'),
+                    pd.to_timedelta(301, unit='s'),
+                    pd.to_timedelta(302, unit='s'),
+                ],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='time',
+                dtype='timedelta64[ns]',
             ),
         ),
         (
@@ -429,6 +455,20 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='date',
                 dtype='datetime64[ns]',
+            ),
+        ),
+        (
+            'db_scheme_with_misc_table',
+            'time',
+            pd.Series(
+                [
+                    pd.to_timedelta(300, unit='s'),
+                    pd.to_timedelta(301, unit='s'),
+                    pd.to_timedelta(302, unit='s'),
+                ],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='time',
+                dtype='timedelta64[ns]',
             ),
         ),
     ]

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -204,31 +204,31 @@ def db_scheme_with_labels():
     db.schemes['scheme'] = audformat.Scheme(
         labels={
             'a': {
-                'alias': 'A',
-                'age': 45.,
-                'location': 0,
-                'mixed': b'abc',
-                'date': pd.to_datetime('2018-10-26'),
-                'time': pd.to_timedelta(300, unit='s'),
                 'bool': True,
+                'date': pd.to_datetime('2018-10-26'),
+                'float': 45.,
+                'int': 0,
+                'object': b'abc',
+                'str': 'A',
+                'time': pd.to_timedelta(300, unit='s'),
             },
             'b': {
-                'alias': 'B',
-                'age': 67.,
-                'location': 0,
-                'mixed': 2,
-                'date': pd.to_datetime('2018-10-27'),
-                'time': pd.to_timedelta(301, unit='s'),
                 'bool': False,
+                'date': pd.to_datetime('2018-10-27'),
+                'float': 67.,
+                'int': 0,
+                'object': 2,
+                'str': 'B',
+                'time': pd.to_timedelta(301, unit='s'),
             },
             'c': {
-                'alias': 'C',
-                'age': 78.,
-                'location': 1,
-                'mixed': 'abc',
-                'date': pd.to_datetime('2018-10-28'),
-                'time': pd.to_timedelta(302, unit='s'),
                 'bool': False,
+                'date': pd.to_datetime('2018-10-28'),
+                'float': 78.,
+                'int': 1,
+                'object': 'abc',
+                'str': 'C',
+                'time': pd.to_timedelta(302, unit='s'),
             },
         },
     )
@@ -243,16 +243,21 @@ def db_scheme_with_misc_table():
     r"""Database with different scheme labels stored in misc table."""
     db = audformat.testing.create_db(minimal=True)
     db.name = 'db_scheme_with_misc_table'
-    db.schemes['gender'] = audformat.Scheme('str', labels=['female', 'male'])
-    db.schemes['location'] = audformat.Scheme(
+    # Schemes
+    db.schemes['bool'] = audformat.Scheme('bool')
+    db.schemes['date'] = audformat.Scheme('date')
+    db.schemes['int-categories'] = audformat.Scheme(
         'int',
         labels={0: 'Berlin', 1: 'Gilching'},
     )
-    db.schemes['age'] = audformat.Scheme('float', minimum=0)
-    db.schemes['name'] = audformat.Scheme('str')
-    db.schemes['date'] = audformat.Scheme('date')
+    db.schemes['float'] = audformat.Scheme('float', minimum=0)
+    db.schemes['str'] = audformat.Scheme('str')
+    db.schemes['str-categories'] = audformat.Scheme(
+        'str',
+        labels=['female', 'male'],
+    )
     db.schemes['time'] = audformat.Scheme('time')
-    db.schemes['bool'] = audformat.Scheme('bool')
+    # Misc table
     db['misc'] = audformat.MiscTable(
         pd.Index(
             ['a', 'b', 'c'],
@@ -260,16 +265,8 @@ def db_scheme_with_misc_table():
             dtype='string',
         ),
     )
-    db['misc']['alias'] = audformat.Column()
-    db['misc']['alias'].set(['A', 'B', 'C'])
-    db['misc']['gender'] = audformat.Column(scheme_id='gender')
-    db['misc']['gender'].set(['female', 'male', 'male'])
-    db['misc']['location'] = audformat.Column(scheme_id='location')
-    db['misc']['location'].set([0, 0, 1])
-    db['misc']['age'] = audformat.Column(scheme_id='age')
-    db['misc']['age'].set([45, 67, 78])
-    db['misc']['name'] = audformat.Column(scheme_id='name')
-    db['misc']['name'].set(['Jae', 'Joe', 'John'])
+    db['misc']['bool'] = audformat.Column(scheme_id='bool')
+    db['misc']['bool'].set([True, False, False])
     db['misc']['date'] = audformat.Column(scheme_id='date')
     db['misc']['date'].set(
         [
@@ -278,6 +275,16 @@ def db_scheme_with_misc_table():
             pd.to_datetime('2018-10-28'),
         ]
     )
+    db['misc']['float'] = audformat.Column(scheme_id='float')
+    db['misc']['float'].set([45., 67., 78.])
+    db['misc']['int-categories'] = audformat.Column(scheme_id='int-categories')
+    db['misc']['int-categories'].set([0, 0, 1])
+    db['misc']['str'] = audformat.Column(scheme_id='str')
+    db['misc']['str'].set(['Jae', 'Joe', 'John'])
+    db['misc']['str-categories'] = audformat.Column(scheme_id='str-categories')
+    db['misc']['str-categories'].set(['female', 'male', 'male'])
+    db['misc']['str-without-scheme'] = audformat.Column()
+    db['misc']['str-without-scheme'].set(['A', 'B', 'C'])
     db['misc']['time'] = audformat.Column(scheme_id='time')
     db['misc']['time'].set(
         [
@@ -286,8 +293,7 @@ def db_scheme_with_misc_table():
             pd.to_timedelta(302, unit='s'),
         ]
     )
-    db['misc']['bool'] = audformat.Column(scheme_id='bool')
-    db['misc']['bool'].set([True, False, False])
+    # Scheme using misc table
     db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
     db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
     db['table']['column'] = audformat.Column(scheme_id='scheme')
@@ -313,42 +319,42 @@ def db_scheme_with_misc_table():
         ),
         (
             'db_scheme_with_labels',
-            'alias',
+            'str',
             pd.Series(
                 ['A', 'B', 'C'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='alias',
+                name='str',
                 dtype='string',
             ),
 
         ),
         (
             'db_scheme_with_labels',
-            'age',
+            'float',
             pd.Series(
-                [45, 67, 78],
+                [45., 67., 78.],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='age',
+                name='float',
                 dtype='float',
             ),
         ),
         (
             'db_scheme_with_labels',
-            'location',
+            'int',
             pd.Series(
                 [0, 0, 1],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='location',
+                name='int',
                 dtype='Int64',
             ),
         ),
         (
             'db_scheme_with_labels',
-            'mixed',
+            'object',
             pd.Series(
                 [b'abc', 2, 'abc'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='mixed',
+                name='object',
                 dtype='object',
             ),
         ),
@@ -404,21 +410,21 @@ def db_scheme_with_misc_table():
         ),
         (
             'db_scheme_with_misc_table',
-            'alias',
+            'str-without-scheme',
             pd.Series(
                 ['A', 'B', 'C'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='alias',
+                name='str-without-scheme',
                 dtype='string',
             ),
         ),
         (
             'db_scheme_with_misc_table',
-            'gender',
+            'str-categories',
             pd.Series(
                 ['female', 'male', 'male'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='gender',
+                name='str-categories',
                 dtype=pd.CategoricalDtype(
                     categories=['female', 'male'],
                     ordered=False,
@@ -427,11 +433,11 @@ def db_scheme_with_misc_table():
         ),
         (
             'db_scheme_with_misc_table',
-            'location',
+            'int-categories',
             pd.Series(
                 [0, 0, 1],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='location',
+                name='int-categories',
                 dtype=pd.CategoricalDtype(
                     categories=[0, 1],
                     ordered=False,
@@ -440,21 +446,21 @@ def db_scheme_with_misc_table():
         ),
         (
             'db_scheme_with_misc_table',
-            'age',
+            'float',
             pd.Series(
-                [45, 67, 78],
+                [45., 67., 78.],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='age',
+                name='float',
                 dtype='float',
             ),
         ),
         (
             'db_scheme_with_misc_table',
-            'name',
+            'str',
             pd.Series(
                 ['Jae', 'Joe', 'John'],
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
-                name='name',
+                name='str',
                 dtype='string',
             ),
         ),
@@ -503,34 +509,36 @@ def test_map_dtypes(request, db, map, expected):
     y = db['table']['column'].get(map=map)
     pd.testing.assert_series_equal(y, expected)
 
-    if map == 'alias':
-        # Change label entry and check that dtype stays the same
-        if db.name == 'db_scheme_with_labels':
-            db.schemes['scheme'].replace_labels(
-                {
-                    'a': {'alias': 'A'},
-                    'b': {'alias': 'B'},
-                }
-            )
-            y = db['table']['column'].get(map='alias')
-            expected = pd.Series(
-                ['A', 'B', None],
-                index=y.index,
-                name='alias',
-                dtype='string',
-            )
-            pd.testing.assert_series_equal(y, expected)
+    # Change label entry and check that dtype stays the same
+    if map == 'str' and db.name == 'db_scheme_with_labels':
+        db.schemes['scheme'].replace_labels(
+            {
+                'a': {'str': 'A'},
+                'b': {'str': 'B'},
+            }
+        )
+        y = db['table']['column'].get(map=map)
+        expected = pd.Series(
+            ['A', 'B', None],
+            index=y.index,
+            name=map,
+            dtype='string',
+        )
+        pd.testing.assert_series_equal(y, expected)
 
-        elif db.name == 'db_scheme_with_misc_table':
-            db['misc']['alias'].set(['A', 'B', None])
-            y = db['table']['column'].get(map='alias')
-            expected = pd.Series(
-                ['A', 'B', None],
-                index=y.index,
-                name='alias',
-                dtype='string',
-            )
-            pd.testing.assert_series_equal(y, expected)
+    elif (
+            map == 'str-without-scheme'
+            and db.name == 'db_scheme_with_misc_table'
+    ):
+        db['misc']['str-without-scheme'].set(['A', 'B', None])
+        y = db['table']['column'].get(map=map)
+        expected = pd.Series(
+            ['A', 'B', None],
+            index=y.index,
+            name=map,
+            dtype='string',
+        )
+        pd.testing.assert_series_equal(y, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -185,12 +185,14 @@ def test_get_as_segmented():
 )
 def test_map(column, map, expected_dtype):
     result = column.get(map=map)
+    print(f'{result=}')
     expected = column.get()
     mapping = {}
     for key, value in pytest.DB.schemes[column.scheme_id].labels.items():
         if isinstance(value, dict):
             value = value[map]
         mapping[key] = value
+    print(f'{mapping=}')
     expected = expected.map(mapping).astype(expected_dtype)
     expected.name = map
     pd.testing.assert_series_equal(result, expected)

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -208,18 +208,21 @@ def db_scheme_with_labels():
                 'age': 45.,
                 'location': 0,
                 'mixed': b'abc',
+                'date': pd.to_datetime('2018-10-26'),
             },
             'b': {
                 'alias': 'B',
                 'age': 67.,
                 'location': 0,
                 'mixed': 2,
+                'date': pd.to_datetime('2018-10-27'),
             },
             'c': {
                 'alias': 'C',
                 'age': 78.,
                 'location': 1,
                 'mixed': 'abc',
+                'date': pd.to_datetime('2018-10-28'),
             },
         },
     )
@@ -241,6 +244,7 @@ def db_scheme_with_misc_table():
     )
     db.schemes['age'] = audformat.Scheme('float', minimum=0)
     db.schemes['name'] = audformat.Scheme('str')
+    db.schemes['date'] = audformat.Scheme('date')
     db['misc'] = audformat.MiscTable(
         pd.Index(
             ['a', 'b', 'c'],
@@ -258,7 +262,14 @@ def db_scheme_with_misc_table():
     db['misc']['age'].set([45, 67, 78])
     db['misc']['name'] = audformat.Column(scheme_id='name')
     db['misc']['name'].set(['Jae', 'Joe', 'John'])
-
+    db['misc']['date'] = audformat.Column(scheme_id='date')
+    db['misc']['date'].set(
+        [
+            pd.to_datetime('2018-10-26'),
+            pd.to_datetime('2018-10-27'),
+            pd.to_datetime('2018-10-28'),
+        ]
+    )
     db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
     db['table'] = audformat.Table(audformat.filewise_index(['f1', 'f2', 'f3']))
     db['table']['column'] = audformat.Column(scheme_id='scheme')
@@ -321,6 +332,20 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='mixed',
                 dtype='object',
+            ),
+        ),
+        (
+            'db_scheme_with_labels',
+            'date',
+            pd.Series(
+                [
+                    pd.to_datetime('2018-10-26'),
+                    pd.to_datetime('2018-10-27'),
+                    pd.to_datetime('2018-10-28'),
+                ],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='date',
+                dtype='datetime64[ns]',
             ),
         ),
         (
@@ -390,6 +415,20 @@ def db_scheme_with_misc_table():
                 index=audformat.filewise_index(['f1', 'f2', 'f3']),
                 name='name',
                 dtype='string',
+            ),
+        ),
+        (
+            'db_scheme_with_misc_table',
+            'date',
+            pd.Series(
+                [
+                    pd.to_datetime('2018-10-26'),
+                    pd.to_datetime('2018-10-27'),
+                    pd.to_datetime('2018-10-28'),
+                ],
+                index=audformat.filewise_index(['f1', 'f2', 'f3']),
+                name='date',
+                dtype='datetime64[ns]',
             ),
         ),
     ]

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -185,14 +185,12 @@ def test_get_as_segmented():
 )
 def test_map(column, map, expected_dtype):
     result = column.get(map=map)
-    print(f'{result=}')
     expected = column.get()
     mapping = {}
     for key, value in pytest.DB.schemes[column.scheme_id].labels.items():
         if isinstance(value, dict):
             value = value[map]
         mapping[key] = value
-    print(f'{mapping=}')
     expected = expected.map(mapping).astype(expected_dtype)
     expected.name = map
     pd.testing.assert_series_equal(result, expected)


### PR DESCRIPTION
Closes #400 

As discussed in https://github.com/audeering/audformat/issues/400#issuecomment-1785143767 when using `audformat.Database.get()` with the `map` argument, it should return the original dtype of the labels scheme (when using a misc table and a scheme is assigned to its corresponding column) or dtype should be inferred from the actual labels.

The example from #400 

```python
import audformat
import numpy as np
import pandas as pd

db = audformat.Database('db')
db.schemes['age'] = audformat.Scheme('int')

db['speaker'] = audformat.MiscTable(pd.Index(['s1', 's2'], dtype='string', name='speaker'))
db['speaker']['age'] = audformat.Column(scheme_id='age')
db['speaker']['age'].set([2, np.NaN])

db.schemes['speaker'] = audformat.Scheme('str', labels='speaker')

db['files'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
db['files']['speaker'] = audformat.Column(scheme_id='speaker')
db['files']['speaker'].set(['s1', 's2'])

db['files']['speaker'].get(map='age')
```
now returns
```
file
f1       2
f2    <NA>
Name: age, dtype: Int64
```

And the example from https://github.com/audeering/audformat/issues/317

```python
db = audformat.Database('db')
db.schemes['text'] = audformat.Scheme(dtype='str')
db['misc'] = audformat.MiscTable(
    pd.Index(
      ['a', 'b', 'c'],
      name='speaker',
      dtype='string',
    )
)
db['misc']['text'] = audformat.Column(scheme_id='text')
db['misc']['text'].set(['A', 'B', 'C'])

db.schemes['scheme'] = audformat.Scheme('str', labels='misc')
db['table'] = audformat.MiscTable(audformat.filewise_index(['f1', 'f2', 'f3']))
db['table']['column'] = audformat.Column(scheme_id='scheme')
db['table']['column'].set(['a', 'b', 'c'])

db['table']['column'].get(map='text')
```

now returns

```
file
f1    A
f2    B
f3    C
Name: text, dtype: string
```

---

In order to use `audformat.core.common.to_audformat_dtype()`, I updated it to also handle the input coming from [`pd.api.types.infer_dtype()`](https://pandas.pydata.org/docs/reference/api/pandas.api.types.infer_dtype.html) which is used to infer the dtype from a list of values.