### PR TITLE
Use numpy representation for hashing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,12 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest
+      if: matrix.requirements != 'minimum'
+
+    - name: Test with pytest (skip doctests)
+      run: |
+        python -m pytest --ignore=audformat --cov-fail-under=99
+      if: matrix.requirements == 'minimum'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,8 +55,7 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
-        pip install "numpy<2.0"
-        pip install "pandas==1.4.1"
+        pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'
@@ -64,12 +63,6 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest
-      if: matrix.requirements != 'minimum'
-
-    - name: Test with pytest (skip doctests)
-      run: |
-        python -m pytest --ignore=audformat --cov-fail-under=99
-      if: matrix.requirements == 'minimum'
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, pyarrow ]
 
 jobs:
   build:
@@ -55,7 +55,7 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
-        pip install "pandas==2.2.0"
+        pip install "pandas==1.4.1"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"
       if: matrix.requirements == 'minimum'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
-        pip install "numpy<=2.0.0"
+        pip install "numpy<2.0.0"
         pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
+        pip install "numpy<=2.0.0"
         pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
       run: |
         pip install "audeer==2.0.0"
         pip install "audiofile==0.4.0"
+        pip install "numpy<2.0"
         pip install "pandas==1.4.1"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1875,7 +1875,19 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
     for column in df.columns:
         # Convert every column to a numpy array,
         # and hash its string representation
-        md5.update(bytes(str(df[column].to_numpy()), "utf-8"))
+        print(df[column].to_numpy())
+        print(df[column].dtype)
+        print(hashlib.md5(bytes(str(df[column].to_numpy()), "utf-8")).hexdigest())
+        if df[column].dtype == "Int64":
+            # Enforce consistent conversion to numpy.array
+            # for integers across different pandas versions
+            # (since pandas 2.2.x,
+            # Int64 is converted to float,
+            # if contains <NA>)
+            y = df[column].astype("float")
+        else:
+            y = df[column]
+        md5.update(bytes(str(y.to_numpy()), "utf-8"))
     return md5.digest()
 
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1875,9 +1875,6 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
     for column in df.columns:
         # Convert every column to a numpy array,
         # and hash its string representation
-        print(df[column].to_numpy())
-        print(df[column].dtype)
-        print(hashlib.md5(bytes(str(df[column].to_numpy()), "utf-8")).hexdigest())
         if df[column].dtype == "Int64":
             # Enforce consistent conversion to numpy.array
             # for integers across different pandas versions

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1844,7 +1844,7 @@ def _assert_table_index(
         )
 
 
-def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
+def _dataframe_hash(df: pd.DataFrame) -> bytes:
     """Hash a dataframe.
 
     The hash value takes into account:
@@ -1860,16 +1860,11 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
 
     Args:
         df: dataframe
-        max_rows: if not ``None``,
-            the maximum number of rows,
-            taken into account for hashing
 
     Returns:
         MD5 hash in bytes
 
     """
-    # Idea for implementation from
-    # https://github.com/streamlit/streamlit/issues/7086#issuecomment-1654504410
     md5 = hashlib.md5()
     df = df.copy().reset_index()
     for column in df.columns:
@@ -1878,9 +1873,7 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
         if df[column].dtype == "Int64":
             # Enforce consistent conversion to numpy.array
             # for integers across different pandas versions
