### PR TITLE
Fix Database.get() for non-existent schemes

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -855,16 +855,13 @@ class Database(HeaderBase):
         # --- Append additional schemes
         objs = [obj]
         for scheme in additional_schemes:
-            if len(obj) == 0:
-                obj = empty_frame(scheme)
-            else:
-                obj = self.get(
-                    scheme,
-                    strict=strict,
-                    map=map,
-                    original_column_names=original_column_names,
-                    aggregate_function=aggregate_function,
-                )
+            obj = self.get(
+                scheme,
+                strict=strict,
+                map=map,
+                original_column_names=original_column_names,
+                aggregate_function=aggregate_function,
+            )
             objs.append(obj)
         if len(objs) > 1:
             obj = utils.concat(objs)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -855,14 +855,19 @@ class Database(HeaderBase):
         # --- Append additional schemes
         objs = [obj]
         for scheme in additional_schemes:
-            obj = self.get(
-                scheme,
-                strict=strict,
-                map=map,
-                original_column_names=original_column_names,
-                aggregate_function=aggregate_function,
-            )
-            objs.append(obj)
+            if len(obj) == 0:
+                # Skip searching for additional schemes,
+                # if main scheme does return empty frame
+                additional_obj = empty_frame(scheme)
+            else:
+                additional_obj = self.get(
+                    scheme,
+                    strict=strict,
+                    map=map,
+                    original_column_names=original_column_names,
+                    aggregate_function=aggregate_function,
+                )
+            objs.append(additional_obj)
         if len(objs) > 1:
             obj = utils.concat(objs)
             obj = obj.loc[index]

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -421,6 +421,40 @@ def wrong_scheme_labels_db(tmpdir):
         ),
         (
             "mono_db",
+            "gender",
+            ["numbers", "non-existing", "sex"],
+            pd.concat(
+                [
+                    pd.Series(
+                        ["female", "", "male"],
+                        index=audformat.filewise_index(["f1.wav", "f2.wav", "f3.wav"]),
+                        dtype="string",
+                        name="gender",
+                    ),
+                    pd.Series(
+                        [0, 1, 2],
+                        index=audformat.filewise_index(["f1.wav", "f2.wav", "f3.wav"]),
+                        dtype="Int64",
+                        name="numbers",
+                    ),
+                    pd.Series(
+                        [],
+                        index=audformat.filewise_index(),
+                        dtype="object",
+                        name="non-existing",
+                    ),
+                    pd.Series(
+                        ["female", np.NaN, "male"],
+                        index=audformat.filewise_index(["f1.wav", "f2.wav", "f3.wav"]),
+                        dtype="object",
+                        name="sex",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
             "winner",
             [],
             pd.DataFrame(

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -387,6 +387,38 @@ def wrong_scheme_labels_db(tmpdir):
                 axis=1,
             ),
         ),
+        # Ensure that requesting a non-existing scheme
+        # before an existing scheme
+        # does return values for existing schemes.
+        # https://github.com/audeering/audformat/issues/426
+        (
+            "mono_db",
+            "gender",
+            ["non-existing", "sex"],
+            pd.concat(
+                [
+                    pd.Series(
+                        ["female", "", "male"],
+                        index=audformat.filewise_index(["f1.wav", "f2.wav", "f3.wav"]),
+                        dtype="string",
+                        name="gender",
+                    ),
+                    pd.Series(
+                        [],
+                        index=audformat.filewise_index(),
+                        dtype="object",
+                        name="non-existing",
+                    ),
+                    pd.Series(
+                        ["female", np.NaN, "male"],
+                        index=audformat.filewise_index(["f1.wav", "f2.wav", "f3.wav"]),
+                        dtype="object",
+                        name="sex",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
         (
             "mono_db",
             "winner",

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -419,6 +419,10 @@ def wrong_scheme_labels_db(tmpdir):
                 axis=1,
             ),
         ),
+        # Ensure that requesting a non-existing scheme
+        # before an existing scheme
+        # does return values for existing schemes.
+        # https://github.com/audeering/audformat/issues/426
         (
             "mono_db",
             "gender",


### PR DESCRIPTION
Closes #426 

Add two tests that cover #246. The code itself is fixed by removing an `if` statement, that explicitly was setting an requested additional scheme to an empty frame, if the additional scheme requested before was also empty. I guess this was some left over code, that was no longer needed, but did also not fail the tests we had so far.