### PR TITLE
Fix pandas deprecation warnings

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -355,7 +355,7 @@ class Base(HeaderBase):
         if fill_values is not None:
             if isinstance(fill_values, dict):
                 for key, value in fill_values.items():
-                    table.df[key].fillna(value, inplace=True)
+                    table.df.fillna({key: value}, inplace=True)
             else:
                 table.df.fillna(fill_values, inplace=True)
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -388,7 +388,7 @@ def concat(
                 index=index,
                 dtype=dtype,
             )
-        columns_reindex[column.name][column.index] = column
+        columns_reindex[column.name].loc[column.index] = column
 
     # Apply custom aggregation function
     # on collected overlapping data

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 graphviz
 ipykernel
 jupyter-sphinx
+pyarrow  # https://github.com/pandas-dev/pandas/issues/54466
 sphinx
 sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1013,7 +1013,8 @@ def test_filewise(num_files, values):
     # slice
     df['column'] = np.nan
     table.df['column'] = np.nan
-    df['column'][1:-1] = values[1:-1]
+    rows = df.index[1:-1]
+    df.loc[rows, 'column'] = values[1:-1]
     index = audformat.filewise_index(table.files[1:-1])
     table.set({'column': values[1:-1]}, index=index)
     pd.testing.assert_frame_equal(
@@ -1025,7 +1026,8 @@ def test_filewise(num_files, values):
     # dtype of file level is object
     df['column'] = np.nan
     table.df['column'] = np.nan
-    df['column'][1:-1] = values[1:-1]
+    rows = df.index[1:-1]
+    df.loc[rows, 'column'] = values[1:-1]
     index = pd.Index(table.files[1:-1], dtype='object', name='file')
     table.set({'column': values[1:-1]}, index=index)
     pd.testing.assert_frame_equal(


### PR DESCRIPTION
Adjust indexing of dataframes and series, and add `pyarrow` dependency for building docs to avoid `pandas` deprecation warnings.