-            # (since pandas 2.2.x,
-            # Int64 is converted to float,
-            # if contains <NA>)
+            # (since pandas 2.2.x, Int64 is converted to float if it contains <NA>)
             y = df[column].astype("float")
         else:
             y = df[column]

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1866,17 +1866,14 @@ def _dataframe_hash(df: pd.DataFrame) -> bytes:
 
     """
     md5 = hashlib.md5()
-    df = df.copy().reset_index()
-    for column in df.columns:
+    for _, y in df.reset_index().items():
         # Convert every column to a numpy array,
         # and hash its string representation
-        if df[column].dtype == "Int64":
+        if y.dtype == "Int64":
             # Enforce consistent conversion to numpy.array
             # for integers across different pandas versions
             # (since pandas 2.2.x, Int64 is converted to float if it contains <NA>)
-            y = df[column].astype("float")
-        else:
-            y = df[column]
+            y = y.astype("float")
         md5.update(bytes(str(y.to_numpy()), "utf-8"))
     return md5.digest()
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1871,16 +1871,11 @@ def _dataframe_hash(df: pd.DataFrame, max_rows: int = None) -> bytes:
     # Idea for implementation from
     # https://github.com/streamlit/streamlit/issues/7086#issuecomment-1654504410
     md5 = hashlib.md5()
-    if max_rows is not None and len(df) > max_rows:  # pragma: nocover (not yet used)
-        df = df.sample(n=max_rows, random_state=0)
-        # Hash length of dataframe, as we have to track if this changes
-        md5.update(str(len(df)).encode("utf-8"))
-    try:
-        md5.update(bytes(str(pd.util.hash_pandas_object(df)), "utf-8"))
-    except TypeError:
-        # Use pickle if pandas cannot hash the object,
-        # e.g. if it contains numpy.arrays.
-        md5.update(f"{pickle.dumps(df, pickle.HIGHEST_PROTOCOL)}".encode("utf-8"))
+    df = df.copy().reset_index()
+    for column in df.columns:
+        # Convert every column to a numpy array,
+        # and hash its string representation
+        md5.update(bytes(str(df[column].to_numpy()), "utf-8"))
     return md5.digest()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'iso-639',
     'iso3166',
     'oyaml',
-    'pandas >=2.2.0',  # hash values, see https://github.com/pandas-dev/pandas/issues/58999
+    'pandas >=1.4.1',
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'  # pandas >=2.2.0
+requires-python = '>=3.9'  # pandas >=2.1.0
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
     'iso-639',
     'iso3166',
     'oyaml',
-    'pandas >=1.4.1',
+    'pandas >=2.1.0',  # for pyarrow -> timedelta conversion
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
 ]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1320,7 +1320,7 @@ def test_hash(tmpdir, storage_format):
         ),
         (
             "misc",
-            "d3bfb0271878be96c42d523ee4c491da",
+            "331f79758b195cb9b7d0e8889e830eb2",
         ),
     ],
 )

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1312,15 +1312,15 @@ def test_hash(tmpdir, storage_format):
     [
         (
             "files",
-            "9caa6722e65a04ddbce1cda2238c9126",
+            "a66a22ee4158e0e5100f1d797155ad81",
         ),
         (
             "segments",
-            "37c9d9dc4f937a6e97ec72a080055e49",
+            "f69eb4a5d19da71e5da00a9b13beb3db",
         ),
         (
             "misc",
-            "3488c007d45b19e04e8fdbf000f0f04d",
+            "d3bfb0271878be96c42d523ee4c491da",
         ),
     ],
 )


### PR DESCRIPTION
This change is in response to

> The hash key's value seems kind of generic but I wonder whether it only had been introduced recently, or whether it is changed sometimes?

from https://github.com/audeering/audformat/pull/419#pullrequestreview-2127732345 and has as target branch `pyarrow` from #419.

### Response to the question

The result of the hashing has indeed changed recently in `pandas`, see https://github.com/pandas-dev/pandas/issues/58999. That is the reason why I require `pandas>2.2.0` in #419 as with lower versions of `pandas` you get a different hash.
I also find this worrisome as this might indicate that they might change it again in the future.

I also checked what changed between `pandas` 2.1.x and 2.2.x inside `pandas/core/util/hashing.py`, but it's only related to the documentation:
```diff
3a4
> 
108c109,110
<     Series of uint64, same length as the object
---
>     Series of uint64
>         Same length as the object.
244a247
>         The input array to hash.
256a260,264
> 
>     See Also
>     --------
>     util.hash_pandas_object : Return a data hash of the Index/Series/DataFrame.
>     util.hash_tuples : Hash an MultiIndex / listlike-of-tuples efficiently.
```

Which means the change in the resulting hash with `pandas` 2.2.x must be related to some restructuring/fixes of the dataframes themselves.

### Description of proposed changes

Instead of relying on the solution introduced in #419 with `pandas.util.hash_pandas_object()` and `pickle.dumps()`, which might also change, I suggest here instead to hash each column separately, by first converting it to a `numpy` array with `pandas.Series.to_numpy()` and then hashing its string representation.

The behavior of `pandas.Series.to_numpy()` might change over time, and did already for `pandas` 2.2.x). We can handle with that by adding custom code, as I do here for  `Int64` dtypes. The same goes with the string representation of a `numpy` array, which might also change over time.

I could also lower the dependency for `pandas` to `pandas >=2.1.0`.

The new hash calculation is slightly slower than before. Storing the big table to CSV now takes 5.0 s instead of 4.2 s in #419.