### PR TITLE
Fix Database.get() for segments + filewise scheme

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1641,15 +1641,15 @@ class Database(HeaderBase):
 
         We want to add a column from ``df_filewise`` to ``df_segmented``.
         As ``df_segmented`` represents a segmented table,
-        we need to convert ``df_filewise`` to a segmented table as well
-        mapping the filwsie labels to each segment.
+        we need to convert ``df_filewise`` to a segmented table as well as
+        mapping the filewise labels to each segment.
 
         Afterwards ``df_segmented`` and ``df_filewise`` can be easily concatenated.
         ``df_filewise`` is changed in place.
 
         Args:
             df_segmented: dataframe representing a segmented table
-            df_filewise: dataframe representing a filwise table
+            df_filewise: dataframe representing a filewise table
 
         Returns:
             dataframe ``df_filewise`` converted to represent a segmented table

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -30,6 +30,8 @@ from audformat.core.errors import BadIdError
 from audformat.core.errors import BadKeyError
 from audformat.core.errors import TableExistsError
 from audformat.core.index import filewise_index
+from audformat.core.index import is_filewise_index
+from audformat.core.index import is_segmented_index
 from audformat.core.media import Media
 from audformat.core.rater import Rater
 from audformat.core.scheme import Scheme
@@ -870,6 +872,18 @@ class Database(HeaderBase):
                     original_column_names=original_column_names,
                     aggregate_function=aggregate_function,
                 )
+            # Expand filewise labels to segments
+            if is_segmented_index(obj) and is_filewise_index(additional_obj):
+                print(f"{obj=}")
+                print(f"{obj.index.get_level_values(define.IndexField.FILE)=}")
+                common_files = obj.index.get_level_values(define.IndexField.FILE)
+                # common_files = utils.intersect([additional_obj.index, files])
+                print(f"{files=}")
+                additional_obj = additional_obj.loc[files]
+                print(f"{additional_obj=}")
+                print(f"{obj.loc[files]=}")
+                print(f"{obj.loc[files].index=}")
+                additional_obj.index = obj.loc[files].index
             objs.append(additional_obj)
         if len(objs) > 1:
             obj = utils.concat(objs)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -875,7 +875,7 @@ class Database(HeaderBase):
             # Expand filewise labels to segments
             # (https://github.com/audeering/audformat/issues/460)
             if is_segmented_index(obj) and is_filewise_index(additional_obj):
-                # Problem of common_files:
+                # Problem of utils.intersect():
                 # squeezes [f1, f1, f2] to [f1, f2]
                 # so we need to separate intersection from listing files
                 files = obj.index.get_level_values(define.IndexField.FILE)

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -877,6 +877,9 @@ class Database(HeaderBase):
                 print(f"{obj=}")
                 print(f"{obj.index.get_level_values(define.IndexField.FILE)=}")
                 common_files = obj.index.get_level_values(define.IndexField.FILE)
