### PR TITLE
Ensure correct boolean dtype in misc table index

### DIFF
--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -360,7 +360,14 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
 
 
 def to_pandas_dtype(dtype: str) -> str:
-    r"""Convert audformat to pandas dtype."""
+    r"""Convert audformat to pandas dtype.
+
+    We use ``"Int64"`` instead of ``"int64"``,
+    and ``"boolean"`` instead of ``"bool"``
+    to allow for nullable entries,
+    e.g. ``[0, 2, <NA>]``.
+
+    """
     if dtype == define.DataType.BOOL:
         return "boolean"
     elif dtype == define.DataType.DATE:

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -367,6 +367,12 @@ def to_pandas_dtype(dtype: str) -> str:
     to allow for nullable entries,
     e.g. ``[0, 2, <NA>]``.
 
+    Args:
+        dtype: audformat dtype
+
+    Returns:
+        pandas dtype
+
     """
     if dtype == define.DataType.BOOL:
         return "boolean"

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -359,7 +359,7 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
         return define.DataType.OBJECT
 
 
-def to_pandas_dtype(dtype: str) -> str:
+def to_pandas_dtype(dtype: str) -> typing.Optional[str]:
     r"""Convert audformat to pandas dtype.
 
     We use ``"Int64"`` instead of ``"int64"``,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -847,6 +847,11 @@ class Base(HeaderBase):
             float_precision="round_trip",
         )
 
+        # Ensure bool values are stored as boolean,
+        # as pandas.read_csv()
+        # does not set this correctly
+        df.index = utils._maybe_convert_pandas_dtype(df.index)
+
         # For an empty CSV file
         # converters will not set the correct dtype
         # and we need to correct it manually
@@ -1072,8 +1077,10 @@ class MiscTable(Base):
             if isinstance(index, pd.MultiIndex) and index.nlevels == 1:
                 index = index.get_level_values(0)
 
-            # Ensure integers are always stored as Int64
-            index = utils._maybe_convert_int_dtype(index)
+            # Ensure integers are always stored as Int64,
+            # and bool as boolean,
+            # compare audformat.core.common.to_pandas_dtype()
+            index = utils._maybe_convert_pandas_dtype(index)
 
             levels = utils._levels(index)
             if not all(levels) or len(levels) > len(set(levels)):

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1072,8 +1072,8 @@ class MiscTable(Base):
             if isinstance(index, pd.MultiIndex) and index.nlevels == 1:
                 index = index.get_level_values(0)
 
-            # Ensure integers are always stored as Int64,
-            # and bool as boolean,
+            # Ensure integers are stored as Int64,
+            # and bool values as boolean,
             # compare audformat.core.common.to_pandas_dtype()
             index = utils._maybe_convert_pandas_dtype(index)
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -847,11 +847,6 @@ class Base(HeaderBase):
             float_precision="round_trip",
         )
 
-        # Ensure bool values are stored as boolean,
-        # as pandas.read_csv()
-        # does not set this correctly
-        df.index = utils._maybe_convert_pandas_dtype(df.index)
-
         # For an empty CSV file
         # converters will not set the correct dtype
         # and we need to correct it manually

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -168,10 +168,10 @@ def test_dtype(
     expected_pandas_dtype,
     expected_audformat_dtype,
 ):
-    r"""Test misc table columns have correct dtype.
+    r"""Test table columns have correct dtype.
 
-    Ensures that the dataframe,
-    associated with the misc table,
+    Ensures that a dataframe column,
+    associated with a table,
     has the dtype,
     which corresponds to the scheme of the column.
 

--- a/tests/test_column.py
+++ b/tests/test_column.py
@@ -24,6 +24,190 @@ def test_access():
                 assert column.rater is None
 
 
