### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Publish Python package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
 
-    # Docuemntation
+    # Documentation
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -541,7 +541,11 @@ class Database(HeaderBase):
 
             >>> import audb
             >>> db = audb.load(
-            ...     "emodb", version="1.4.1", only_metadata=True, full_path=False, verbose=False
+            ...     "emodb",
+            ...     version="1.4.1",
+            ...     only_metadata=True,
+            ...     full_path=False,
+            ...     verbose=False,
             ... )
             >>> db.get("emotion").head()
                                emotion


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.

## Summary by Sourcery

Update the versions of 'ruff' and 'codespell' pre-commit hooks to align with versions used in other packages.

Build:
- Update the version of the 'ruff' pre-commit hook to v0.7.0.
- Update the version of the 'codespell' pre-commit hook to v2.3.0.