### PR TITLE
Column.get(map=) support dicts with partial keys

### DIFF
--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -254,20 +254,38 @@ class Column(HeaderBase):
                     "for its labels."
                 )
 
+            # Check that at least one key is available for map
+            keys = list(labels.keys())
+            keys = []
+            for key, value in labels.items():
+                if isinstance(value, dict):
+                    keys += list(value.keys())
+            keys = sorted(list(set(keys)))
+            if len(keys) > 0 and map not in keys:
+                raise ValueError(
+                    f"Cannot map "
+                    f"'{self._id}' "
+                    f"to "
+                    f"'{map}'. "
+                    f"Expected one of "
+                    f"{list(keys)}."
+                )
+
             mapping = {}
             for key, value in labels.items():
                 if isinstance(value, dict):
                     if map in value:
                         value = value[map]
                     else:
-                        raise ValueError(
-                            f"Cannot map "
-                            f"'{self._id}' "
-                            f"to "
-                            f"'{map}'. "
-                            f"Expected one of "
-                            f"{list(value)}."
-                        )
+                        # raise ValueError(
+                        #     f"Cannot map "
+                        #     f"'{self._id}' "
+                        #     f"to "
+                        #     f"'{map}'. "
+                        #     f"Expected one of "
+                        #     f"{list(value)}."
+                        # )
+                        value = np.NaN
                 mapping[key] = value
 
             result = result.map(mapping)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,11 @@ import audformat.testing
 
 
 pytest.DB = audformat.testing.create_db()
+# Adjust scheme dictionary to contain one missing label
+labels = pytest.DB.schemes["label_map_str"].labels
+labels['label3'].pop('prop2')
+pytest.DB.schemes["label_map_str"].replace_labels(labels)
+
 pytest.DB_ROOT = 'db'
 pytest.FILE_DUR = pd.to_timedelta('1s')
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -177,7 +177,7 @@ def test_get_as_segmented():
             pytest.DB['files']['string'], 'map', None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
-        pytest.param(  # no labels
+        pytest.param(  # no labels in dict
             pytest.DB['files']['label_map_str'], 'bad', None,
             marks=pytest.mark.xfail(raises=ValueError),
         ),
@@ -189,7 +189,10 @@ def test_map(column, map, expected_dtype):
     mapping = {}
     for key, value in pytest.DB.schemes[column.scheme_id].labels.items():
         if isinstance(value, dict):
-            value = value[map]
+            if map in value:
+                value = value[map]
+            else:
+                value = np.NaN
         mapping[key] = value
     expected = expected.map(mapping).astype(expected_dtype)
     expected.name = map


### PR DESCRIPTION
This updates `audformat.Column.get(map=)` to only raise an error if the requested mapping scheme is not available in all dictionaries of the scheme labels and not just in some.

Let's start with:

```python
import audformat

db = audformat.Database('db')
db.schemes['speaker'] = audformat.Scheme(
    'int',
    labels={
        0: {'age': 35, 'gender': 'female'},
        1: {'age': 26},
    },
)
db['files'] = audformat.Table(audformat.filewise_index(['f1', 'f2']))
db['files']['speaker'] = audformat.Column(scheme_id='speaker')
db['files']['speaker'].set([0, 1])
```

Now we get

```python
>>> db['files']['speaker'].get(map='location')
...
ValueError: Cannot map 'speaker' to 'location'. Expected one of ['age', 'gender'].
```

but the following no longer raises an error

```python
>>> db['files']['speaker'].get(map='gender')
file
f1    female
f2      <NA>
Name: gender, dtype: string
```
db.get('gender')