### PR TITLE
DOC: add link to ISE 639-3 definition

### DIFF
--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1273,7 +1273,7 @@ def map_language(language: str) -> str:
 
     `ISO 639-3`_ is an international standard for language codes.
     It defines three-letter codes for identifying languages,
-    with an aim to cover all known natural languages.
+    with the aim to cover all known languages.
 
     .. _ISO 639-3: https://iso639-3.sil.org/code_tables/639/data/
 

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1271,6 +1271,12 @@ def map_file_path(
 def map_language(language: str) -> str:
     r"""Map language to ISO 639-3.
 
+    `ISO 639-3`_ is an international standard for language codes.
+    It defines three-letter codes for identifying languages,
+    with an aim to cover all known natural languages.
+
+    .. _ISO 639-3: https://iso639-3.sil.org/code_tables/639/data/
+
     Args:
         language: language string
 


### PR DESCRIPTION
This expands the docstring of `audformat.utils.map_language()` to contain additional information on ISO 639-3, and provides a link to a list of all included language codes.

![image](https://github.com/user-attachments/assets/b0d3339d-8f03-456c-bd8d-7aa7fc59c634)