### PR TITLE
Load csv tables with pandas if pyarrow fails

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -881,6 +881,8 @@ class Base(HeaderBase):
         than the method applied here.
         We first load the CSV file as a :class:`pyarrow.Table`
         and convert it to a dataframe afterwards.
+        If this fails,
+        we fall back to :func:`pandas.read_csv()`.
 
         Args:
             path: path to table, including file extension
@@ -905,20 +907,32 @@ class Base(HeaderBase):
             # If pyarrow fails to parse the CSV file
             # https://github.com/audeering/audformat/issues/449
 
-            # Replace dtype with converter for dates or timestamps
+            # Collect csv file columns and data types.
+            # index
+            columns_and_dtypes = self._levels_and_dtypes
+            # columns
+            for column_id, column in self.columns.items():
+                if column.scheme_id is not None:
+                    columns_and_dtypes[column_id] = self.db.schemes[
+                        column.scheme_id
+                    ].dtype
+                else:
+                    columns_and_dtypes[column_id] = define.DataType.OBJECT
+
+            # Replace data type with converter for dates or timestamps
             converters = {}
             dtypes_wo_converters = {}
-            for level, dtype in self._levels_and_dtypes.items():
-                if dtype == "date":
-                    converters[level] = lambda x: pd.to_datetime(x)
-                elif dtype == "time":
-                    converters[level] = lambda x: pd.to_timedelta(x)
+            for column, dtype in columns_and_dtypes.items():
+                if dtype == define.DataType.DATE:
+                    converters[column] = lambda x: pd.to_datetime(x)
+                elif dtype == define.DataType.TIME:
+                    converters[column] = lambda x: pd.to_timedelta(x)
                 else:
