### PR TITLE
Store tables as PARQUET files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.8'
-          - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, pyarrow ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,11 @@ jobs:
 
     - name: Downgrade to minimum dependencies
       run: |
-        pip install "audeer==2.0.0"
-        pip install "audiofile>=0.4.0"
+        # pip install "audeer==2.0.0"
+        # pip install "audiofile>=0.4.0"
         pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
-        pip install "pyyaml==5.4.1"
+        # pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'
 
     - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==11.0"
+        pip install "pyarrow==10.0"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, windows-latest, macOS-latest ]
         python-version: [ '3.10' ]
-        requirements: [ 'newest' ]
         include:
           - os: ubuntu-latest
             python-version: '3.9'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,11 @@ jobs:
 
     - name: Downgrade to minimum dependencies
       run: |
-        # pip install "audeer==2.0.0"
-        # pip install "audiofile>=0.4.0"
+        pip install "audeer==2.0.0"
+        pip install "audiofile>=0.4.0"
         pip install "pandas==2.2.0"
         pip install "pyarrow==10.0.1"
-        # pip install "pyyaml==5.4.1"
+        pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'
 
     - name: Test with pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==15.0.2"
+        pip install "pyarrow==14.0.2"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==10.0"
+        pip install "pyarrow==10.0.1"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         # pip install "audeer==2.0.0"
         # pip install "audiofile>=0.4.0"
-        pip install "pandas==2.1.0"
+        pip install "pandas==2.2.0"
         pip install "pyarrow==10.0.1"
         # pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==13.0"
+        pip install "pyarrow==12.0"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, pyarrow ]
 
 jobs:
   build:
@@ -55,7 +55,8 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
-        pip install "pandas==2.2.0"
+        pip install "numpy<2.0.0"
+        pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==12.0"
+        pip install "pyarrow==11.0"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
+        pip install "pyarrow==15.0.2"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Downgrade to minimum dependencies
       run: |
         pip install "audeer==2.0.0"
-        pip install "audiofile>=0.4.0"
+        pip install "audiofile==0.4.0"
         pip install "pandas==2.2.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==10.0.1"
+        pip install "pandas<2.1.0"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pyarrow==14.0.2"
+        pip install "pyarrow==13.0"
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,15 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, windows-latest, macOS-latest ]
         python-version: [ '3.10' ]
+        requirements: [ 'newest' ]
         include:
           - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.9'
+            requirements: 'minimum'
 
     steps:
     - uses: actions/checkout@v4
@@ -47,7 +51,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r tests/requirements.txt
-        pip install "pandas<2.1.0"
+
+    - name: Downgrade to minimum dependencies
+      run: |
+        pip install "audeer==2.0.0"
+        pip install "audiofile>=0.4.0"
+        pip install "pandas==2.1.0"
+        pip install "pyarrow==10.0.1"
+        pip install "pyyaml==5.4.1"
+      if: matrix.requirements == 'minimum'
 
     - name: Test with pytest
       run: |

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -6,6 +6,7 @@ import typing
 
 import oyaml as yaml
 import pandas as pd
+import pyarrow as pa
 
 from audformat import define
 from audformat.core.errors import BadKeyError
@@ -388,3 +389,33 @@ def to_pandas_dtype(dtype: str) -> typing.Optional[str]:
         return "string"
     elif dtype == define.DataType.TIME:
         return "timedelta64[ns]"
+
+
+def to_pyarrow_dtype(dtype: str) -> typing.Optional[str]:
+    r"""Convert audformat to pyarrow dtype.
+
+    For ``"object"`` as ``dtype``
+    there is no equivalent,
+    and we don't return a value here.
+    We let ``pyarrow`` decide,
+    which dtype fits best in that case.
+
+    Args:
+        dtype: audformat dtype
+
+    Returns:
+        pyarrow dtype
+
+    """
+    if dtype == define.DataType.BOOL:
+        return pa.bool_()
+    elif dtype == define.DataType.DATE:
+        return pa.timestamp("ns")
+    elif dtype == define.DataType.FLOAT:
+        return pa.float64()
+    elif dtype == define.DataType.INTEGER:
+        return pa.int64()
+    elif dtype == define.DataType.STRING:
+        return pa.string()
+    elif dtype == define.DataType.TIME:
+        return pa.string()

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -418,4 +418,7 @@ def to_pyarrow_dtype(dtype: str) -> typing.Optional[str]:
     elif dtype == define.DataType.STRING:
         return pa.string()
     elif dtype == define.DataType.TIME:
+        # A better fitting type would be `pa.duration("ns")`,
+        # but this is not yet supported
+        # when reading CSV files
         return pa.string()

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -6,7 +6,6 @@ import typing
 
 import oyaml as yaml
 import pandas as pd
-import pyarrow as pa
 
 from audformat import define
 from audformat.core.errors import BadKeyError
@@ -389,36 +388,3 @@ def to_pandas_dtype(dtype: str) -> typing.Optional[str]:
         return "string"
     elif dtype == define.DataType.TIME:
         return "timedelta64[ns]"
