### PR TITLE
CI: fix version of audformat by fetching tags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-tags: true
+        fetch-depth: 50
 
     - name: Cache emodb
       uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
 
     - name: Cache emodb
       uses: actions/cache@v4


### PR DESCRIPTION
At the moment, the CI jobs are just checking out the last commit of the repository. As we use git tags to get the version of `audformat`, this means the version of `audformat` after running `pip install -r requirements.txt` starts always with `0.1-dev`. Which means when running `pip install -r tests/requirements.txt` afterwards another version of `audformat` is installed as we install `audb` which requires `>=1.2.0`.

Now it installs

![image](https://github.com/user-attachments/assets/fa504607-9ef6-45bd-bf25-77285e415028)

and does not need to install another version of `audformat` when running `pip install -r tests/requirements.txt`.