+@pytest.mark.parametrize(
+    "column_values, column_dtype, expected_pandas_dtype, expected_audformat_dtype",
+    [
+        (
+            [],
+            None,
+            "object",
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
+            "datetime64[ns]",
+            "datetime64[ns]",
+            audformat.define.DataType.DATE,
+        ),
+        (
+            [],
+            float,
+            "float64",
+            audformat.define.DataType.FLOAT,
+        ),
+        (
+            [],
+            int,
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [],
+            "int64",
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [],
+            "Int64",
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [],
+            str,
+            "object",
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            "string",
+            "string",
+            audformat.define.DataType.STRING,
+        ),
+        (
+            [],
+            "timedelta64[ns]",
+            "timedelta64[ns]",
+            audformat.define.DataType.TIME,
+        ),
+        (
+            [0],
+            "datetime64[ns]",
+            "datetime64[ns]",
+            audformat.define.DataType.DATE,
+        ),
+        (
+            [0.0],
+            None,
+            "float64",
+            audformat.define.DataType.FLOAT,
+        ),
+        (
+            [0],
+            None,
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [np.NaN],
+            "Int64",
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [0, np.NaN],
+            "Int64",
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            [np.NaN],
+            "Int64",
+            "Int64",
+            audformat.define.DataType.INTEGER,
+        ),
+        (
+            ["0"],
+            None,
+            "object",
+            audformat.define.DataType.OBJECT,
+        ),
+        (
+            [0],
+            "timedelta64[ns]",
+            "timedelta64[ns]",
+            audformat.define.DataType.TIME,
+        ),
+        (
+            [True],
+            None,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+    ],
+)
+def test_dtype(
+    tmpdir,
+    column_values,
+    column_dtype,
+    expected_pandas_dtype,
+    expected_audformat_dtype,
+):
+    r"""Test misc table columns have correct dtype.
+
+    Ensures that the dataframe,
+    associated with the misc table,
+    has the dtype,
+    which corresponds to the scheme of the column.
+
+    Args:
+        tmpdir: pytest tmpdir fixture
+        column_values: values assigned to the column
+        column_dtype: pandas dtype of values assigned to column
+        expected_pandas_dtype: pandas dtype of column after assignment
+        expected_audformat_dtype: audformat dtype corresponding
+            to the expected pandas dtype.
+            This is assigned to the scheme of the column
+
+    """
+    y = pd.Series(column_values, dtype=column_dtype or "object")
+
+    index_values = [f"f{n}" for n in range(len(column_values))]
+    index = audformat.filewise_index(index_values)
+
+    db = audformat.testing.create_db(minimal=True)
+    db["table"] = audformat.Table(index)
+    db.schemes["column"] = audformat.Scheme(expected_audformat_dtype)
+    db["table"]["column"] = audformat.Column(scheme_id="column")
+    db["table"]["column"].set(y.values)
+
+    assert db["table"]["column"].scheme.dtype == expected_audformat_dtype
+    assert db["table"].df["column"].dtype == expected_pandas_dtype
+
+    # Store and load table
+    db_root = tmpdir.join("db")
+    db.save(db_root, storage_format="csv")
+    db_new = audformat.Database.load(db_root)
+
+    assert db_new["table"]["column"].scheme.dtype == expected_audformat_dtype
+    assert db_new["table"].df["column"].dtype == expected_pandas_dtype
+
+
 def test_exceptions():
     column = audformat.Column()
     with pytest.raises(RuntimeError):

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -467,8 +467,8 @@ def test_dtype_column(
 ):
     r"""Test misc table columns have correct dtype.
 
-    Ensures that the dataframe,
-    associated with the misc table,
+    Ensures that a dataframe column,
+    associated with a misc table,
     has the dtype,
     which corresponds to the scheme of the column.
 

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -322,13 +322,25 @@ def test_copy(table):
 
 
 @pytest.mark.parametrize(
-    "column_values, column_dtype, " "expected_pandas_dtype, expected_audformat_dtype",
+    "column_values, column_dtype, expected_pandas_dtype, expected_audformat_dtype",
     [
         (
             [],
             None,
             "object",
             audformat.define.DataType.OBJECT,
+        ),
+        (
+            [],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
         ),
         (
             [],
@@ -426,6 +438,24 @@ def test_copy(table):
             "timedelta64[ns]",
             audformat.define.DataType.TIME,
         ),
+        (
+            [True],
+            None,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
     ],
 )
 def test_dtype_column(
@@ -435,6 +465,23 @@ def test_dtype_column(
     expected_pandas_dtype,
     expected_audformat_dtype,
 ):
+    r"""Test misc table columns have correct dtype.
+
+    Ensures that the dataframe,
+    associated with the misc table,
+    has the dtype,
+    which corresponds to the scheme of the column.
+
+    Args:
+        tmpdir: pytest tmpdir fixture
+        column_values: values assigned to the column
+        column_dtype: pandas dtype of values assigned to column
+        expected_pandas_dtype: pandas dtype of column after assignment
+        expected_audformat_dtype: audformat dtype corresponding
+            to the expected pandas dtype.
+            This is assigned to the scheme of the column
+
+    """
     name = "column"
     y = pd.Series(column_values, dtype=column_dtype or "object", name=name)
 
@@ -470,6 +517,20 @@ def test_dtype_column(
             None,
             "object",
             audformat.define.DataType.OBJECT,
+        ),
+        (
+            pd.Index,
+            [],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            pd.Index,
+            [],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
         ),
         (
             pd.DatetimeIndex,
@@ -590,6 +651,28 @@ def test_dtype_column(
             "object",
             audformat.define.DataType.OBJECT,
         ),
+        # The following should be a bug in the current main
+        (
+            pd.Index,
+            [True],
+            None,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            pd.Index,
+            [True],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            pd.Index,
+            [True, False],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
     ],
 )
 def test_dtype_index(
@@ -600,6 +683,33 @@ def test_dtype_index(
     expected_pandas_dtype,
     expected_audformat_dtype,
 ):
+    r"""Test misc table index has correct dtype.
+
+    Ensures that a single level index,
+    associated with a misc table,
+    has the expected dtype.
+
+    audformat doesn't associate schemes with an index,
+    but infers the matching audformat dtype
+    from the original dtype of the index,
+    or values of the index
+    when reading from a file.
+    The pandas dtype of the index
+    is then also updated,
+    if necessary.
+
+    Args:
+        tmpdir: pytest tmpdir fixture
+        index_object: index class, e.g. ``pd.Index``
+        index_values: values to be assigned to the index
+        index_dtype: dtype of the index,
+            before assignment to misc table
+        expected_pandas_dtype: pandas dtype of the index
+            after assignment to misc table
+        expected_audformat_dtype: audformat dtype corresponding
+            to the expected pandas dtype
+
+    """
     name = "idx"
     index = index_object(index_values, dtype=index_dtype, name=name)
     table = audformat.MiscTable(index)
@@ -628,6 +738,18 @@ def test_dtype_index(
             "datetime64[ns]",
             "datetime64[ns]",
             audformat.define.DataType.DATE,
+        ),
+        (
+            [],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
         ),
         (
             [],
@@ -719,6 +841,18 @@ def test_dtype_index(
             "timedelta64[ns]",
             audformat.define.DataType.TIME,
         ),
+        (
+            [True, False],
+            bool,
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            "boolean",
+            "boolean",
+            audformat.define.DataType.BOOL,
+        ),
     ],
 )
 def test_dtype_multiindex(
@@ -728,6 +862,32 @@ def test_dtype_multiindex(
     expected_pandas_dtype,
     expected_audformat_dtype,
 ):
+    r"""Test misc table multi-index has correct dtypes.
+
+    Ensures that the levels of a multi-index,
+    associated with a misc table,
+    have the expected dtypes.
+
+    audformat doesn't associate schemes with an index,
+    but infers the matching audformat dtype
+    from the original dtype of the index,
+    or values of the index
+    when reading from a file.
+    The pandas dtype of the index
+    is then also updated,
+    if necessary.
+
+    Args:
+        tmpdir: pytest tmpdir fixture
+        index_values: values to be assigned to the index
+        index_dtype: dtype of the index,
+            before assignment to misc table
+        expected_pandas_dtype: pandas dtype of the index
+            after assignment to misc table
+        expected_audformat_dtype: audformat dtype corresponding
+            to the expected pandas dtype
+
+    """
     expected_audformat_dtypes = [expected_audformat_dtype] * 2
     expected_pandas_dtypes = [expected_pandas_dtype] * 2
     index = pd.MultiIndex.from_arrays(
@@ -765,6 +925,12 @@ def test_dtype_multiindex(
         ),
         (
             [],
+            "boolean",
+            pd.BooleanDtype(),
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
             float,
             "float64",
             audformat.define.DataType.FLOAT,
@@ -852,6 +1018,12 @@ def test_dtype_multiindex(
             "timedelta64[ns]",
             "timedelta64[ns]",
             audformat.define.DataType.TIME,
+        ),
+        (
+            [True, False],
+            "boolean",
+            pd.BooleanDtype(),
+            audformat.define.DataType.BOOL,
         ),
     ],
 )

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -925,8 +925,14 @@ def test_dtype_multiindex(
         ),
         (
             [],
+            bool,
             "boolean",
-            pd.BooleanDtype(),
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [],
+            "boolean",
+            "boolean",
             audformat.define.DataType.BOOL,
         ),
         (
@@ -1021,8 +1027,14 @@ def test_dtype_multiindex(
         ),
         (
             [True, False],
+            bool,
             "boolean",
-            pd.BooleanDtype(),
+            audformat.define.DataType.BOOL,
+        ),
+        (
+            [True, False],
+            "boolean",
+            "boolean",
             audformat.define.DataType.BOOL,
         ),
     ],


### PR DESCRIPTION
Closes #430 

This pull request adds extra tests to cover #430 and fixes it by ensuring `bool` dtype is always converted to `"boolean"` dtype.
The fix is done by incorporating the needed conversion into `audformat.core.utils._maybe_convert_int_dtype()` and renaming the function to `audformat.core.utils._maybe_convert_pandas_dtype()`

The second example from #430 now produces the desired result:

```python
>>> import audformat
>>> import pandas as pd
>>> index = pd.Index([True, False], name="bool")
>>> index.dtype
dtype('bool')
>>> table = audformat.MiscTable(index)
>>> table.index
Index([True, False], dtype='boolean', name='bool')
```

Besides the actual changes, I also added or expanded docstrings.
Note: I also added tests for columns of a normal table, even though the issue was not occurring there before.