-                    dtypes_wo_converters[level] = to_pandas_dtype(dtype)
+                    dtypes_wo_converters[column] = to_pandas_dtype(dtype)
 
             df = pd.read_csv(
                 path,
-                usecols=levels + columns,
+                usecols=list(columns_and_dtypes.keys()),
                 dtype=dtypes_wo_converters,
                 index_col=levels,
                 converters=converters,

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1159,7 +1159,9 @@ def test_load_broken_csv(tmpdir):
     """
     build_dir = audeer.mkdir(tmpdir, "build")
 
-    # Create database with single table and column
+    # Create database with hidden columns
+    # that are stored in csv,
+    # but not in the header of the table.
     #
     # Ensure:
     #
@@ -1167,7 +1169,9 @@ def test_load_broken_csv(tmpdir):
     # * the columns use schemes with time and date data types
     # * at least one column has no scheme
     #
-    # as those cases needed special care with csv files
+    # as those cases needed special care with csv files,
+    # before switching to use pyarrow.csv.read_csv()
+    # in https://github.com/audeering/audformat/pull/419
     #
     db = audformat.Database("mydb")
     db.schemes["date"] = audformat.Scheme("date")
@@ -1181,7 +1185,6 @@ def test_load_broken_csv(tmpdir):
     db["table"]["no-scheme"].set(["label"])
     db["empty-table"] = audformat.Table(audformat.filewise_index())
     db["empty-table"]["column"] = audformat.Column()
-
     # Add a hidden column to the table dataframes,
     # without adding it to the table header
     db["table"].df["hidden"] = ["hidden"]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1143,7 +1143,7 @@ def test_load(tmpdir):
         os.remove(f"{path_no_ext}.{ext}")
 
 
-def test_load_broken_csv(tmpdir):
+class TestLoadBrokenCsv:
     r"""Test loading of malformed csv files.
 
     If csv files contain a lot of special characters,
@@ -1153,49 +1153,67 @@ def test_load_broken_csv(tmpdir):
 
     See https://github.com/audeering/audformat/issues/449
 
-    Args:
-        tmpdir: tmpdir ficture
-
     """
-    build_dir = audeer.mkdir(tmpdir, "build")
 
-    # Create database with hidden columns
-    # that are stored in csv,
-    # but not in the header of the table.
-    #
-    # Ensure:
-    #
-    # * it contains an empty table
-    # * the columns use schemes with time and date data types
-    # * at least one column has no scheme
-    #
-    # as those cases needed special care with csv files,
-    # before switching to use pyarrow.csv.read_csv()
-    # in https://github.com/audeering/audformat/pull/419
-    #
-    db = audformat.Database("mydb")
-    db.schemes["date"] = audformat.Scheme("date")
-    db.schemes["time"] = audformat.Scheme("time")
-    db["table"] = audformat.Table(audformat.filewise_index("file.wav"))
-    db["table"]["date"] = audformat.Column(scheme_id="date")
-    db["table"]["date"].set([pd.to_datetime("2018-10-26")])
-    db["table"]["time"] = audformat.Column(scheme_id="time")
-    db["table"]["time"].set([pd.Timedelta(1)])
-    db["table"]["no-scheme"] = audformat.Column()
-    db["table"]["no-scheme"].set(["label"])
-    db["empty-table"] = audformat.Table(audformat.filewise_index())
-    db["empty-table"]["column"] = audformat.Column()
-    # Add a hidden column to the table dataframes,
-    # without adding it to the table header
-    db["table"].df["hidden"] = ["hidden"]
-    db["empty-table"].df["hidden"] = []
+    def database_with_hidden_columns(self) -> audformat.Database:
+        r"""Database with hidden columns.
 
-    db.save(build_dir, storage_format="csv")
-    db_loaded = audformat.Database.load(build_dir, load_data=True)
-    assert "table" in db_loaded
-    assert "empty-table" in db_loaded
-    assert "hidden" not in db_loaded["table"].df
-    assert "hidden-column" not in db_loaded["empty-table"].df
+        Create database with hidden columns
+        that are stored in csv,
+        but not in the header of the table.
+
+        Ensure:
+
+        * it contains an empty table
+        * the columns use schemes with time and date data types
+        * at least one column has no scheme
+
+        as those cases needed special care with csv files,
+        before switching to use pyarrow.csv.read_csv()
+        in https://github.com/audeering/audformat/pull/419.
+
+        Returns:
+            database
+
+        """
+        db = audformat.Database("mydb")
+        db.schemes["date"] = audformat.Scheme("date")
+        db.schemes["time"] = audformat.Scheme("time")
+        db["table"] = audformat.Table(audformat.filewise_index("file.wav"))
+        db["table"]["date"] = audformat.Column(scheme_id="date")
+        db["table"]["date"].set([pd.to_datetime("2018-10-26")])
+        db["table"]["time"] = audformat.Column(scheme_id="time")
+        db["table"]["time"].set([pd.Timedelta(1)])
+        db["table"]["no-scheme"] = audformat.Column()
+        db["table"]["no-scheme"].set(["label"])
+        db["empty-table"] = audformat.Table(audformat.filewise_index())
+        db["empty-table"]["column"] = audformat.Column()
+        # Add a hidden column to the table dataframes,
+        # without adding it to the table header
+        db["table"].df["hidden"] = ["hidden"]
+        db["empty-table"].df["hidden"] = []
+        return db
+
+    def test_load_broken_csv(self, tmpdir):
+        r"""Test loading a database table from broken csv files.
+
+        Broken csv files
+        refer to csv tables,
+        that raise an error
+        when loading with ``pyarrow.csv.read_csv()``.
+
+        Args:
+            tmpdir: tmpdir fixture
+
+        """
+        db = self.database_with_hidden_columns()
+        build_dir = audeer.mkdir(tmpdir, "build")
+        db.save(build_dir, storage_format="csv")
+        db_loaded = audformat.Database.load(build_dir, load_data=True)
+        assert "table" in db_loaded
+        assert "empty-table" in db_loaded
+        assert "hidden" not in db_loaded["table"].df
+        assert "hidden-column" not in db_loaded["empty-table"].df
 
 
 def test_load_old_pickle(tmpdir):


### PR DESCRIPTION
Closes #449 

Unfortunately, loading csv files with `pyarrow.csv.read_csv()` as introduced in https://github.com/audeering/audformat/pull/419 is not as tolerant to malformed csv files as `pandas.read_csv()`. I have identified so far three cases in which loading of a csv file might fail (two of them are listed in #449):
1. Loading a csv file can fail, if the csv file contains more columns, as mentioned in the header of a database
2. Loading a csv file can also fail, if it is very long and contains a lot of special characters, like `"`, `""`, `,`. I did not added a test for it, because it turns out that the syntax of the csv file is correct, and it works when splitting the file into smaller ones.
3. Loading of a csv file can fail, if it contain some offsets in there `date` values, e.g. `+00:00`, which is the case for some of our older datasets.

As `pyarrow.csv.read_csv()` cannot be easily extended to handle those cases, I use now a `try`-`except` statement, that falls back to loading the file with `pandas.read_csv()`. This is very unfortunate as it means when implementing a new feature (e.g. streaming) it needs to be implemented for both cases. But I don't know a better solution at the moment.

In principle, we could solve 1. and 3. by updating the databases, but you will still no longer be able to load old versions then, which is not acceptable. How we could solve 2. otherwise, I don't know.