### PR TITLE
CI: specify audb version in minimum test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,9 @@ jobs:
         pip install "pandas==2.1.0"
         pip install "pyarrow==10.0.1"
         pip install "pyyaml==5.4.1"
+        # need to use an audb version in the test,
+        # that supports audeer==2.0.0
+        pip install "audb==1.7.4"
       if: matrix.requirements == 'minimum'
 
     - name: Test with pytest


### PR DESCRIPTION
As `audb>=1.8` requires `audeer>=2.1.0`, but we use `audeer==2.0.0` in our minimum requirements test, we need to explicitly specify the used `audb` version as well.