-
-
-def to_pyarrow_dtype(dtype: str) -> typing.Optional[str]:
-    r"""Convert audformat to pyarrow dtype.
-
-    For ``"object"`` as ``dtype``
-    there is no equivalent,
-    and we don't return a value here.
-    We let ``pyarrow`` decide,
-    which dtype fits best in that case.
-
-    Args:
-        dtype: audformat dtype
-
-    Returns:
-        pyarrow dtype
-
-    """
-    if dtype == define.DataType.BOOL:
-        return pa.bool_()
-    elif dtype == define.DataType.DATE:
-        return pa.timestamp("ns")
-    elif dtype == define.DataType.FLOAT:
-        return pa.float64()
-    elif dtype == define.DataType.INTEGER:
-        return pa.int64()
-    elif dtype == define.DataType.STRING:
-        return pa.string()
-    elif dtype == define.DataType.TIME:
-        # A better fitting type would be `pa.duration("ns")`,
-        # but this is not yet supported
-        # when reading CSV files
-        return pa.string()

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1383,7 +1383,7 @@ class Database(HeaderBase):
         r"""Load database from disk.
 
         Expects a header ``<root>/<name>.yaml``
-        and for every table a file ``<root>/<name>.<table-id>.[csv|pkl]``
+        and for every table a file ``<root>/<name>.<table-id>.[csv|parquet|pkl]``
         Media files should be located under ``root``.
 
         Args:
@@ -1409,7 +1409,7 @@ class Database(HeaderBase):
         Raises:
             FileNotFoundError: if the database header file cannot be found
                 under ``root``
-            RuntimeError: if a CSV table file is newer
+            RuntimeError: if a CSV or PARQUET table file is newer
                 than the corresponding PKL file
 
         """

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -121,7 +121,6 @@ class Database(HeaderBase):
         tables:
           table:
             type: filewise
-            levels: {file: str}
             media_id: audio
             columns:
               column: {scheme_id: emotion, rater_id: rater}

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -979,7 +979,7 @@ class Database(HeaderBase):
         r"""Save database to disk.
 
         Creates a header ``<root>/<name>.yaml``
-        and for every table a file ``<root>/<name>.<table-id>.[csv,pkl]``.
+        and for every table a file ``<root>/<name>.<table-id>.[csv,parquet,pkl]``.
 
         Existing files will be overwritten.
         If ``update_other_formats`` is provided,

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -121,6 +121,7 @@ class Database(HeaderBase):
         tables:
           table:
             type: filewise
+            levels: {file: str}
             media_id: audio
             columns:
               column: {scheme_id: emotion, rater_id: rater}

--- a/audformat/core/define.py
+++ b/audformat/core/define.py
@@ -337,6 +337,9 @@ class TableStorageFormat(DefineBase):
     CSV = "csv"
     """File extension for tables stored in CSV format."""
 
+    PARQUET = "parquet"
+    """File extension for tables stored in PARQUET format."""
+
     PICKLE = "pkl"
     """File extension for tables stored in PKL format."""
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -902,8 +902,6 @@ class Base(HeaderBase):
                 pa.string(): pd.StringDtype(),
             }.get,  # we have to provide a callable, not a dict
         )
-        # Free no longer needed memory
-        del table
         # Adjust dtypes, that cannot be handled by pyarrow
         for column in timedelta_columns:
             if len(df) == 0:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -444,10 +444,10 @@ class Base(HeaderBase):
     ):
         r"""Load table data from disk.
 
-        Tables can be stored as PKL and/or CSV files to disk.
-        If both files are present
+        Tables are stored as CSV, PARQUET and/or PKL files to disk.
+        If the PKL file exists,
         it will load the PKL file
-        as long as its modification date is newer,
+        as long as its modification date is the newest,
         otherwise it will raise an error
         and ask to delete one of the files.
 
@@ -456,7 +456,7 @@ class Base(HeaderBase):
 
         Raises:
             RuntimeError: if table file(s) are missing
-            RuntimeError: if CSV file is newer than PKL file
+            RuntimeError: if CSV or PARQUET file is newer than PKL file
 
         """
         path = audeer.path(path)

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -954,7 +954,8 @@ class Base(HeaderBase):
         labeled_columns = []
 
         # Collect columns,
-        # belonging to the index
+        # belonging to the table index
+        # (not the index of the provided dataframe)
         index_columns = []
 
         # --- Index ---

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -896,6 +896,14 @@ class Base(HeaderBase):
         self._df = df
 
     def _load_pickled(self, path: str):
+        r"""Load table from PKL file.
+
+        The loaded table is stored under ``self._df``.
+
+        Args:
+            path: path to table, including file extension
+
+        """
         # Older versions of audformat used xz compression
         # which produced smaller files,
         # but was slower.

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1100,7 +1100,7 @@ class Base(HeaderBase):
 
     def _save_parquet(self, path: str):
         table = pa.Table.from_pandas(self.df.reset_index(), preserve_index=False)
-        parquet.write_table(table, path)
+        parquet.write_table(table, path, compression="snappy")
 
     def _save_pickled(self, path: str):
         self.df.to_pickle(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1873,7 +1873,7 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
     md5 = hashlib.md5()
     if max_rows is not None and len(df) > max_rows:  # pragma: nocover (not yet used)
         df = df.sample(n=max_rows, random_state=0)
-        # Hash length, as we have to track if this changes
+        # Hash length of dataframe, as we have to track if this changes
         md5.update(str(len(df)).encode("utf-8"))
     try:
         md5.update(bytes(str(pd.util.hash_pandas_object(df)), "utf-8"))

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1379,7 +1379,6 @@ class Table(Base):
         >>> table["values"] = Column()
         >>> table
         type: filewise
-        levels: {file: str}
         split_id: test
         columns:
           values: {}

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -847,9 +847,6 @@ class Base(HeaderBase):
         # The returned dictionary is used
         # to infer index column names and dtypes
         # when reading CSV files.
-        # This means the names and dtypes cannot be inferred
-        # from the index itself,
-        # but need to be known before.
         raise NotImplementedError()  # pragma: no cover
 
     def _load_csv(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -17,7 +17,6 @@ from audformat.core import utils
 from audformat.core.column import Column
 from audformat.core.common import HeaderBase
 from audformat.core.common import HeaderDict
-from audformat.core.common import to_audformat_dtype
 from audformat.core.errors import BadIdError
 from audformat.core.index import filewise_index
 from audformat.core.index import index_type

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1316,8 +1316,7 @@ class MiscTable(Base):
                     f"{levels}, "
                     f"but names must be non-empty and unique."
                 )
-
-            dtypes = [to_audformat_dtype(dtype) for dtype in utils._dtypes(index)]
+            dtypes = utils._audformat_dtypes(index)
             self.levels = {level: dtype for level, dtype in zip(levels, dtypes)}
 
         super().__init__(

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -826,6 +826,7 @@ class Base(HeaderBase):
         # Returns `df, df_is_copy`
         raise NotImplementedError()
 
+    @property
     def _levels_and_dtypes(self) -> typing.Dict[str, str]:
         r"""Levels and dtypes of index columns.
 
