### PR TITLE
Fix iso-639 Poetry Dependency Issues

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -8,6 +8,7 @@ import sys
 import typing as typing
 
 import iso639
+from iso639.exceptions import InvalidLanguageValue
 import iso3166
 import numpy as np
 import pandas as pd
@@ -1288,31 +1289,12 @@ def map_language(language: str) -> str:
         'eng'
 
     """
-    result = None
-
-    if len(language) == 2:
-        try:
-            result = iso639.languages.get(alpha2=language.lower())
-        except KeyError:
-            pass
-    elif len(language) == 3:
-        try:
-            result = iso639.languages.get(part3=language.lower())
-        except KeyError:
-            pass
-    else:
-        try:
-            result = iso639.languages.get(name=language.title())
-        except KeyError:
-            pass
-
-    if result is not None:
-        result = result.part3
-
-    if not result:
+    try:
+        return iso639.Lang(
+            language.title() if len(language) > 3 else language.lower()
+        ).pt3
+    except InvalidLanguageValue:
         raise ValueError(f"'{language}' is not supported by ISO 639-3.")
-
-    return result
 
 
 def read_csv(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = '>=3.9'  # pandas >=2.1.0
 dependencies = [
     'audeer >=2.0.0',
     'audiofile >=0.4.0',
-    'iso-639',
+    'iso639-lang',
     'iso3166',
     'oyaml',
     'pandas >=2.1.0',  # for pyarrow -> timedelta conversion


### PR DESCRIPTION
There seems to be an issue with the `iso-639` package in combination with Poetry (very similar to https://github.com/python-poetry/poetry/issues/6996).
Poetry is unable to determine the version of the package (see below), therefore `audformat` as well as any packages that depend on it (like `opensmile`) cannot be used in poetry projects.

```
Because test-audformat depends on iso-639 (*) which doesn't match any versions, version solving failed.
```

To reproduce, run `poetry lock` for the following `pyproject.toml`:

```toml
[tool.poetry]
name = "test-audformat"
version = "0.1.0"
description = ""
authors = []

[tool.poetry.dependencies]
python = "^3.9"
iso-639 = "^0.4.5"

[build-system]
requires = ["poetry-core"]
build-backend = "poetry.core.masonry.api"
```

The workaround for local projects is to directly fetch the package from git:
```toml
iso-639 = { git = "https://github.com/noumar/iso639.git", tag = "0.4.5", optional = true }
```

However, this is not a viable solution for publishing on PyPI, i.e. no package can be published using poetry that depends on `audformat`.

---

This PR replaces `iso-639` with [`iso639-lang`](https://github.com/LBeaudoux/iso639) under the hood to solve the dependency resolution.
All tests are passing and running `poetry lock` with the updated dependency works like a charm.