### PR TITLE
CI: remove forced audeer>=2.0.0 installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        # Force audeer 2.0.0
-        # until we have a new audformat version released,
-        # that does not have "audeer <2.0.0"
-        # in its dependencies
-        pip install --upgrade audeer
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
In #413 we created a new release of `audformat`, that does no longer have `audeer <2.0.0` as a requirement, so we don't need to force its installation in the test CI jobs.