### PR TITLE
utils.read_csv() now handles start, end in seconds

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -21,7 +21,6 @@ from audformat.core.index import filewise_index
 from audformat.core.index import is_filewise_index
 from audformat.core.index import is_segmented_index
 from audformat.core.index import segmented_index
-from audformat.core.index import to_timedelta
 from audformat.core.scheme import Scheme
 
 
@@ -1334,12 +1333,12 @@ def read_csv(
 
     starts = None
     if define.IndexField.START in frame.columns:
-        starts = to_timedelta(frame[define.IndexField.START])
+        starts = frame[define.IndexField.START]
         drop.append(define.IndexField.START)
 
     ends = None
     if define.IndexField.END in frame.columns:
-        ends = to_timedelta(frame[define.IndexField.END])
+        ends = frame[define.IndexField.END]
         drop.append(define.IndexField.END)
 
     if starts is None and ends is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1463,6 +1463,23 @@ f2,00:00:02,2.0"""
         ),
         (
             StringIO(
+                """file,start,value
+f1,0,0.0
+f1,1,1.0
+f2,2,2.0"""
+            ),
+            pd.Series(
+                [0.0, 1.0, 2.0],
+                index=audformat.segmented_index(
+                    ["f1", "f1", "f2"],
+                    starts=["0s", "1s", "2s"],
+                    ends=pd.to_timedelta([pd.NaT, pd.NaT, pd.NaT]),
+                ),
+                name="value",
+            ),
+        ),
+        (
+            StringIO(
                 """file,end,value
 f1,00:00:01,0.0
 f1,00:00:02,1.0
@@ -1484,6 +1501,19 @@ f2,00:00:03,2.0"""
 f1,00:00:00,00:00:01
 f1,00:00:01,00:00:02
 f2,00:00:02,00:00:03"""
+            ),
+            audformat.segmented_index(
+                ["f1", "f1", "f2"],
+                ["0s", "1s", "2s"],
+                ["1s", "2s", "3s"],
+            ),
+        ),
+        (
+            StringIO(
+                """file,start,end
+f1,0,1
+f1,1,2
+f2,2,3"""
             ),
             audformat.segmented_index(
                 ["f1", "f1", "f2"],
@@ -1528,9 +1558,9 @@ f2,2,3,2.0"""
         (
             StringIO(
                 """file,start,end,value
-f1,0.,1.,0.0
-f1,1.,2.,1.0
-f2,2.,3.,2.0"""
+f1,0.0,1.0,0.0
+f1,1.0,2.0,1.0
+f2,2.0,3.0,2.0"""
             ),
             pd.Series(
                 [0.0, 1.0, 2.0],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1510,6 +1510,40 @@ f2,00:00:02,00:00:03,2.0"""
         ),
         (
             StringIO(
+                """file,start,end,value
+f1,0,1,0.0
+f1,1,2,1.0
+f2,2,3,2.0"""
+            ),
+            pd.Series(
+                [0.0, 1.0, 2.0],
+                index=audformat.segmented_index(
+                    ["f1", "f1", "f2"],
+                    starts=["0s", "1s", "2s"],
+                    ends=["1s", "2s", "3s"],
+                ),
+                name="value",
+            ),
+        ),
+        (
+            StringIO(
+                """file,start,end,value
+f1,0.,1.,0.0
+f1,1.,2.,1.0
+f2,2.,3.,2.0"""
+            ),
+            pd.Series(
+                [0.0, 1.0, 2.0],
+                index=audformat.segmented_index(
+                    ["f1", "f1", "f2"],
+                    starts=["0s", "1s", "2s"],
+                    ends=["1s", "2s", "3s"],
+                ),
+                name="value",
+            ),
+        ),
+        (
+            StringIO(
                 """file,start,end,value1,value2
 f1,00:00:00,00:00:01,0.0,a
 f1,00:00:01,00:00:02,1.0,b


### PR DESCRIPTION
Closes #422 

This adjusts `audformat.utils.read_csv()` to handle time values provided for `start` and `end` values as seconds when provided as float/integer and not as time string, e.g. `00:00:01`. The behavior is now identical to `audformat.segmented_index()`.

![image](https://github.com/audeering/audformat/assets/173624/3ae0937d-ed48-4593-88fd-50da7d25512c)