+                # Problem of next line:
+                # squeezes [f1, f1, f2] to [f1, f2]
+                # so we need to separate intersection from listing files
                 # common_files = utils.intersect([additional_obj.index, files])
                 print(f"{files=}")
                 additional_obj = additional_obj.loc[files]

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -544,6 +544,39 @@ def wrong_scheme_labels_db(tmpdir):
         ),
         (
             "mono_db",
+            "regression",
+            ["speaker"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        ["s1", "s1", "s1", None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype=pd.CategoricalDtype(
+                            ["s1", "s2", "s3"],
+                            ordered=False,
+                        ),
+                        name="speaker",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
             "selection",
             [],
             pd.DataFrame(

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -912,6 +912,7 @@ def test_database_get(request, db, scheme, additional_schemes, expected):
     if additional_schemes:
         print(f"{db.get(additional_schemes[0])=}")
     print(f"{expected=}")
+    print(f"{db.get(scheme, additional_schemes)=}")
     df = db.get(scheme, additional_schemes)
     pd.testing.assert_frame_equal(df, expected)
 

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -21,6 +21,7 @@ def mono_db(tmpdir):
 
     # --- Schemes
     db.schemes["age"] = audformat.Scheme("int", minimum=0)
+    db.schemes["annotated"] = audformat.Scheme("bool")
     db.schemes["height"] = audformat.Scheme("float")
     db.schemes["int"] = audformat.Scheme("int")
     db.schemes["partial"] = audformat.Scheme("str")
@@ -31,6 +32,7 @@ def mono_db(tmpdir):
         "str",
         labels=["low", "normal", "high"],
     )
+    db.schemes["status"] = audformat.Scheme("bool")
     db.schemes["winner"] = audformat.Scheme(
         "str",
         labels={
@@ -125,6 +127,16 @@ def mono_db(tmpdir):
     db["rating.test"] = audformat.Table(index, split_id="test")
     db["rating.test"]["rating"] = audformat.Column(scheme_id="rating")
     db["rating.test"]["rating"].set([1])
+
+    index = audformat.filewise_index(["f2.wav"])
+    db["single"] = audformat.Table(index)
+    db["single"]["status"] = audformat.Column(scheme_id="status")
+    db["single"]["status"].set(True)
+
+    index = audformat.filewise_index(["f3.wav"])
+    db["last"] = audformat.Table(index)
+    db["last"]["annotated"] = audformat.Column(scheme_id="annotated")
+    db["last"]["annotated"].set(True)
 
     # --- Segmented tables
     index = audformat.segmented_index(
@@ -545,6 +557,8 @@ def wrong_scheme_labels_db(tmpdir):
                 dtype="float",
             ),
         ),
+        # Segmented index with filewise additional entries
+        # https://github.com/audeering/audformat/issues/460
         (
             "mono_db",
             "regression",
@@ -603,6 +617,66 @@ def wrong_scheme_labels_db(tmpdir):
                         ),
                         dtype="string",
                         name="partial",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
+            "regression",
+            ["status"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        [None, None, None, True],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="boolean",
+                        name="status",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
+            "regression",
+            ["annotated"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        [None, None, None, None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="boolean",
+                        name="annotated",
                     ),
                 ],
                 axis=1,

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -684,6 +684,46 @@ def wrong_scheme_labels_db(tmpdir):
         ),
         (
             "mono_db",
+            "regression",
+            ["partial", "status"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        ["a", "a", "a", None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="string",
+                        name="partial",
+                    ),
+                    pd.Series(
+                        [None, None, None, True],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="boolean",
+                        name="status",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
             "selection",
             [],
             pd.DataFrame(

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -906,13 +906,6 @@ def wrong_scheme_labels_db(tmpdir):
 )
 def test_database_get(request, db, scheme, additional_schemes, expected):
     db = request.getfixturevalue(db)
-    print(f"{scheme=}")
-    print(f"{additional_schemes=}")
-    print(f"{db.get(scheme)=}")
-    if additional_schemes:
-        print(f"{db.get(additional_schemes[0])=}")
-    print(f"{expected=}")
-    print(f"{db.get(scheme, additional_schemes)=}")
     df = db.get(scheme, additional_schemes)
     pd.testing.assert_frame_equal(df, expected)
 

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -33,6 +33,7 @@ def mono_db(tmpdir):
         labels=["low", "normal", "high"],
     )
     db.schemes["status"] = audformat.Scheme("bool")
+    db.schemes["update"] = audformat.Scheme("bool")
     db.schemes["winner"] = audformat.Scheme(
         "str",
         labels={
@@ -129,9 +130,11 @@ def mono_db(tmpdir):
     db["rating.test"]["rating"].set([1])
 
     index = audformat.filewise_index(["f2.wav"])
-    db["single"] = audformat.Table(index)
-    db["single"]["status"] = audformat.Column(scheme_id="status")
-    db["single"]["status"].set(True)
+    db["status"] = audformat.Table(index)
+    db["status"]["status"] = audformat.Column(scheme_id="status")
+    db["status"]["status"].set(True)
+    db["status"]["update"] = audformat.Column(scheme_id="update")
+    db["status"]["update"].set(False)
 
     index = audformat.filewise_index(["f3.wav"])
     db["last"] = audformat.Table(index)
@@ -151,6 +154,15 @@ def mono_db(tmpdir):
     db["segments"]["winner"].set(["w1", "w1", "w1", "w1"])
     db["segments"]["regression"] = audformat.Column(scheme_id="regression")
     db["segments"]["regression"].set([0.3, 0.2, 0.6, 0.4])
+
+    index = audformat.segmented_index(
+        ["f1.wav", "f1.wav"],
+        [0, 0.3],
+        [0.2, 0.4],
+    )
+    db["segments.other"] = audformat.Table(index)
+    db["segments.other"]["update"] = audformat.Column(scheme_id="update")
+    db["segments.other"]["update"].set([True, True])
 
     db.save(path)
     audformat.testing.create_audio_files(db, channels=1, file_duration="1s")
@@ -717,6 +729,46 @@ def wrong_scheme_labels_db(tmpdir):
                         ),
                         dtype="boolean",
                         name="status",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
+            "regression",
+            ["partial", "update"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        ["a", "a", "a", None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="string",
+                        name="partial",
+                    ),
+                    pd.Series(
+                        [True, None, None, None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="boolean",
+                        name="update",
                     ),
                 ],
                 axis=1,

--- a/tests/test_database_get.py
+++ b/tests/test_database_get.py
@@ -23,6 +23,7 @@ def mono_db(tmpdir):
     db.schemes["age"] = audformat.Scheme("int", minimum=0)
     db.schemes["height"] = audformat.Scheme("float")
     db.schemes["int"] = audformat.Scheme("int")
+    db.schemes["partial"] = audformat.Scheme("str")
     db.schemes["rating"] = audformat.Scheme("int", labels=[0, 1, 2])
     db.schemes["regression"] = audformat.Scheme("float")
     db.schemes["selection"] = audformat.Scheme("int", labels=[0, 1])
@@ -103,6 +104,8 @@ def mono_db(tmpdir):
     db["files.sub"]["text"].set("a")
     db["files.sub"]["numbers"] = audformat.Column(scheme_id="int")
     db["files.sub"]["numbers"].set(0)
+    db["files.sub"]["partial"] = audformat.Column(scheme_id="partial")
+    db["files.sub"]["partial"].set("a")
 
     index = audformat.filewise_index(["f1.wav", "f3.wav"])
     db["other"] = audformat.Table(index)
@@ -559,7 +562,7 @@ def wrong_scheme_labels_db(tmpdir):
                         name="regression",
                     ),
                     pd.Series(
-                        ["s1", "s1", "s1", None],
+                        ["s1", "s1", "s1", "s2"],
                         index=audformat.segmented_index(
                             ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
                             [0, 0.1, 0.3, 0],
@@ -570,6 +573,36 @@ def wrong_scheme_labels_db(tmpdir):
                             ordered=False,
                         ),
                         name="speaker",
+                    ),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            "mono_db",
+            "regression",
+            ["partial"],
+            pd.concat(
+                [
+                    pd.Series(
+                        [0.3, 0.2, 0.6, 0.4],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="float",
+                        name="regression",
+                    ),
+                    pd.Series(
+                        ["a", "a", "a", None],
+                        index=audformat.segmented_index(
+                            ["f1.wav", "f1.wav", "f1.wav", "f2.wav"],
+                            [0, 0.1, 0.3, 0],
+                            [0.2, 0.2, 0.5, 0.7],
+                        ),
+                        dtype="string",
+                        name="partial",
                     ),
                 ],
                 axis=1,


### PR DESCRIPTION
Closes #460 

This fixes requesting an additional scheme that is filewise for a scheme that is segmented, e.g.

```python
db.get("scheme_stored_in_segmented_table", additional_schemes="scheme_stored_in_filewise_table")
```

Before it was refusing to load the data for the additional scheme.

As discussed in the issue there were two potential expected outcomes, I settled for the following:

<details><summary>database definition</summary>

```python
import audformat


db = audformat.Database("mydb")
db.schemes["label1"] = audformat.Scheme("str")
db.schemes["label2"] = audformat.Scheme("int")
files = audformat.filewise_index(["f1", "f2"])
segments = audformat.segmented_index(["f1", "f1", "f2", "f2"], [0, 1, 0, 1], [1, 2, 1, 2])
db["files"] = audformat.Table(files)
db["files"]["label1"] = audformat.Column(scheme_id="label1")
db["files"]["label1"].set(["a", "b"])
db["segments"] = audformat.Table(segments)
db["segments"]["label2"] = audformat.Column(scheme_id="label2")
db["segments"]["label2"].set([0, 1, 2, 3])
```

</details>

Starting with the database definition from above, that is copied from #460, we have:

```python
>>> db["files"].df
     label1
file       
f1        a
f2        b

>>> db["segments"].df
                                      label2
file start           end                    
f1   0 days 00:00:00 0 days 00:00:01       0
     0 days 00:00:01 0 days 00:00:02       1
f2   0 days 00:00:00 0 days 00:00:01       2
     0 days 00:00:01 0 days 00:00:02       3
```

I decided to opt for the solution that converts the filewise annotations from the additional scheme to segments:

```python
>>> db.get("label2", additional_schemes="label1")
                                      label2 label1
file start           end                           
f1   0 days 00:00:00 0 days 00:00:01       0      a
     0 days 00:00:01 0 days 00:00:02       1      a
f2   0 days 00:00:00 0 days 00:00:01       2      b
     0 days 00:00:01 0 days 00:00:02       3      b
```

## Summary by Sourcery

Enable mixing segmented main schemes with filewise additional schemes by automatically expanding filewise columns to segment granularity in Database.get.

Bug Fixes:
- Allow requesting a filewise additional scheme alongside a segmented main scheme without refusing to load the data.

Enhancements:
- Detect when the main table is segmented and the additional scheme is filewise, then align and expand filewise annotations to match each segment.

Tests:
- Add tests covering string, categorical, boolean, and missing-value scenarios for filewise-to-segment expansion.