### PR TITLE
Simplify benchmark of utils.union()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1842,7 +1842,7 @@ def union(
     objs = _maybe_convert_single_level_multi_index(objs)
     _assert_index_alike(objs)
 
-    # Combine all MultiIndex entries and drop duplicates afterwards,
+    # Combine all index entries and drop duplicates afterwards,
     # faster than using index.union(),
     # compare https://github.com/audeering/audformat/pull/98
 

--- a/benchmarks/benchmark_union.py
+++ b/benchmarks/benchmark_union.py
@@ -1,10 +1,8 @@
-import os
 import time
 import typing
 
+import numpy as np
 import pandas as pd
-
-import audeer
 
 import audformat
 
@@ -13,15 +11,11 @@ import audformat
 # audformat.utils.union()
 # that concatenates a list of index objects.
 # This can be achieved with pd.concat().
-# However,
-# for indices with less than 500 entries,
-# it is faster to convert the level values to lists
-# and create the index from those.
 #
 # See also https://github.com/audeering/audformat/pull/354
 
 
-cache_root = audeer.mkdir('cache')
+np.random.seed(1)
 
 
 def benchmark(
@@ -29,34 +23,18 @@ def benchmark(
         num_segs: typing.Tuple[int],
         num_objs: typing.Tuple[int],
         num_repeat: int,
-        threshold: int,
 ) -> pd.Series:
-
-    cache_name = (
-            hash(segmented) +
-            hash(num_segs) +
-            hash(num_objs) +
-            hash(num_repeat) +
-            hash(threshold)
-    )
-    cache_path = audeer.path(cache_root, f'{cache_name}.pkl')
-
-    if os.path.exists(cache_path):
-        return pd.read_pickle(cache_path)
-
-    audformat.core.utils.UNION_MAX_INDEX_LEN_THRES = threshold
 
     ds = []
 
-    for num_seg in num_segs:
-        for num_obj in num_objs:
+    for num_seg, num_obj in zip(num_segs, num_objs):
 
             objs = []
             for idx in range(num_obj):
                 files = [f'file-{idx}-{seg}' for seg in range(num_seg)]
                 if segmented:
-                    starts = [0] * len(files)
-                    ends = [1] * len(files)
+                    starts = np.random.randn(len(files))
+                    ends = np.random.randn(len(files)) + 2
                     index = audformat.segmented_index(files, starts, ends)
                 else:
                     index = audformat.filewise_index(files)
@@ -75,53 +53,32 @@ def benchmark(
             ds.append(d)
 
     y = pd.DataFrame(ds).set_index(['num_obj', 'num_seg'])['elapsed']
-    y.to_pickle(cache_path)
 
     return y
 
 
 def main():
 
-    default_threshold = audformat.core.utils.UNION_MAX_INDEX_LEN_THRES
+    num_segs = [1000000, 1000, 10000, 100000, 100, 1000, 10000,  100, 1000]
+    num_objs = [      2,   10,    10,     10, 100,  100,   100, 1000, 1000]
+    num_repeat = 10
 
-    num_segs = tuple(range(100, 1000, 100))
-    num_objs = (10, 100, 1000)
-    num_repeat = 5
+    print(f'Execution time averaged over {num_repeat} runs.')
 
     for segmented in [False, True]:
 
+        print()
         print(f'{"segmented" if segmented else "filewise"} index')
 
-        # always use pd.concat()
-        y_pandas = benchmark(
+        y = benchmark(
             segmented,
             num_segs,
             num_objs,
             num_repeat,
-            0,
         )
-
-        # use pd.concat() only when at least one index
-        # has more than UNION_MAX_INDEX_LEN_THRES entries
-        # otherwise create index from lists
-        y_audformat = benchmark(
-            segmented,
-            num_segs,
-            num_objs,
-            num_repeat,
-            default_threshold,
-        )
-
-        df = pd.DataFrame(
-            {
-                'pandas': y_pandas.values,
-                'audformat': y_audformat.values,
-                'factor': (y_audformat / y_pandas).values,
-            },
-            index=y_pandas.index,
-        )
-        print(df.round(2))
-        print(df.mean())
+        y.name = 'time (s)'
+        print(y.round(2))
+        print(f'Average: {y.mean()}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I tried to speed up `audformat.utils.union()` for MultiIndex entries.

I did not succeed, but on the way I simplified the corresponding benchmark script.

Output is now:

```bash
$ python benchmark_union.py
Execution time averaged over 10 runs.
                        
filewise index          
num_obj  num_seg        
2        1000000    0.80
10       1000       0.01
         10000      0.01
         100000     0.22
100      100        0.01
         1000       0.03      
         10000      0.23   
1000     100        0.05
         1000       0.39                                                   
Name: time (s), dtype: float64
Average: 0.19366467528873021

segmented index
num_obj  num_seg
2        1000000    4.58
10       1000       0.02
         10000      0.13
         100000     1.62
100      100        0.09
         1000       0.16
         10000      1.62
1000     100        0.99
         1000       2.13
Name: time (s), dtype: float64
Average: 1.2612204843097263
```