@@ -837,6 +838,9 @@ class Base(HeaderBase):
         # The returned dictionary is used
         # to infer index column names and dtypes
         # when reading CSV files.
+        # This means the names and dtypes cannot be inferred
+        # from the index itself,
+        # but need to be known before.
         raise NotImplementedError()  # pragma: no cover
 
     def _load_csv(self, path: str):
@@ -853,7 +857,7 @@ class Base(HeaderBase):
             path: path to table, including file extension
 
         """
-        levels = list(self._levels_and_dtypes().keys())
+        levels = list(self._levels_and_dtypes.keys())
         columns = list(self.columns.keys())
         table = csv.read_csv(
             path,
@@ -1330,6 +1334,7 @@ class MiscTable(Base):
     def _get_by_index(self, index: pd.Index) -> pd.DataFrame:
         return self.df.loc[index]
 
+    @property
     def _levels_and_dtypes(self) -> typing.Dict[str, str]:
         r"""Levels and dtypes of index columns.
 
@@ -1740,6 +1745,7 @@ class Table(Base):
 
         return result
 
+    @property
     def _levels_and_dtypes(self) -> typing.Dict[str, str]:
         r"""Levels and dtypes of index columns.
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -914,9 +914,6 @@ class Base(HeaderBase):
 
         # Adjust dtypes, that cannot be handled by pyarrow
         for column in timedelta_columns:
-            # Older versions of pandas cannot convert None to timedelta
-            df[column] = df[column].map(lambda x: pd.NA if x is None else x)
-            # df[column] = df[column].fillna(pd.NA)
             df[column] = df[column].astype("timedelta64[ns]")
         for column in boolean_columns:
             df[column] = df[column].astype("boolean")

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -935,7 +935,6 @@ class Base(HeaderBase):
         convert_all: bool = False,
     ) -> pd.DataFrame:
         r"""Convert dtypes that are not handled by pyarrow.
-
         This adjusts dtypes in a dataframe,
         that could not be set correctly
         when converting to the dataframe

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1122,11 +1122,11 @@ class Base(HeaderBase):
 
         The hash is calculated from the pyarrow schema
         (to track column names and data types)
-        and the pandas dataframes
+        and the pandas dataframe
         (to track values and order or rows),
         from which the PARQUET file is generated.
 
-        The hash of the PARQUET can then be read by::
+        The hash of the PARQUET file can then be read by::
 
             pyarrow.parquet.read_schema(path).metadata[b"hash"].decode()
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -915,7 +915,7 @@ class Base(HeaderBase):
                 )
         for column in boolean_columns:
             df[column] = df[column].map(lambda x: pd.NA if x is None else x)
-            df[column] = df[column].astype(pd.BooleanDtype())
+            df[column] = df[column].astype("boolean")
         for column in object_columns:
             df[column] = df[column].astype("object")
             df[column] = df[column].replace(pd.NA, None)
@@ -940,13 +940,11 @@ class Base(HeaderBase):
         #
         if len(index_columns) > 0:
             index_dtypes = {column: df[column].dtype for column in index_columns}
+            print(f"{self.levels=}")
+            print(f"{index_dtypes=}")
         df.set_index(index_columns, inplace=True)
-        if len(index_columns) > 1:
+        if len(index_columns) > 0:
             df.index = utils.set_index_dtypes(df.index, index_dtypes)
-        elif len(index_columns) > 0:
-            # Ensure pd.BooleanDtype is used for pd.Index
-            if index_dtypes[index_columns[0]] == bool:
-                df.index = df.index.astype(pd.BooleanDtype())
 
         self._df = df
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -578,7 +578,7 @@ class Base(HeaderBase):
         self,
         path: str,
         *,
