### PR TITLE
DOC: add PARQUET tables to data format definition

### DIFF
--- a/docs/data-format.rst
+++ b/docs/data-format.rst
@@ -6,7 +6,7 @@ several **tables**,
 and **media** files.
 On hard disk all of them are stored inside a single folder.
 The header is stored as a YAML file,
-the tables contain labels stored in (possibly) multiple CSV files,
+the tables contain labels stored in (possibly) multiple CSV or PARQUET files,
 and the media files are usually stored in sub-folders.
 Each table column is linked to a scheme and/or to a rater.
 Each table row is linked to a media file,
@@ -18,16 +18,16 @@ The database is implemented as :class:`audformat.Database`.
 
 .. table:: Parts of a database stored in audformat on the hard disk.
 
-    ==========================  ==========================================
-    File                        Content
-    ==========================  ==========================================
-    ``db.yaml``                 Meta information, schemes, list of raters
-    ``db.<table_id>.csv``       Table with files or file segments as index
-                                and columns holding annotations
-    ``db.<misc_table_id>.csv``  Misc table with unspecified index
-                                and columns holding annotations
-    ``<folder(s)/file(s)>``     Audio/Video files referenced in the tables
-    ==========================  ==========================================
+    ====================================  ==========================================
+    File                                  Content
+    ====================================  ==========================================
+    ``db.yaml``                           Meta information, schemes, list of raters
+    ``db.<table_id>.[csv|parquet]``       Table with files or file segments as index
+                                          and columns holding annotations
+    ``db.<misc_table_id>.[csv|parquet]``  Misc table with unspecified index
+                                          and columns holding annotations
+    ``<folder(s)/file(s)>``               Audio/Video files referenced in the tables
+    ====================================  ==========================================
 
 The connection between the header, media files and a table
 is highlighted in the following sketch:


### PR DESCRIPTION
In https://github.com/audeering/audformat/pull/419 we added support for tables stored as PARQUET files.
Here, we update the data format definition in the documentation accordingly:

![image](https://github.com/audeering/audformat/assets/173624/d2b00cf1-5127-40a7-9720-9cf389ea4ea7)

I checked the rest of the documentation as well, but it seems we only need to update this single paragraph + table.