### PR TITLE
CI: make Python 3.10 default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, windows-latest, macOS-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.8'
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'
 


### PR DESCRIPTION
Use Python 3.10 for Windows, MacOS, docs, linter, and publishing.