### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.3.1 (2024-09-16)
+--------------------------
+
+* Changed: replace not maintained ``iso-639`` dependency
+  with ``iso639-lang``
+* Fixed: ensure ``poetry`` can manage ``audformat``
+
+
 Version 1.3.0 (2024-07-18)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ and this project adheres to `Semantic Versioning`_.
 Version 1.3.1 (2024-09-16)
 --------------------------
 
-* Changed: replace not maintained ``iso-639`` dependency
+* Changed: replace unmaintained ``iso-639`` dependency
   with ``iso639-lang``
 * Fixed: ensure ``poetry`` can manage ``audformat``
 


### PR DESCRIPTION
We had a nice contribution in https://github.com/audeering/audformat/pull/456, which changed the ISO639 package we are using to a better maintained one. As this also fixes the handling of `audformat` by `poetry` I would vote to do an immediate bug fix release.

![image](https://github.com/user-attachments/assets/dab5cbcb-8052-448a-9d68-2b6495007a0f)
