### PR TITLE
DOC: utils.hash() can change with pandas>=2.2

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -672,6 +672,12 @@ def hash(
     independent of the ordering of the elements,
     and level or column names.
 
+    .. warning::
+
+        If ``obj`` is a dataframe or series
+        with data type ``"Int64"``,
+        the returned hash value changes with ``pandas>=2.2.0``.
+
     Args:
         obj: object
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -552,6 +552,7 @@ def test_expand_file_path(tmpdir, index, root, expected):
                 pd.__version__ < "2.2.0",
                 reason="Changed in pandas 2.2.0",
             ),
+        ),
     ],
 )
 def test_hash(obj, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -509,6 +509,49 @@ def test_expand_file_path(tmpdir, index, root, expected):
             pd.DataFrame([0, 1], columns=["name"]),
             "-7179254265801896228",
         ),
+        pytest.param(
+            pd.DataFrame(
+                [0, 1, 2],
+                pd.Index([0, 1, 2], dtype="Int64"),
+            ),
+            "5440931770055407318",
+            marks=pytest.mark.skipif(
+                pd.__version__ >= "2.2.0",
+                reason="Changed in pandas 2.2.0",
+            ),
+        ),
+        pytest.param(
+            pd.DataFrame(
+                [0, 1, 2],
+                pd.Index([0, 1, 2], dtype="Int64"),
+            ),
+            "-5491649331962632325",
+            marks=pytest.mark.skipif(
+                pd.__version__ < "2.2.0",
+                reason="Changed in pandas 2.2.0",
+            ),
+        ),
+        pytest.param(
+            pd.Series(
+                [0, 1, 2],
+                pd.Index([0, 1, 2], dtype="Int64"),
+            ),
+            "5440931770055407318",
+            marks=pytest.mark.skipif(
+                pd.__version__ >= "2.2.0",
+                reason="Changed in pandas 2.2.0",
+            ),
+        ),
+        pytest.param(
+            pd.Series(
+                [0, 1, 2],
+                pd.Index([0, 1, 2], dtype="Int64"),
+            ),
+            "-5491649331962632325",
+            marks=pytest.mark.skipif(
+                pd.__version__ < "2.2.0",
+                reason="Changed in pandas 2.2.0",
+            ),
     ],
 )
 def test_hash(obj, expected):


### PR DESCRIPTION
Closes #433 

As there is no easy fix to ensure the hash of `audfromat.utils.hash()` stays the same when using a dataframe or series with data type `"Int64"`, I added a warning to the docs. I also added two tests documenting the behavior.

When we require `pandas >=2.2.0` as installation requirements of `audformat`, we can then remove that warning again (and should create an issue to track this).

![image](https://github.com/audeering/audformat/assets/173624/1ac16e4e-1cee-4282-85ea-cb76a7cda7ef)
