### PR TITLE
CI: update publish actions to use Node.js 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
         python -m sphinx docs/ docs/_build/ -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build


### PR DESCRIPTION
In https://github.com/audeering/audformat/pull/424 I forgot to update `peaceiris/actions-gh-pages`.