### PR TITLE
Store tables per default as parquet files

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -970,7 +970,7 @@ class Database(HeaderBase):
         *,
         name: str = "db",
         indent: int = 2,
-        storage_format: str = define.TableStorageFormat.CSV,
+        storage_format: str = define.TableStorageFormat.PARQUET,
         update_other_formats: bool = True,
         header_only: bool = False,
         num_workers: typing.Optional[int] = 1,

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -579,7 +579,7 @@ class Base(HeaderBase):
         self,
         path: str,
         *,
-        storage_format: str = define.TableStorageFormat.CSV,
+        storage_format: str = define.TableStorageFormat.PARQUET,
         update_other_formats: bool = True,
     ):
         r"""Save table data to disk.


### PR DESCRIPTION
As we now support storing tables as parquet files in `audb>=1.8.0`, and have published the first databases, I would propose to switch to parquet for storing tables in the next `audformat` release.

This pull request changes the default values of the `storage_format` argument in `audformat.Database.save()` and `audformat.Table.save()` to `"parquet"`.

![image](https://github.com/user-attachments/assets/b054cd71-4074-4690-aff3-d020f3b356b7)

![image](https://github.com/user-attachments/assets/33510d73-9b58-4de7-b5b6-dbcbc095471a)
