### PR TITLE
Support loading db with splits in misc tables

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1505,6 +1505,12 @@ class Database(HeaderBase):
                 media.from_dict(media_d)
                 db.media[media_id] = media
 
+        if "splits" in header and header["splits"]:
+            for split_id, split_d in header["splits"].items():
+                split = Split()
+                split.from_dict(split_d)
+                db.splits[split_id] = split
+
         if "misc_tables" in header and header["misc_tables"]:
             for table_id, table_d in header["misc_tables"].items():
                 table = MiscTable(None)
@@ -1554,12 +1560,6 @@ class Database(HeaderBase):
                 value_type=Scheme,
                 set_callback=db._set_scheme,
             )
-
-        if "splits" in header and header["splits"]:
-            for split_id, split_d in header["splits"].items():
-                split = Split()
-                split.from_dict(split_d)
-                db.splits[split_id] = split
 
         if "tables" in header and header["tables"]:
             for table_id, table_d in header["tables"].items():

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -1260,6 +1260,29 @@ def test_pick_index(table, index, expected):
     pd.testing.assert_index_equal(table.index, expected)
 
 
+def test_split(tmpdir):
+    """Misc table with assigned split.
+
+    This tests saving and loading a database
+    with a misc table
+    that has a split assigned.
+
+    """
+    path = audeer.mkdir(tmpdir, "db")
+    # Save database
+    db = audformat.Database("db")
+    db.schemes["text"] = audformat.Scheme("str")
+    db.splits["test"] = audformat.Split("test")
+    index = pd.Index([0, 1, 2], name="index")
+    db["misc"] = audformat.MiscTable(index, split_id="test")
+    db["misc"]["text"] = audformat.Column(scheme_id="text")
+    db["misc"]["text"].set(["abc", "def", "ghi"])
+    db.save(path)
+    # Load database
+    db2 = audformat.Database.load(path)
+    assert db == db2
+
+
 @pytest.mark.parametrize(
     "table, overwrite, others",
     [


### PR DESCRIPTION
It was possible to assign splits to misc tables before and also to store those databases. But when trzing to load a database with a misc table that has a split assigned, loading failed as the splits objects were loaded after the misc tables were loaded.

This pull request adds a test for loading a database with a misc table that has a split assigned. This tests fails for the current master. The needed fix is then added to the code of `audformat.Database.load()`.