-        storage_format: str = define.TableStorageFormat.PARQUET,
+        storage_format: str = define.TableStorageFormat.CSV,
         update_other_formats: bool = True,
     ):
         r"""Save table data to disk.

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1099,12 +1099,8 @@ class Base(HeaderBase):
             df.to_csv(fp, encoding="utf-8")
 
     def _save_parquet(self, path: str):
-        # Load table before opening PARQUET file
-        # to avoid creating a PARQUET file
-        # that is newer than the PKL file
-        df = self.df  # loads table
         table = pa.Table.from_pandas(
-            df.reset_index(),
+            self.df.reset_index(),
             preserve_index=False,
             # TODO: check if faster when providing schema?
             # schema=self._schema,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -857,9 +857,12 @@ class Base(HeaderBase):
                         timedelta_columns.append(name)
                     elif dtype == define.DataType.INTEGER:
                         integer_columns.append(name)
+                    elif dtype == define.DataType.BOOL:
+                        boolean_columns.append(name)
                 else:
                     object_columns.append(name)
 
+        print(f"{dtypes=}")
         # --- Columns ---
         categories = {}
         columns = list(self.columns)
@@ -894,12 +897,14 @@ class Base(HeaderBase):
                 strings_can_be_null=True,
             ),
         )
+        print(f"{table=}")
         df = table.to_pandas(
             deduplicate_objects=False,
             types_mapper={
                 pa.string(): pd.StringDtype(),
             }.get,  # we have to provide a callable, not a dict
         )
+        print(f"{df=}")
         # Free no longer needed memory
         del table
         # Adjust dtypes, that cannot be handled by pyarrow
@@ -938,13 +943,17 @@ class Base(HeaderBase):
         # As the MultiIndex does not preserve dtypes,
         # we need to set them manually.
         #
-        if len(index_columns) > 0:
-            index_dtypes = {column: df[column].dtype for column in index_columns}
-            print(f"{self.levels=}")
-            print(f"{index_dtypes=}")
+        # if len(index_columns) > 0:
+        #     index_dtypes = {column: df[column].dtype for column in index_columns}
+        #     dtypes = {
+        #         level: to_pandas_dtype(dtype)
+        #         for level, dtype in self.levels.items()
+        #     }
+        #     print(f"{self.levels=}")
+        #     print(f"{index_dtypes=}")
         df.set_index(index_columns, inplace=True)
-        if len(index_columns) > 0:
-            df.index = utils.set_index_dtypes(df.index, index_dtypes)
+        # if len(index_columns) > 0:
+        #    df.index = utils.set_index_dtypes(df.index, index_dtypes)
 
         self._df = df
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1099,12 +1099,7 @@ class Base(HeaderBase):
             df.to_csv(fp, encoding="utf-8")
 
     def _save_parquet(self, path: str):
-        table = pa.Table.from_pandas(
-            self.df.reset_index(),
-            preserve_index=False,
-            # TODO: check if faster when providing schema?
-            # schema=self._schema,
-        )
+        table = pa.Table.from_pandas(self.df.reset_index(), preserve_index=False)
         parquet.write_table(table, path)
 
     def _save_pickled(self, path: str):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -935,6 +935,7 @@ class Base(HeaderBase):
         convert_all: bool = False,
     ) -> pd.DataFrame:
         r"""Convert dtypes that are not handled by pyarrow.
+
         This adjusts dtypes in a dataframe,
         that could not be set correctly
         when converting to the dataframe

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -915,8 +915,8 @@ class Base(HeaderBase):
         # Adjust dtypes, that cannot be handled by pyarrow
         for column in timedelta_columns:
             # Older versions of pandas cannot convert None to timedelta
-            # df[column] = df[column].map(lambda x: pd.NA if x is None else x)
-            df[column] = df[column].fillna(pd.NA)
+            df[column] = df[column].map(lambda x: pd.NA if x is None else x)
+            # df[column] = df[column].fillna(pd.NA)
             df[column] = df[column].astype("timedelta64[ns]")
         for column in boolean_columns:
             df[column] = df[column].astype("boolean")

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -862,7 +862,6 @@ class Base(HeaderBase):
                 else:
                     object_columns.append(name)
 
-        print(f"{dtypes=}")
         # --- Columns ---
         categories = {}
         columns = list(self.columns)
@@ -897,14 +896,12 @@ class Base(HeaderBase):
                 strings_can_be_null=True,
             ),
         )
-        print(f"{table=}")
         df = table.to_pandas(
             deduplicate_objects=False,
             types_mapper={
                 pa.string(): pd.StringDtype(),
             }.get,  # we have to provide a callable, not a dict
         )
-        print(f"{df=}")
         # Free no longer needed memory
         del table
         # Adjust dtypes, that cannot be handled by pyarrow
@@ -940,20 +937,14 @@ class Base(HeaderBase):
         #
         # When assigning more than one column,
         # a MultiIndex is assigned.
-        # As the MultiIndex does not preserve dtypes,
-        # we need to set them manually.
+        # As the MultiIndex does not preserve pandas dtypes,
+        # we need to restore them manually.
         #
-        # if len(index_columns) > 0:
-        #     index_dtypes = {column: df[column].dtype for column in index_columns}
-        #     dtypes = {
-        #         level: to_pandas_dtype(dtype)
-        #         for level, dtype in self.levels.items()
-        #     }
-        #     print(f"{self.levels=}")
-        #     print(f"{index_dtypes=}")
+        if len(index_columns) > 1:
+            index_dtypes = {column: df[column].dtype for column in index_columns}
         df.set_index(index_columns, inplace=True)
