### PR TITLE
DOC: utils.hash() is not influenced by names

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -669,7 +669,8 @@ def hash(
 
     Objects with the same elements
     produce the same hash string
-    independent of the ordering of the elements.
+    independent of the ordering of the elements,
+    and potential level or column names.
 
     Args:
         obj: object

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -670,7 +670,7 @@ def hash(
     Objects with the same elements
     produce the same hash string
     independent of the ordering of the elements,
-    and potential level or column names.
+    and level or column names.
 
     Args:
         obj: object

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -477,6 +477,38 @@ def test_expand_file_path(tmpdir, index, root, expected):
             ),
             "-103439349488189352",
         ),
+        (pd.Index([0, 1], name="idx"), "6238072747940578789"),
+        (pd.Index([0, 1], name="name"), "6238072747940578789"),
+        (
+            pd.MultiIndex.from_arrays(
+                [[0, 1], ["a", "b"]],
+                names=["idx1", "idx2"],
+            ),
+            "8378370490910668918",
+        ),
+        (
+            pd.MultiIndex.from_arrays(
+                [[0, 1], ["a", "b"]],
+                names=["name1", "name2"],
+            ),
+            "8378370490910668918",
+        ),
+        (
+            pd.Series([0, 1], name="series"),
+            "-7179254265801896228",
+        ),
+        (
+            pd.Series([0, 1], name="name"),
+            "-7179254265801896228",
+        ),
+        (
+            pd.DataFrame([0, 1], columns=["frame"]),
+            "-7179254265801896228",
+        ),
+        (
+            pd.DataFrame([0, 1], columns=["name"]),
+            "-7179254265801896228",
+        ),
     ],
 )
 def test_hash(obj, expected):


### PR DESCRIPTION
Closes #434 

`audformat.utils.hash()` does only consider values, not level/column names.
To make this more obvious, I added a sentence to the docs:

![image](https://github.com/audeering/audformat/assets/173624/02154872-955f-4e0c-8c19-48b25a8de1bd)

I also added tests for the expected behavior.