### PR TITLE
DOC: Table.save() store hash for parquet files

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -592,9 +592,14 @@ class Base(HeaderBase):
         is stored under the key ``b"hash"``
         in the metadata of the schema of the parquet file.
         This provides a deterministic hash for the file,
-        as md5 sums of parquet files
-        can be different
-        for the same content.
+        as md5 sums of parquet files,
+        containing identical information,
+        often differ.
+        Reasons include factors like the library
+        that wrote the parquet file,
+        the chosen compression codec
+        and metadata written by the library.
+
         The hash can be accessed with ``pyarrow`` by::
 
             pyarrow.parquet.read_schema(f"{path}.parquet").metadata[b"hash"].decode()

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -597,7 +597,7 @@ class Base(HeaderBase):
         for the same content.
         The hash can be accessed with ``pyarrow`` by::
 
-            pyarrow.parquet.read_schema(file).metadata[b"hash"].decode()
+            pyarrow.parquet.read_schema(f"{path}.parquet").metadata[b"hash"].decode()
 
         Args:
             path: file path without extension

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -591,10 +591,13 @@ class Base(HeaderBase):
         based on the content of the table,
         is stored under the key ``b"hash"``
         in the metadata of the schema of the parquet file.
-        This provides a deterministic hash,
+        This provides a deterministic hash for the file,
         as md5 sums of parquet files
         can be different
         for the same content.
+        The hash can be accessed with ``pyarrow`` by::
+
+            pyarrow.parquet.read_schema(file).metadata[b"hash"].decode()
 
         Args:
             path: file path without extension

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -599,6 +599,10 @@ class Base(HeaderBase):
 
             pyarrow.parquet.read_schema(f"{path}.parquet").metadata[b"hash"].decode()
 
+        The hash is used by :mod:`audb`
+        when publishing a database
+        to track changes of database files.
+
         Args:
             path: file path without extension
             storage_format: storage format of table.

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -586,6 +586,16 @@ class Base(HeaderBase):
 
         Existing files will be overwritten.
 
+        When using ``"parquet"`` as ``storage_format``
+        a hash,
+        based on the content of the table,
+        is stored under the key ``b"hash"``
+        in the metadata of the schema of the parquet file.
+        This provides a deterministic hash,
+        as md5 sums of parquet files
+        can be different
+        for the same content.
+
         Args:
             path: file path without extension
             storage_format: storage format of table.


### PR DESCRIPTION
Document, that we store a hash value in the metadata of the schema of the PARQUET file, when saving to the file.

![image](https://github.com/audeering/audformat/assets/173624/4a1c8a85-6fc6-4da0-90a3-5cfee3b117c4)

