### PR TITLE
Add as_dataframe argument to read_csv()

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1261,6 +1261,7 @@ def map_language(language: str) -> str:
 
 def read_csv(
     *args,
+    always_return_dataframe: bool = False,
     **kwargs,
 ) -> typing.Union[pd.Index, pd.Series, pd.DataFrame]:
     r"""Read object from CSV file.
@@ -1273,6 +1274,9 @@ def read_csv(
 
     Args:
         *args: arguments
+        always_return_dataframe: if ``False``,
+            a series is returned for data with one column,
+            and an index for data with zero columns
         **kwargs: keyword arguments
 
     Returns:
@@ -1283,19 +1287,24 @@ def read_csv(
             :ref:`table specifications <data-tables:Tables>`
 
     Examples:
-        >>> from io import StringIO
-        >>> string = StringIO(
-        ...     '''file,start,end,value
+        >>> string = '''file,start,end,value
         ... f1,00:00:00,00:00:01,0.0
         ... f1,00:00:01,00:00:02,1.0
         ... f2,00:00:02,00:00:03,2.0'''
-        ... )
-        >>> read_csv(string)
+        >>> with open("file.csv", "w") as file:
+        ...     _ = file.write(string)
+        >>> read_csv("file.csv")
         file  start            end
         f1    0 days 00:00:00  0 days 00:00:01    0.0
               0 days 00:00:01  0 days 00:00:02    1.0
         f2    0 days 00:00:02  0 days 00:00:03    2.0
         Name: value, dtype: float64
+        >>> read_csv("file.csv", always_return_dataframe=True)
+                                              value
+        file start           end
+        f1   0 days 00:00:00 0 days 00:00:01    0.0
+             0 days 00:00:01 0 days 00:00:02    1.0
+        f2   0 days 00:00:02 0 days 00:00:03    2.0
 
     """
     frame = pd.read_csv(*args, **kwargs)
@@ -1322,11 +1331,11 @@ def read_csv(
         index = segmented_index(files, starts=starts, ends=ends)
     frame.drop(drop, axis="columns", inplace=True)
 
-    if len(frame.columns) == 0:
+    if len(frame.columns) == 0 and not always_return_dataframe:
         return index
 
     frame = frame.set_index(index)
-    if len(frame.columns) == 1:
+    if len(frame.columns) == 1 and not always_return_dataframe:
         return frame[frame.columns[0]]
     else:
         return frame

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1261,7 +1261,7 @@ def map_language(language: str) -> str:
 
 def read_csv(
     *args,
-    always_return_dataframe: bool = False,
+    as_dataframe: bool = False,
     **kwargs,
 ) -> typing.Union[pd.Index, pd.Series, pd.DataFrame]:
     r"""Read object from CSV file.
@@ -1272,9 +1272,10 @@ def read_csv(
 
     Args:
         *args: arguments passed on to :func:`pandas.read_csv`
-        always_return_dataframe: if ``False``,
-            a series is returned for data with one column,
-            and an index for data with zero columns
+        as_dataframe: if ``False``,
+            a dataframe is only returned for data with two or more columns,
+            a series for data with one column,
+            an index for data with zero columns
         **kwargs: keyword arguments passed on to :func:`pandas.read_csv`
 
     Returns:
@@ -1297,7 +1298,7 @@ def read_csv(
               0 days 00:00:01  0 days 00:00:02    1.0
         f2    0 days 00:00:02  0 days 00:00:03    2.0
         Name: value, dtype: float64
-        >>> read_csv("file.csv", always_return_dataframe=True)
+        >>> read_csv("file.csv", as_dataframe=True)
                                               value
         file start           end
         f1   0 days 00:00:00 0 days 00:00:01    0.0
@@ -1329,11 +1330,11 @@ def read_csv(
         index = segmented_index(files, starts=starts, ends=ends)
     frame.drop(drop, axis="columns", inplace=True)
 
-    if len(frame.columns) == 0 and not always_return_dataframe:
+    if len(frame.columns) == 0 and not as_dataframe:
         return index
 
     frame = frame.set_index(index)
-    if len(frame.columns) == 1 and not always_return_dataframe:
+    if len(frame.columns) == 1 and not as_dataframe:
         return frame[frame.columns[0]]
     else:
         return frame

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1270,14 +1270,12 @@ def read_csv(
     conform to :ref:`table specifications <data-tables:Tables>`.
     If conversion is not possible, an error is raised.
 
-    See :meth:`pandas.read_csv` for supported arguments.
-
     Args:
-        *args: arguments
+        *args: arguments passed on to :func:`pandas.read_csv`
         always_return_dataframe: if ``False``,
             a series is returned for data with one column,
             and an index for data with zero columns
-        **kwargs: keyword arguments
+        **kwargs: keyword arguments passed on to :func:`pandas.read_csv`
 
     Returns:
         object conform to :ref:`table specifications <data-tables:Tables>`

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1550,7 +1550,7 @@ def test_read_csv(csv, result):
         pd.testing.assert_frame_equal(obj, result)
     # Request dataframe as return type
     csv.seek(0)  # rewind string file object
-    obj = audformat.utils.read_csv(csv, always_return_dataframe=True)
+    obj = audformat.utils.read_csv(csv, as_dataframe=True)
     if isinstance(result, pd.Index):
         result = pd.DataFrame([], columns=[], index=result)
     elif isinstance(result, pd.Series):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1548,6 +1548,14 @@ def test_read_csv(csv, result):
         pd.testing.assert_series_equal(obj, result)
     else:
         pd.testing.assert_frame_equal(obj, result)
+    # Request dataframe as return type
+    csv.seek(0)  # rewind string file object
+    obj = audformat.utils.read_csv(csv, always_return_dataframe=True)
+    if isinstance(result, pd.Index):
+        result = pd.DataFrame([], columns=[], index=result)
+    elif isinstance(result, pd.Series):
+        result = result.to_frame()
+    pd.testing.assert_frame_equal(obj, result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Relates to #420 

This adds the `as_dataframe` argument to `audformat.utils.read_csv()`, to have the option to enforce that always a dataframe is returned. The pull request also enhances the documentation of the default behavior, which returns a series if the CSV file holds one column, and an index if the CSV file contains 0 data columns.

![image](https://github.com/audeering/audformat/assets/173624/c5a07d3b-7d41-45ff-86fb-f0e0b3b0a2f1)