-        # if len(index_columns) > 0:
-        #    df.index = utils.set_index_dtypes(df.index, index_dtypes)
+        if len(index_columns) > 1:
+            df.index = utils.set_index_dtypes(df.index, index_dtypes)
 
         self._df = df
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -929,8 +929,7 @@ def is_index_alike(
     # check dtypes
     dtypes = set()
     for obj in objs:
-        ds = [to_audformat_dtype(dtype) for dtype in _dtypes(obj)]
-        dtypes.add(tuple(ds))
+        dtypes.add(tuple(_audformat_dtypes(obj)))
     if len(dtypes) > 1:
         return False
 
@@ -2017,7 +2016,7 @@ def _assert_index_alike(
 
     dtypes = []
     for obj in objs:
-        ds = [to_audformat_dtype(dtype) for dtype in _dtypes(obj)]
+        ds = _audformat_dtypes(obj)
         dtypes.append(tuple(ds) if len(ds) > 1 else ds[0])
     dtypes = list(dict.fromkeys(dtypes))
     if len(dtypes) > 1:
@@ -2026,12 +2025,18 @@ def _assert_index_alike(
     raise ValueError(msg)
 
 
-def _dtypes(obj):
-    r"""List of dtypes of object."""
-    if isinstance(obj, pd.MultiIndex):
-        return list(obj.dtypes)
-    else:
-        return [obj.dtype]
+def _audformat_dtypes(index) -> typing.List[str]:
+    r"""List of audformat data types of index.
+
+    Args:
+        index: index
+
+    Returns:
+        audformat data types of index
+
+    """
+    dtypes = _pandas_dtypes(index)
+    return [to_audformat_dtype(dtype) for dtype in dtypes]
 
 
 def _is_same_dtype(d1, d2) -> bool:
@@ -2051,12 +2056,20 @@ def _is_same_dtype(d1, d2) -> bool:
     return d1.name == d2.name
 
 
-def _levels(obj):
-    r"""List of levels of object."""
-    if isinstance(obj, pd.MultiIndex):
-        return list(obj.names)
+def _levels(index) -> typing.List[str]:
+    r"""List of levels of index.
+
+    Args:
+        index: index
+
+    Returns:
+        index levels
+
+    """
+    if isinstance(index, pd.MultiIndex):
+        return list(index.names)
     else:
-        return [obj.name]
+        return [index.name]
 
 
 def _maybe_convert_filewise_index(
@@ -2101,7 +2114,7 @@ def _maybe_convert_pandas_dtype(
 
     """
     levels = _levels(index)
-    dtypes = _dtypes(index)
+    dtypes = _pandas_dtypes(index)
 
     # Ensure integers are stored as Int64
     int_dtypes = {
@@ -2152,3 +2165,19 @@ def _maybe_convert_single_level_multi_index(
                 objs[idx].index = obj.index.get_level_values(0)
 
     return objs
+
+
+def _pandas_dtypes(index) -> typing.List[typing.Any]:
+    r"""List of pandas dtypes of index.
+
+    Args:
+        index: index
+
+    Returns:
+        pandas data types of index
+
+    """
+    if isinstance(index, pd.MultiIndex):
+        return list(index.dtypes)
+    else:
+        return [index.dtype]

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -2052,7 +2052,7 @@ def _is_same_dtype(d1, d2) -> bool:
 
 
 def _levels(obj):
-    r"""List of dtypes of object."""
+    r"""List of levels of object."""
     if isinstance(obj, pd.MultiIndex):
         return list(obj.names)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.9'  # pandas >=2.1.0
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
@@ -37,7 +37,7 @@ dependencies = [
     'oyaml',
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
-    'pandas >=2.1.0',
+    'pandas >=2.1.0',  # support <NA> in timedelta
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,9 @@ dependencies = [
     'iso-639',
     'iso3166',
     'oyaml',
+    'pandas >=2.1.0',  # support <NA> in timedelta
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
-    'pandas >=2.1.0',  # support <NA> in timedelta
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'iso-639',
     'iso3166',
     'oyaml',
-    'pyarrow',
+    'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
     'pandas >=2.1.0',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,12 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
@@ -38,7 +37,7 @@ dependencies = [
     'oyaml',
     'pyarrow',
     'pyyaml >=5.4.1',
-    'pandas >=1.4.1',
+    'pandas >=2.1.0',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'  # pandas >=2.1.0
+requires-python = '>=3.9'  # pandas >=2.2.0
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
     'iso-639',
     'iso3166',
     'oyaml',
-    'pandas >=2.1.0',  # support <NA> in timedelta
+    'pandas >=2.2.0',  # hash values, see https://github.com/pandas-dev/pandas/issues/58999
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'  # pandas >=2.2.0
+requires-python = '>=3.9'  # pandas >=2.1.0
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
     'iso-639',
     'iso3166',
     'oyaml',
-    'pandas >=2.2.0',  # hash values, see https://github.com/pandas-dev/pandas/issues/58999
+    'pandas >=2.1.0',  # for pyarrow -> timedelta conversion
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     'iso-639',
     'iso3166',
     'oyaml',
+    'pyarrow',
     'pyyaml >=5.4.1',
     'pandas >=1.4.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ addopts = '''
     --cov-report term-missing
     --cov-report xml
     --ignore=docs/
+    --ignore=benchmarks/
 '''
 
 

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -907,6 +907,7 @@ def test_dtype_multiindex(
     assert list(db["misc"].levels.values()) == expected_audformat_dtypes
     assert list(db["misc"].index.dtypes) == expected_pandas_dtypes
 
+    print(f"{db['misc'].index=}")
     db_root = tmpdir.join("db")
     db.save(db_root, storage_format="csv")
     db_new = audformat.Database.load(db_root)

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -513,6 +513,13 @@ def test_dtype_column(
     [
         (
             pd.Index,
+            ["0"],
+            None,
+            "object",
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            pd.Index,
             [],
             None,
             "object",
@@ -907,7 +914,6 @@ def test_dtype_multiindex(
     assert list(db["misc"].levels.values()) == expected_audformat_dtypes
     assert list(db["misc"].index.dtypes) == expected_pandas_dtypes
 
-    print(f"{db['misc'].index=}")
     db_root = tmpdir.join("db")
     db.save(db_root, storage_format="csv")
     db_new = audformat.Database.load(db_root)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1342,9 +1342,6 @@ def test_parquet_hash_reproducibility(tmpdir, table_id, expected_hash):
     random.seed(1)  # ensure the same random table values are created
     db = audformat.testing.create_db()
 
-    # Check that the output of audfromat.utils.hash() does not change
-    # assert audformat.utils.hash(db[table_id].df) == expected_hash
-
     # Write to PARQUET file and check if correct hash is stored
     path_wo_ext = audeer.path(tmpdir, table_id)
     path = f"{path_wo_ext}.parquet"

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1215,15 +1215,15 @@ def test_map(table, map):
     [
         (
             "files",
-            "b079f9c2331d924a0388dde079cde55c7dcf6bf2bae851d77dc5cba5b33c31e1",
+            "a6031ff402141834ec9ca3886e8672261a2671b534aaae798cf5918f12b9db14",
         ),
         (
             "segments",
-            "741e139f7adae5199539ec8260f3a55a868038865a3f5a385ea172a5ca72960b",
+            "8bb0c5da4aaf1c4b145361a1542ebd2f3857fabc6fdc3cf80deba1307109f5dc",
         ),
         (
             "misc",
-            "cb09eb7d3adaf7d45dfff0606c6ab61a1a03333aa1b8351febbba20d8c22a63d",
+            "ecc24f9ab8c25995017396f363987990d7421507532ee78da57cab0ca2e4b680",
         ),
     ],
 )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1213,9 +1213,18 @@ def test_map(table, map):
 @pytest.mark.parametrize(
     "table_id, expected_hash",
     [
-        ("files", "-4778271914368537359"),
-        ("segments", "6154135801036965154"),
-        ("misc", "8941499293930597709"),
+        (
+            "files",
+            "b079f9c2331d924a0388dde079cde55c7dcf6bf2bae851d77dc5cba5b33c31e1",
+        ),
+        (
+            "segments",
+            "741e139f7adae5199539ec8260f3a55a868038865a3f5a385ea172a5ca72960b",
+        ),
+        (
+            "misc",
+            "cb09eb7d3adaf7d45dfff0606c6ab61a1a03333aa1b8351febbba20d8c22a63d",
+        ),
     ],
 )
 def test_parquet_reproducibility(tmpdir, table_id, expected_hash):
@@ -1238,7 +1247,7 @@ def test_parquet_reproducibility(tmpdir, table_id, expected_hash):
     db = audformat.testing.create_db()
 
     # Check that the output of audfromat.utils.hash() does not change
-    assert audformat.utils.hash(db[table_id].df) == expected_hash
+    # assert audformat.utils.hash(db[table_id].df) == expected_hash
 
     # Write to PARQUET file and check if correct hash is stored
     path_wo_ext = audeer.path(tmpdir, table_id)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1506,6 +1506,8 @@ def test_save_and_load(tmpdir, storage_format):
     db["multi-misc"]["arrays"].set([np.array([0, 1]), np.array([2, 3])])
     db["multi-misc"]["lists"] = audformat.Column(scheme_id="object")
     db["multi-misc"]["lists"].set([[0, 1], [2, 3]])
+    db["multi-misc"]["no-scheme"] = audformat.Column()
+    db["multi-misc"]["no-scheme"].set([0, 1])
 
     for table_id in list(db):
         expected_df = db[table_id].get()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2159,6 +2159,14 @@ def test_update_other_formats(
     with the argument `update_other_formats=True`,
     it should write the table to the CSV and PKL file.
 
+    Args:
+        tmpdir: tmpdir fixture
+        storage_format: storage format of table
+        existing_formats: formats the table should be stored in
+            before saving to ``storage_format``
+        update_other_formats: if tables specified in ``existing_formats``
+            should be updated when saving ``storage_format``
+
     """
     db = audformat.testing.create_db()
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1215,15 +1215,15 @@ def test_map(table, map):
     [
         (
             "files",
-            "a6031ff402141834ec9ca3886e8672261a2671b534aaae798cf5918f12b9db14",
+            "4d0295654694751bdcd12be86b89b73e",
         ),
         (
             "segments",
-            "8bb0c5da4aaf1c4b145361a1542ebd2f3857fabc6fdc3cf80deba1307109f5dc",
+            "d2a9b84d03abde24ae84cf647a019b71",
         ),
         (
             "misc",
-            "ecc24f9ab8c25995017396f363987990d7421507532ee78da57cab0ca2e4b680",
+            "6b6faecc836354bd89472095c1fa746a",
         ),
     ],
 )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1312,15 +1312,15 @@ def test_hash(tmpdir, storage_format):
     [
         (
             "files",
-            "9caa6722e65a04ddbce1cda2238c9126",
+            "a66a22ee4158e0e5100f1d797155ad81",
         ),
         (
             "segments",
-            "37c9d9dc4f937a6e97ec72a080055e49",
+            "f69eb4a5d19da71e5da00a9b13beb3db",
         ),
         (
             "misc",
-            "3488c007d45b19e04e8fdbf000f0f04d",
+            "331f79758b195cb9b7d0e8889e830eb2",
         ),
     ],
 )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2200,11 +2200,11 @@ def test_update_other_formats(
     # Ensure mtimes are correct
     if update_other_formats:
         if "pickle" in formats and "csv" in formats:
-            assert mtime["pickle"] > mtime["csv"]
+            assert mtime["pickle"] >= mtime["csv"]
         if "pickle" in formats and "parquet" in formats:
-            assert mtime["pickle"] > mtime["parquet"]
+            assert mtime["pickle"] >= mtime["parquet"]
         if "csv" in formats and "parquet" in formats:
-            assert mtime["csv"] > mtime["parquet"]
+            assert mtime["csv"] >= mtime["parquet"]
     else:
         for ext in existing_formats:
             assert mtime[ext] == old_mtime[ext]


### PR DESCRIPTION
Closes #382
Closes #376 

Several improvement/speed ups to the table handling by using `pyarrow`:

* Support for storing tables as PARQUET files
* Reading tables from CSV files with `pyarrow`
* Require `pandas >=2.1.0`
* Require `pyarrow`
* Remove support for Python 3.8 (as we need `pandas >=2.1.0`)
* Add a new CI job "ubuntu-latest, 3.9, minimum", that tests with all Python packages installed at its minimum version

I decided to stay with `"csv"` as the default setting for the `storage_format` argument in `audformat.Database.save()` and `audformat.Table.save()`. This way, we could make a new release of `audformat` and can test storing tables as PARQUET file with some databases, without exposing it to other users as well. In addition, `audb` needs to be updated to support publishing PARQUET tables.

### Loading benchmark

We can benchmark the behavior with loading a dataset from a folder, that contains all tables with
`audformat.Database.load(db_root, load_data=True)`. Results are given as average over 10 runs.

| Dataset | # table rows | CSV (previous) | CSV (new) | PARQUET | PKL |
| --- | --- | --- | --- | --- | --- |
| mozillacommonvoice | 1,923,269 | 8.62 ± 0.3 s | 4.76 ± 0.6 s | 3.58 ± 0.7 s | 2.30 ± 0.8 s |
| voxceleb2 | 2,894,987 | 17.44 ± 0.3 s  | 6.05 ± 0.2 s | 1.33 ± 0.1 s | 1.01 ± 0.1 s |
| librispeech | 36,422,346 | 1036.1 ± 30 s  | 284.95 ± 17.3 s | 26.88 ± 0.7 s | 3.01 ± 1.0 s |
| imda-nsc-read-speech-balanced | 4,538,128 | 8.38 ± 0.2 s | 2.86 ± 0.4 s | 3.07 ± 0.3 s | 2.04 ± 0.3 s |
| emodb | 1,605 | 0.02 ± 0.00 s | 0.05 ± 0.01 s  | 0.03 ± 0.01 s | 0.03 ± 0.07 s |


<details><summary>Benchmark code</summary>

```python
import os
import time

import numpy as np

import audb
import audeer
import audformat


repetitions = 10

db_root = audeer.path("./db")
audeer.rmdir(db_root)
cache_root = audeer.path("./cache")
audeer.rmdir(cache_root)
audeer.mkdir(cache_root)

datasets = [
    ("mozillacommonvoice", "10.3.0"),
    ("voxceleb2", "2.6.0"),
    ("librispeech", "3.1.0"),
    ("imda-nsc-read-speech-balanced", "2.6.0"),
    ("emodb", "1.4.1"),
]
for name, version in datasets:
    audeer.rmdir(db_root)
    audb.load_to(
        db_root,
        name,
        version=version,
        only_metadata=True,
        cache_root=cache_root,
        num_workers=1,
    )

    # PKL files
    times = []
    for _ in range(repetitions):
        t0 = time.time()
        db = audformat.Database.load(db_root, load_data=True)
        t = time.time() - t0
        times.append(t)
    print(
        f"Execution time with PKL tables {name}: "
        f"{np.mean(times):.3f}±{np.std(times):.3f}s"
    )

    # CSV files
    pkl_files = audeer.list_file_names(db_root, filetype="pkl")
    for pkl_file in pkl_files:
        os.remove(pkl_file)
    times = []
    for _ in range(repetitions):
        t0 = time.time()
        db = audformat.Database.load(db_root, load_data=True)
        t = time.time() - t0
        times.append(t)
    print(
        f"Execution time with CSV tables {name}: "
        f"{np.mean(times):.3f}±{np.std(times):.3f}s"
    )

    # PARQUET files
    if audformat.__version__ > "1.1.4":
        # Replace CSV with PARQUET files
        # and repeat benchmark
        for table_id in list(db):
            path = audeer.path(db_root, f"db.{table_id}")
            db[table_id].save(path, storage_format="parquet")
            os.remove(f"{path}.csv")
        times = []
        for _ in range(repetitions):
            t0 = time.time()
            db = audformat.Database.load(db_root, load_data=True)
            t = time.time() - t0
            times.append(t)
        print(
            f"Execution time with PARQUET tables {name}: "
            f"{np.mean(times):.3f}±{np.std(times):.3f}s"
        )
```

</details>

The benchmark highlights two important results:

* The new implementation speeds up loading of CSV files by a factor of ~4.
* Reading from PARQUET is at least as fast as reading from CSV, and for some datasets much faster.


### Memory benchmark

I investigated memory consumption using [heaptrack](https://github.com/KDE/heaptrack), when loading the `phonetic-transcription.train-clean-360` table from the `librispeech` dataset from our internal server. Stored as CSV file the table has a size of 1,3 G, stored as PARQUET file 49 M.


| branch | peak heap memory | execution time |
| --- | --- | --- |
| CSV (main) | 1.36 G | 197.9 s |
| CSV (pull request) | 1.33 G | 43.9 s |
| PARQUET (pull request) | 1.11 G | 3.7 s |


<details><summary>Benchmark code</summary>

`csv-table-loading.py`
```python
import time

import audb
import audformat


# Measure execution time when loading a CSV table.
# Assumes the file `db.phonetic-transcription.train-clean-360.csv`
# or `db.phonetic-transcription.train-clean-360.parquet`
# exists in the same folder
# as this script.
# Note, that the CSV file is only loaded
# when the PARQUET file is not present.

db = audb.info.header("librispeech")
table_id = "phonetic-transcription.train-clean-360"
t0 = time.time()
db[table_id].load(f"db.{table_id}")
t = time.time() - t0
print(f"Execution time: {t:.1f} s")
```

The memory consumption is then profiled with:
```bash
$ heaptrack python csv-table-loading.py
```

The execution time was measured without `heaptrack`:
```bash
$ python csv-table-loading.py
```

</details>

### Why and when is reading from a CSV file slow?

By far the slowest part when reading a CSV file with `pyarrow` is the conversion to `pandas.Timedelta` values for columns, that specify a duration.
E.g. when reading the CSV from the memory benchmark, the reading with `pyarrow` and conversion to `pandas.DataFrame` takes **3 s**, whereas the conversion of the `start` and `end` column to `pandas.Timedelta` takes roughly **40 s**.
There is a dedicated dtype with [`pyarrow.duration`](https://arrow.apache.org/docs/python/generated/pyarrow.duration.html), but it does not have yet reading support for CSV files. When trying so, you get:

```
pyarrow.lib.ArrowNotImplementedError: CSV conversion to duration[ns] is not supported
```

When storing a table as a PARQUET file we use `duration[ns]` for time values, and converting those back to `pandas.Timedelta` seems to be much faster. Reading the PARQUET file needs **0.3 s**, converting to the dataframe then takes the remaining **3.4 s**.

The conversion can very likely be speed up when switching to use `pyarrow` based dtypes in the dataframe as we do for `audb.Dependencies._df`, but at the moment this is not fully supported in `pandas`, e.g. timedelta values are not implemented yet (https://github.com/pandas-dev/pandas/issues/52284).


### Hashing of PARQUET files

As we have experienced already at https://github.com/audeering/audb/pull/372, PARQUET files are not stored in a reproducible fashion and might return different MD5 hash sums, even though they store the same dataframe.
To overcome this problem, I calculate now a hash based on the content of the dataframe and store the resulting value inside the metadata of schema of the PARQUET file. Which means in `audb` we can access it by just loading the schema of a PARQUET file. The corresponding code to access the hash is:
```python
import pyarrow.parquet as parquet

hash = parquet.read_schema(path).metadata[b"hash"].decode()
```

This approach is faster than calculating the MD5 sum with `audeer.md5()`.
Execution time benchmarked as average over 100 repetitions:

| method | execution time |
| --- | --- |
| read hash | 0.0001 ± 0.0000 s |
| calculate md5 | 0.0716 ± 0.0007 s |

<details><summary>Benchmark code</summary>

```python
import time

import numpy as np
import pyarrow.parquet as parquet

import audeer

# Compare execution times
# for calculating the MD5 sum
# vs reading the hash from the PARQUET file.
# Assumes the file `db.phonetic-transcription.train-clean-360.parquet`
# exists in the same folder
# as this script.
table_id = "phonetic-transcription.train-clean-360"
repetitions = 100 

path = f"db.{table_id}.parquet"
times = []
for _ in range(repetitions):
    t0 = time.time()
    audeer.md5(path)
    t = time.time() - t0
    times.append(t)
print(f"Execution time MD5: {np.mean(times):.4f} ± {np.std(times):.4f} s")

times = []
for _ in range(repetitions):
    t0 = time.time()
    parquet.read_schema(path).metadata[b"hash"].decode()
    t = time.time() - t0
    times.append(t)
print(f"Execution time hash: {np.mean(times):.4f} ± {np.std(times):.4f} s")
```

</details>

### Writing benchmark

Comparison of saving the `phonetic-transcription.train-clean-360` table from `librispeech` in different formats.
Note, saving as a PARQUET file includes calculating of the hash of the underlying dataframe.

| format | execution time |
| --- | --- |
| CSV | 22.2 s |
| PARQUET | 5.1 s |
| PKL | 1.0 s |

<details><summary>Benchmark code</summary>

```python
import os
import time

import audb
import audformat


# Measure execution time when saving table.
# Assumes the file `db.phonetic-transcription.train-clean-360.csv`
# or `db.phonetic-transcription.train-clean-360.parquet`
# exists in the same folder
# as this script.
db = audb.info.header("librispeech")
table_id = "phonetic-transcription.train-clean-360"
db[table_id].load(f"db.{table_id}")

t0 = time.time()
db[table_id].save("table", storage_format="csv")
t = time.time() - t0
os.remove("table.csv")
print(f"Execution time CSV: {t:.1f} s")

t0 = time.time()
db[table_id].save("table", storage_format="parquet")
t = time.time() - t0
os.remove("table.parquet")
print(f"Execution time PARQUET: {t:.1f} s")

t0 = time.time()
db[table_id].save("table", storage_format="pkl")
t = time.time() - t0
os.remove("table.pkl")
print(f"Execution time PKL: {t:.1f} s")
```

</details>