### PR TITLE
DOC: mention explicitly text files as media files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ audformat
 Specification and reference implementation of **audformat**.
 
 audformat stores media data,
-such as audio or video,
+such as audio, video, or text
 together with corresponding annotations
 in a pre-defined way.
 This makes it easy to combine or replace databases

--- a/docs/data-format.rst
+++ b/docs/data-format.rst
@@ -8,8 +8,8 @@ On hard disk all of them are stored inside a single folder.
 The header is stored as a YAML file,
 the tables contain labels stored in (possibly) multiple CSV or PARQUET files,
 and the media files are usually stored in sub-folders.
-Media files are not restricted to a particular file type,
-but consist usually of audio, video, or text files.
+Media files are not restricted to a particular file type.
+Usually, they consist of audio, video, or text files.
 Each table column is linked to a scheme and/or to a rater.
 Each table row is linked to a media file,
 or,

--- a/docs/data-format.rst
+++ b/docs/data-format.rst
@@ -8,9 +8,13 @@ On hard disk all of them are stored inside a single folder.
 The header is stored as a YAML file,
 the tables contain labels stored in (possibly) multiple CSV or PARQUET files,
 and the media files are usually stored in sub-folders.
+Media files are not restricted to a particular file type,
+but consist usually of audio, video, or text files.
 Each table column is linked to a scheme and/or to a rater.
 Each table row is linked to a media file,
-or a specific segment in a media file.
+or,
+if applicable,
+a specific segment in a media file.
 If no links to media files are given,
 the table is called miscellaneous table,
 or short **misc table**.
@@ -26,7 +30,7 @@ The database is implemented as :class:`audformat.Database`.
                                           and columns holding annotations
     ``db.<misc_table_id>.[csv|parquet]``  Misc table with unspecified index
                                           and columns holding annotations
-    ``<folder(s)/file(s)>``               Audio/Video files referenced in the tables
+    ``<folder(s)/file(s)>``               Media files referenced in the tables
     ====================================  ==========================================
 
 The connection between the header, media files and a table

--- a/docs/data-introduction.rst
+++ b/docs/data-introduction.rst
@@ -20,7 +20,7 @@ but simple enough to be understood and parsed easily**.
 
 The format further allows to
 
-* link audio files to meta data and annotations
+* link media files to meta data and annotations
 * use generic tools to access the data,
   create statistics,
   merge annotations


### PR DESCRIPTION
Closes #439 

Rephrases the README and data format specifications to better indicate that media files are not restricted in its file type.

In addition, it explicitly names text files as potential media files. I also state that a segmented table can be used, if applicable, as some file types might not have a direct connection to a timeline. E.g. you can create a segmented table for text files, but it might be meaningless as no other application might be able to use that information.

**README**

![image](https://github.com/audeering/audformat/assets/173624/b770312c-9ded-4661-ba39-5b172cfbbd8f)

**Format specifications -- Introduction**

![image](https://github.com/audeering/audformat/assets/173624/6e8f87b8-10cb-4944-b999-bc0f414ebd72)

**Format specification -- Database**

![image](https://github.com/audeering/audformat/assets/173624/f38668b6-a97f-4f7c-b0fe-38e469f2dc43)
