### PR TITLE
Update syntax to Python >=3.9

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,7 +97,7 @@ It is also possible to automatically check if all links are still valid::
 
    python -m sphinx docs/ build/sphinx/html -b linkcheck
 
-.. _Sphinx: https://sphinx-doc.org
+.. _Sphinx: https://www.sphinx-doc.org
 
 
 Running the Tests

--- a/audformat/core/attachment.py
+++ b/audformat/core/attachment.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import audeer
 
@@ -62,7 +61,7 @@ class Attachment(HeaderBase):
     @property
     def files(
         self,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List all files that are part of the attachment.
 
         List recursively the relative path

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+from __future__ import annotations  # allow typing without string
 
 import typing
 import warnings

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -103,7 +103,7 @@ class Column(HeaderBase):
         self._id = None
 
     @property
-    def rater(self) -> typing.Optional[Rater]:
+    def rater(self) -> Rater | None:
         r"""Rater object.
 
         Returns:
@@ -118,7 +118,7 @@ class Column(HeaderBase):
             return self.table.db.raters[self.rater_id]
 
     @property
-    def scheme(self) -> typing.Optional[Scheme]:
+    def scheme(self) -> Scheme | None:
         r"""Scheme object.
 
         Returns:
@@ -151,7 +151,7 @@ class Column(HeaderBase):
         as_segmented: bool = False,
         allow_nat: bool = True,
         root: str = None,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         verbose: bool = False,
     ) -> pd.Series:
         r"""Get labels.
@@ -377,7 +377,7 @@ class Column(HeaderBase):
 
     def __eq__(
         self,
-        other: "Column",
+        other: Column,
     ) -> bool:
         r"""Compare if column equals another column."""
         if self.dump() != other.dump():

--- a/audformat/core/column.py
+++ b/audformat/core/column.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # allow typing without string
+from __future__ import annotations
 
 import typing
 import warnings

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import OrderedDict
 import inspect
 import os
@@ -267,7 +269,7 @@ class HeaderBase:
 
     def __eq__(
         self,
-        other: "HeaderBase",
+        other: HeaderBase,
     ) -> bool:
         return self.dump() == other.dump()
 
@@ -328,7 +330,7 @@ def series_to_html(self):  # pragma: no cover
     return df.to_html()
 
 
-def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
+def to_audformat_dtype(dtype: str | type) -> str:
     r"""Convert pandas to audformat dtype."""
     # bool
     if pd.api.types.is_bool_dtype(dtype):
@@ -359,7 +361,7 @@ def to_audformat_dtype(dtype: typing.Union[str, typing.Type]) -> str:
         return define.DataType.OBJECT
 
 
-def to_pandas_dtype(dtype: str) -> typing.Optional[str]:
+def to_pandas_dtype(dtype: str) -> str | None:
     r"""Convert audformat to pandas dtype.
 
     We use ``"Int64"`` instead of ``"int64"``,

--- a/audformat/core/common.py
+++ b/audformat/core/common.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Callable
+from collections.abc import Sequence
 import inspect
 import os
 import textwrap
-import typing
 
 import oyaml as yaml
 import pandas as pd
@@ -74,8 +75,8 @@ class HeaderDict(OrderedDict):
         *args,
         sort_by_key: bool = True,
         value_type: type = None,
-        get_callback: typing.Callable = None,
-        set_callback: typing.Callable = None,
+        get_callback: Callable = None,
+        set_callback: Callable = None,
         **kwargs,
     ):
         self.sort_by_key = sort_by_key
@@ -225,7 +226,7 @@ class HeaderBase:
     def from_dict(
         self,
         d: dict,
-        ignore_keys: typing.Sequence[str] = None,
+        ignore_keys: Sequence[str] = None,
     ):
         r"""Deserialize object from dictionary.
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1424,7 +1424,7 @@ class Database(HeaderBase):
         if not os.path.exists(path):
             raise FileNotFoundError(path)
 
-        with open(path, "r") as fp:
+        with open(path) as fp:
             header = yaml.load(fp, Loader=Loader)
             db = Database.load_header_from_yaml(header)
 

--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import datetime
 import itertools
 import os
 import shutil
-import typing
 
 import oyaml as yaml
 
@@ -146,11 +149,11 @@ class Database(HeaderBase):
         usage: str = define.Usage.UNRESTRICTED,
         *,
         expires: datetime.date = None,
-        languages: typing.Union[str, typing.Sequence[str]] = None,
+        languages: str | Sequence[str] = None,
         description: str = None,
         author: str = None,
         organization: str = None,
-        license: typing.Union[str, define.License] = None,
+        license: str | define.License = None,
         license_url: str = None,
         meta: dict = None,
     ):
@@ -264,7 +267,7 @@ class Database(HeaderBase):
         return all(is_relative_path(f) for f in self.files)
 
     @property
-    def root(self) -> typing.Optional[str]:
+    def root(self) -> str | None:
         r"""Database root directory.
 
         Returns ``None`` if database has not been stored yet.
@@ -292,12 +295,8 @@ class Database(HeaderBase):
 
     def drop_files(
         self,
-        files: typing.Union[
-            str,
-            typing.Sequence[str],
-            typing.Callable[[str], bool],
-        ],
-        num_workers: typing.Optional[int] = 1,
+        files: (str | Sequence[str] | Callable[[str], bool]),
+        num_workers: int | None = 1,
         verbose: bool = False,
     ):
         r"""Drop files from tables.
@@ -323,7 +322,7 @@ class Database(HeaderBase):
 
     def drop_tables(
         self,
-        table_ids: typing.Union[str, typing.Sequence[str]],
+        table_ids: str | Sequence[str],
     ):
         r"""Drop (miscellaneous) tables by ID.
 
@@ -363,7 +362,7 @@ class Database(HeaderBase):
 
     def files_duration(
         self,
-        files: typing.Union[str, typing.Sequence[str]],
+        files: str | Sequence[str],
         *,
         root: str = None,
     ) -> pd.Series:
@@ -438,14 +437,14 @@ class Database(HeaderBase):
     def get(
         self,
         scheme: str,
-        additional_schemes: typing.Union[str, typing.Sequence] = [],
+        additional_schemes: str | Sequence = [],
         *,
-        tables: typing.Union[str, typing.Sequence] = None,
-        splits: typing.Union[str, typing.Sequence] = None,
+        tables: str | Sequence = None,
+        splits: str | Sequence = None,
         strict: bool = False,
         map: bool = True,
         original_column_names: bool = False,
-        aggregate_function: typing.Callable[[pd.Series], typing.Any] = None,
+        aggregate_function: Callable[[pd.Series], object] = None,
         aggregate_strategy: str = "mismatch",
     ) -> pd.DataFrame:
         r"""Get labels by scheme.
@@ -882,8 +881,8 @@ class Database(HeaderBase):
 
     def map_files(
         self,
-        func: typing.Callable[[str], str],
-        num_workers: typing.Optional[int] = 1,
+        func: Callable[[str], str],
+        num_workers: int | None = 1,
         verbose: bool = False,
     ):
         r"""Apply function to file names in all tables.
@@ -914,12 +913,8 @@ class Database(HeaderBase):
 
     def pick_files(
         self,
-        files: typing.Union[
-            str,
-            typing.Sequence[str],
-            typing.Callable[[str], bool],
-        ],
-        num_workers: typing.Optional[int] = 1,
+        files: (str | Sequence[str] | Callable[[str], bool]),
+        num_workers: int | None = 1,
         verbose: bool = False,
     ):
         r"""Pick files from tables.
@@ -945,7 +940,7 @@ class Database(HeaderBase):
 
     def pick_tables(
         self,
-        table_ids: typing.Union[str, typing.Sequence[str]],
+        table_ids: str | Sequence[str],
     ):
         r"""Pick (miscellaneous) tables by ID.
 
@@ -977,7 +972,7 @@ class Database(HeaderBase):
         storage_format: str = define.TableStorageFormat.PARQUET,
         update_other_formats: bool = True,
         header_only: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         verbose: bool = False,
     ):
         r"""Save database to disk.
@@ -1038,12 +1033,12 @@ class Database(HeaderBase):
 
     def update(
         self,
-        others: typing.Union["Database", typing.Sequence["Database"]],
+        others: Database | Sequence[Database],
         *,
         copy_attachments: bool = False,
         copy_media: bool = False,
         overwrite: bool = False,
-    ) -> "Database":
+    ) -> Database:
         r"""Update database with other database(s).
 
         In order to :ref:`update a database <update-a-database>`,
@@ -1121,7 +1116,7 @@ class Database(HeaderBase):
 
         def join_dict(
             field: str,
-            ds: typing.Sequence[dict],
+            ds: Sequence[dict],
         ):
             r"""Join list of dictionaries.
 
@@ -1148,7 +1143,7 @@ class Database(HeaderBase):
         def join_field(
             other: Database,
             field: str,
-            op: typing.Callable,
+            op: Callable,
         ):
             r"""Join two fields of db header."""
             value1 = self.__dict__[field]
@@ -1312,7 +1307,7 @@ class Database(HeaderBase):
     def __getitem__(
         self,
         table_id: str,
-    ) -> typing.Union[MiscTable, Table]:
+    ) -> MiscTable | Table:
         r"""Get (miscellaneous) table from database.
 
         Args:
@@ -1334,7 +1329,7 @@ class Database(HeaderBase):
 
     def __eq__(
         self,
-        other: "Database",
+        other: Database,
     ) -> bool:
         r"""Comparison if database equals another database."""
         if self.dump() != other.dump():
@@ -1346,15 +1341,15 @@ class Database(HeaderBase):
 
     def __iter__(
         self,
-    ) -> typing.Union[MiscTable, Table]:
+    ) -> MiscTable | Table:
         r"""Iterate over (miscellaneous) tables of database."""
         yield from sorted(list(self.tables) + list(self.misc_tables))
 
     def __setitem__(
         self,
         table_id: str,
-        table: typing.Union[MiscTable, Table],
-    ) -> typing.Union[MiscTable, Table]:
+        table: MiscTable | Table,
+    ) -> MiscTable | Table:
         r"""Add table to database.
 
         Args:
@@ -1381,9 +1376,9 @@ class Database(HeaderBase):
         *,
         name: str = "db",
         load_data: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         verbose: bool = False,
-    ) -> "Database":
+    ) -> Database:
         r"""Load database from disk.
 
         Expects a header ``<root>/<name>.yaml``
@@ -1467,7 +1462,7 @@ class Database(HeaderBase):
         return db
 
     @staticmethod
-    def load_header_from_yaml(header: dict) -> "Database":
+    def load_header_from_yaml(header: dict) -> Database:
         r"""Load database header from YAML.
 
         Args:
@@ -1619,8 +1614,8 @@ class Database(HeaderBase):
     def _set_table(
         self,
         table_id: str,
-        table: typing.Union[MiscTable, Table],
-    ) -> typing.Union[MiscTable, Table]:
+        table: MiscTable | Table,
+    ) -> MiscTable | Table:
         if isinstance(table, MiscTable) and table_id in self.tables:
             raise TableExistsError(self[table_id].type, table_id)
         elif isinstance(table, Table) and table_id in self.misc_tables:

--- a/audformat/core/errors.py
+++ b/audformat/core/errors.py
@@ -1,4 +1,4 @@
-import typing
+from collections.abc import Sequence
 
 
 class BadIdError(ValueError):
@@ -30,7 +30,7 @@ class BadKeyError(KeyError):
 
     """
 
-    def __init__(self, invalid_key: str, valid_keys: typing.Sequence[str]):
+    def __init__(self, invalid_key: str, valid_keys: Sequence[str]):
         message = f"Bad key '{invalid_key}', " f"expected one of {list(valid_keys)}"
         super().__init__(message)
 
@@ -44,7 +44,7 @@ class BadTypeError(TypeError):
 
     """
 
-    def __init__(self, invalid_value: typing.Any, expected_type: type):
+    def __init__(self, invalid_value: object, expected_type: type):
         message = f"Bad type '{type(invalid_value)}', " f"expected '{expected_type}'"
         super().__init__(message)
 
@@ -58,7 +58,7 @@ class BadValueError(ValueError):
 
     """
 
-    def __init__(self, invalid_value: str, valid_values: typing.Sequence[str]):
+    def __init__(self, invalid_value: str, valid_values: Sequence[str]):
         message = (
             f"Bad value '{invalid_value}', " f"expected one of {list(valid_values)}"
         )

--- a/audformat/core/index.py
+++ b/audformat/core/index.py
@@ -1,4 +1,4 @@
-import typing
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -9,14 +9,14 @@ from audformat.core.typing import Files
 from audformat.core.typing import Timestamps
 
 
-def is_scalar(value: typing.Any) -> bool:
+def is_scalar(value: object) -> bool:
     r"""Check if value is scalar."""
     return (value is not None) and (
         isinstance(value, str) or not hasattr(value, "__len__")
     )
 
 
-def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
+def to_array(value: object) -> list | np.ndarray:
     r"""Convert value to list or array."""
     if value is not None:
         if isinstance(value, (pd.Series, pd.DataFrame, pd.Index)):
@@ -35,7 +35,7 @@ def to_timedelta(times):
 
 
 def assert_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ):
     r"""Assert object is conform to :ref:`table specifications
     <data-tables:Tables>`.
@@ -115,7 +115,7 @@ def assert_index(
 
 
 def assert_no_duplicates(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ):
     r"""Assert object contains no duplicates in its index.
 
@@ -184,7 +184,7 @@ def filewise_index(
 
 
 def index_type(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ) -> define.IndexType:
     r"""Derive index type.
 
@@ -221,7 +221,7 @@ def index_type(
 
 
 def is_filewise_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ) -> bool:
     r"""Check if object has a filewise index.
 
@@ -248,7 +248,7 @@ def is_filewise_index(
 
 
 def is_segmented_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ) -> bool:
     r"""Check if object has a segmented index.
 

--- a/audformat/core/media.py
+++ b/audformat/core/media.py
@@ -1,4 +1,4 @@
-import typing
+from collections.abc import Sequence
 
 from audformat.core import define
 from audformat.core.common import HeaderBase
@@ -47,7 +47,7 @@ class Media(HeaderBase):
         channels: int = None,
         bit_depth: int = None,
         video_fps: int = None,
-        video_resolution: typing.Sequence[int] = None,
+        video_resolution: Sequence[int] = None,
         video_channels: int = None,
         video_depth: int = None,
         description: str = None,

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -177,7 +177,7 @@ class Scheme(common.HeaderBase):
         return self.dtype in (define.DataType.INTEGER, define.DataType.FLOAT)
 
     @property
-    def labels_as_list(self) -> typing.List:
+    def labels_as_list(self) -> list:
         r"""Scheme labels as list.
 
         If scheme does not define labels
@@ -472,7 +472,7 @@ class Scheme(common.HeaderBase):
     def _labels_to_dict(
         self,
         labels: typing.Union[dict, list, str] = None,
-    ) -> typing.Dict:
+    ) -> dict:
         r"""Return actual labels as dict."""
         if labels is None:
             labels = self.labels
@@ -488,7 +488,7 @@ class Scheme(common.HeaderBase):
     def _labels_to_list(
         self,
         labels: typing.Union[dict, list, str] = None,
-    ) -> typing.List:
+    ) -> list:
         r"""Convert labels to actual labels as list."""
         return list(self._labels_to_dict(labels))
 

--- a/audformat/core/scheme.py
+++ b/audformat/core/scheme.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import datetime
 import random
 import string
-import typing
 
 import pandas as pd
 
@@ -107,9 +108,9 @@ class Scheme(common.HeaderBase):
         self,
         dtype: str = None,
         *,
-        labels: typing.Union[dict, list, str] = None,
-        minimum: typing.Union[int, float] = None,
-        maximum: typing.Union[int, float] = None,
+        labels: dict | list | str = None,
+        minimum: int | float = None,
+        maximum: int | float = None,
         description: str = None,
         meta: dict = None,
     ):
@@ -269,10 +270,7 @@ class Scheme(common.HeaderBase):
 
     def to_pandas_dtype(
         self,
-    ) -> typing.Union[
-        str,
-        pd.api.types.CategoricalDtype,
-    ]:
+    ) -> str | pd.api.types.CategoricalDtype:
         r"""Convert data type to :mod:`pandas` data type.
 
         If ``labels`` is not ``None``, :class:`pandas.CategoricalDtype` is
@@ -303,7 +301,7 @@ class Scheme(common.HeaderBase):
 
     def replace_labels(
         self,
-        labels: typing.Union[dict, list, str],
+        labels: dict | list | str,
     ):
         r"""Replace labels.
 
@@ -390,7 +388,7 @@ class Scheme(common.HeaderBase):
 
     def _check_labels(
         self,
-        labels: typing.Union[dict, list, str],
+        labels: dict | list | str,
     ):
         r"""Raise label related errors."""
         if not isinstance(labels, (dict, list, str)):
@@ -443,7 +441,7 @@ class Scheme(common.HeaderBase):
 
     def _dtype_from_labels(
         self,
-        labels: typing.Union[dict, list, str],
+        labels: dict | list | str,
     ) -> str:
         r"""Derive audformat dtype from labels."""
         if isinstance(labels, str):
@@ -471,7 +469,7 @@ class Scheme(common.HeaderBase):
 
     def _labels_to_dict(
         self,
-        labels: typing.Union[dict, list, str] = None,
+        labels: dict | list | str = None,
     ) -> dict:
         r"""Return actual labels as dict."""
         if labels is None:
@@ -487,12 +485,12 @@ class Scheme(common.HeaderBase):
 
     def _labels_to_list(
         self,
-        labels: typing.Union[dict, list, str] = None,
+        labels: dict | list | str = None,
     ) -> list:
         r"""Convert labels to actual labels as list."""
         return list(self._labels_to_dict(labels))
 
-    def __contains__(self, item: typing.Any) -> bool:
+    def __contains__(self, item: object) -> bool:
         r"""Check if scheme contains data type of item.
 
         ``None``, ``NaT`` and ``NaN`` always match

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1,9 +1,11 @@
-from __future__ import annotations  # allow typing without string
+from __future__ import annotations
 
+from collections.abc import Callable
+from collections.abc import Sequence
 import copy
 import os
 import pickle
-import typing
+from typing import Self
 
 import pandas as pd
 import pyarrow as pa
@@ -57,7 +59,7 @@ class Base(HeaderBase):
         self._db = None
         self._id = None
 
-    def __add__(self, other: typing.Self) -> typing.Self:
+    def __add__(self, other: Self) -> Self:
         r"""Create new table by combining two tables.
 
         The new :ref:`combined table <combine-tables>`
@@ -213,7 +215,7 @@ class Base(HeaderBase):
         return self.df.index
 
     @property
-    def media(self) -> typing.Optional[Media]:
+    def media(self) -> Media | None:
         r"""Media object.
 
         Returns:
@@ -224,7 +226,7 @@ class Base(HeaderBase):
             return self.db.media[self.media_id]
 
     @property
-    def split(self) -> typing.Optional[Split]:
+    def split(self) -> Split | None:
         r"""Split object.
 
         Returns:
@@ -234,7 +236,7 @@ class Base(HeaderBase):
         if self.split_id is not None and self.db is not None:
             return self.db.splits[self.split_id]
 
-    def copy(self) -> typing.Self:
+    def copy(self) -> Self:
         r"""Copy table.
 
         Return:
@@ -259,10 +261,10 @@ class Base(HeaderBase):
 
     def drop_columns(
         self,
-        column_ids: typing.Union[str, typing.Sequence[str]],
+        column_ids: str | Sequence[str],
         *,
         inplace: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Drop columns by ID.
 
         Args:
@@ -292,7 +294,7 @@ class Base(HeaderBase):
         index: pd.Index,
         *,
         inplace: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Drop rows from index.
 
         Args:
@@ -324,9 +326,9 @@ class Base(HeaderBase):
         self,
         index: pd.Index,
         *,
-        fill_values: typing.Union[typing.Any, typing.Dict[str, typing.Any]] = None,
+        fill_values: object | dict[str, object] = None,
         inplace: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Extend table with new rows.
 
         Args:
@@ -366,7 +368,7 @@ class Base(HeaderBase):
         self,
         index: pd.Index = None,
         *,
-        map: typing.Dict[str, typing.Union[str, typing.Sequence[str]]] = None,
+        map: dict[str, str | Sequence[str]] = None,
         copy: bool = True,
     ) -> pd.DataFrame:
         r"""Get labels.
@@ -519,10 +521,10 @@ class Base(HeaderBase):
 
     def pick_columns(
         self,
-        column_ids: typing.Union[str, typing.Sequence[str]],
+        column_ids: str | Sequence[str],
         *,
         inplace: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Pick columns by ID.
 
         All other columns will be dropped.
@@ -548,7 +550,7 @@ class Base(HeaderBase):
         index: pd.Index,
         *,
         inplace: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Pick rows from index.
 
         Args:
@@ -655,10 +657,7 @@ class Base(HeaderBase):
 
     def set(
         self,
-        values: typing.Union[
-            typing.Dict[str, Values],
-            pd.DataFrame,
-        ],
+        values: (dict[str, Values] | pd.DataFrame),
         *,
         index: pd.Index = None,
     ):
@@ -687,10 +686,10 @@ class Base(HeaderBase):
 
     def update(
         self,
-        others: typing.Union[typing.Self, typing.Sequence[typing.Self]],
+        others: Self | Sequence[Self],
         *,
         overwrite: bool = False,
-    ) -> typing.Self:
+    ) -> Self:
         r"""Update table with other table(s).
 
         Table which calls ``update()``
@@ -740,15 +739,15 @@ class Base(HeaderBase):
 
         def raise_error(
             msg,
-            left: typing.Optional[HeaderDict],
-            right: typing.Optional[HeaderDict],
+            left: HeaderDict | None,
+            right: HeaderDict | None,
         ):
             raise ValueError(f"{msg}:\n" f"{left}\n" "!=\n" f"{right}")
 
         def assert_equal(
             msg: str,
-            left: typing.Optional[HeaderDict],
-            right: typing.Optional[HeaderDict],
+            left: HeaderDict | None,
+            right: HeaderDict | None,
         ):
             equal = True
             if left and right:
@@ -858,7 +857,7 @@ class Base(HeaderBase):
         raise NotImplementedError()
 
     @property
-    def _levels_and_dtypes(self) -> typing.Dict[str, str]:
+    def _levels_and_dtypes(self) -> dict[str, str]:
         r"""Levels and dtypes of index columns.
 
         Returns:
@@ -1246,7 +1245,7 @@ class Base(HeaderBase):
 
         return column
 
-    def _set_index(self, df: pd.DataFrame, columns: typing.Sequence) -> pd.DataFrame:
+    def _set_index(self, df: pd.DataFrame, columns: Sequence) -> pd.DataFrame:
         r"""Set columns as index.
 
         Setting of index columns is performed inplace!
@@ -1431,7 +1430,7 @@ class MiscTable(Base):
         return self.df.loc[index]
 
     @property
-    def _levels_and_dtypes(self) -> typing.Dict[str, str]:
+    def _levels_and_dtypes(self) -> dict[str, str]:
         r"""Levels and dtypes of index columns.
 
         Returns:
@@ -1647,11 +1646,7 @@ class Table(Base):
 
     def drop_files(
         self,
-        files: typing.Union[
-            str,
-            typing.Sequence[str],
-            typing.Callable[[str], bool],
-        ],
+        files: (str | Sequence[str] | Callable[[str], bool]),
         *,
         inplace: bool = False,
     ) -> Table:
@@ -1690,12 +1685,12 @@ class Table(Base):
         self,
         index: pd.Index = None,
         *,
-        map: typing.Dict[str, typing.Union[str, typing.Sequence[str]]] = None,
+        map: dict[str, str | Sequence[str]] = None,
         copy: bool = True,
         as_segmented: bool = False,
         allow_nat: bool = True,
         root: str = None,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         verbose: bool = False,
     ) -> pd.DataFrame:
         r"""Get labels.
@@ -1773,7 +1768,7 @@ class Table(Base):
 
     def map_files(
         self,
-        func: typing.Callable[[str], str],
+        func: Callable[[str], str],
     ):
         r"""Apply function to file names in table.
 
@@ -1789,11 +1784,7 @@ class Table(Base):
 
     def pick_files(
         self,
-        files: typing.Union[
-            str,
-            typing.Sequence[str],
-            typing.Callable[[str], bool],
-        ],
+        files: (str | Sequence[str] | Callable[[str], bool]),
         *,
         inplace: bool = False,
     ) -> Table:
@@ -1842,7 +1833,7 @@ class Table(Base):
         return result
 
     @property
-    def _levels_and_dtypes(self) -> typing.Dict[str, str]:
+    def _levels_and_dtypes(self) -> dict[str, str]:
         r"""Levels and dtypes of index columns.
 
         Returns:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 import copy
 import os
 import pickle
-from typing import Self
+import typing
 
 import pandas as pd
 import pyarrow as pa
@@ -59,7 +59,7 @@ class Base(HeaderBase):
         self._db = None
         self._id = None
 
-    def __add__(self, other: Self) -> Self:
+    def __add__(self, other: typing.Self) -> typing.Self:
         r"""Create new table by combining two tables.
 
         The new :ref:`combined table <combine-tables>`
@@ -236,7 +236,7 @@ class Base(HeaderBase):
         if self.split_id is not None and self.db is not None:
             return self.db.splits[self.split_id]
 
-    def copy(self) -> Self:
+    def copy(self) -> typing.Self:
         r"""Copy table.
 
         Return:
@@ -264,7 +264,7 @@ class Base(HeaderBase):
         column_ids: str | Sequence[str],
         *,
         inplace: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Drop columns by ID.
 
         Args:
@@ -294,7 +294,7 @@ class Base(HeaderBase):
         index: pd.Index,
         *,
         inplace: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Drop rows from index.
 
         Args:
@@ -328,7 +328,7 @@ class Base(HeaderBase):
         *,
         fill_values: object | dict[str, object] = None,
         inplace: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Extend table with new rows.
 
         Args:
@@ -524,7 +524,7 @@ class Base(HeaderBase):
         column_ids: str | Sequence[str],
         *,
         inplace: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Pick columns by ID.
 
         All other columns will be dropped.
@@ -550,7 +550,7 @@ class Base(HeaderBase):
         index: pd.Index,
         *,
         inplace: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Pick rows from index.
 
         Args:
@@ -686,10 +686,10 @@ class Base(HeaderBase):
 
     def update(
         self,
-        others: Self | Sequence[Self],
+        others: typing.Self | Sequence[typing.Self],
         *,
         overwrite: bool = False,
-    ) -> Self:
+    ) -> typing.Self:
         r"""Update table with other table(s).
 
         Table which calls ``update()``

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Sequence
 import os
 import random
-from typing import Callable
 
 import numpy as np
 import pandas as pd

--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import os
 import random
 from typing import Callable
-from typing import Dict
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -34,11 +32,9 @@ def add_misc_table(
     table_id: str,
     index: pd.Index,
     *,
-    columns: Union[
-        str,
-        Sequence[str],
-        Dict[str, Union[str, Tuple[Optional[str], Optional[str]]]],
-    ] = None,
+    columns: (
+        str | Sequence[str] | dict[str, str | tuple[str | None, str | None]]
+    ) = None,
     p_none: float = None,
     split_id: str = None,
     media_id: str = None,
@@ -78,14 +74,12 @@ def add_table(
     table_id: str,
     index_type: str,
     *,
-    columns: Union[
-        str,
-        Sequence[str],
-        Dict[str, Union[str, Tuple[Optional[str], Optional[str]]]],
-    ] = None,
-    num_files: Union[int, Sequence[int]] = 5,
+    columns: (
+        str | Sequence[str] | dict[str, str | tuple[str | None, str | None]]
+    ) = None,
+    num_files: int | Sequence[int] = 5,
     num_segments_per_file: int = 5,
-    file_duration: Union[str, pd.Timedelta] = "5s",
+    file_duration: str | pd.Timedelta = "5s",
     file_root: str = "audio",
     p_none: float = None,
     split_id: str = None,
@@ -201,7 +195,7 @@ def create_audio_files(
     sample_generator: Callable[[float], float] = None,
     sampling_rate: int = 16000,
     channels: int = 1,
-    file_duration: Union[str, pd.Timedelta] = "60s",
+    file_duration: str | pd.Timedelta = "60s",
 ):
     r"""Create audio files for a database.
 
@@ -245,7 +239,7 @@ def create_audio_files(
 
 def create_db(
     minimal: bool = False,
-    data: Dict[str, Union[pd.Series, pd.DataFrame]] = None,
+    data: dict[str, pd.Series | pd.DataFrame] = None,
 ) -> Database:
     r"""Create test database.
 
@@ -439,13 +433,9 @@ def create_db(
 def _add_columns(
     db: Database,
     table: Table,
-    columns: Optional[
-        Union[
-            str,
-            Sequence[str],
-            Dict[str, Union[str, Tuple[Optional[str], Optional[str]]]],
-        ]
-    ],
+    columns: (
+        None | (str | Sequence[str] | dict[str, str | tuple[str | None, str | None]])
+    ),
     n_items: int,
     p_none: float,
 ):

--- a/audformat/core/typing.py
+++ b/audformat/core/typing.py
@@ -1,27 +1,32 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+import typing
 
 import numpy as np
 import pandas as pd
 
 
-Files = str | Sequence[str] | pd.Index | pd.Series
-Timestamps = (
-    float
-    | int
-    | str
-    | pd.Timedelta
-    | Sequence[float | int | str | pd.Timedelta]
-    | pd.Index
-    | pd.Series
-)
-Values = (
-    int
-    | float
-    | str
-    | pd.Timedelta
-    | Sequence[int | float | str | pd.Timedelta]
-    | np.ndarray
-    | pd.Series
-)
+Files = typing.Union[
+    str,
+    typing.Sequence[str],
+    pd.Index,
+    pd.Series,
+]
+Timestamps = typing.Union[
+    float,
+    int,
+    str,
+    pd.Timedelta,
+    typing.Sequence[typing.Union[float, int, str, pd.Timedelta]],
+    pd.Index,
+    pd.Series,
+]
+Values = typing.Union[
+    int,
+    float,
+    str,
+    pd.Timedelta,
+    typing.Sequence[typing.Union[int, float, str, pd.Timedelta],],
+    np.ndarray,
+    pd.Series,
+]

--- a/audformat/core/typing.py
+++ b/audformat/core/typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 
 import numpy as np

--- a/audformat/core/typing.py
+++ b/audformat/core/typing.py
@@ -1,32 +1,27 @@
 from __future__ import annotations
 
-import typing
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
 
 
-Files = typing.Union[
-    str,
-    typing.Sequence[str],
-    pd.Index,
-    pd.Series,
-]
-Timestamps = typing.Union[
-    float,
-    int,
-    str,
-    pd.Timedelta,
-    typing.Sequence[typing.Union[float, int, str, pd.Timedelta]],
-    pd.Index,
-    pd.Series,
-]
-Values = typing.Union[
-    int,
-    float,
-    str,
-    pd.Timedelta,
-    typing.Sequence[typing.Union[int, float, str, pd.Timedelta],],
-    np.ndarray,
-    pd.Series,
-]
+Files = str | Sequence[str] | pd.Index | pd.Series
+Timestamps = (
+    float
+    | int
+    | str
+    | pd.Timedelta
+    | Sequence[float | int | str | pd.Timedelta]
+    | pd.Index
+    | pd.Series
+)
+Values = (
+    int
+    | float
+    | str
+    | pd.Timedelta
+    | Sequence[int | float | str | pd.Timedelta]
+    | np.ndarray
+    | pd.Series
+)

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1079,7 +1079,7 @@ def join_labels(
     if not isinstance(labels, list):
         labels = list(labels)
 
-    if len(misc_table_ids := [x for x in labels if isinstance(x, str)]) > 1:
+    if misc_table_ids := [x for x in labels if isinstance(x, str)]:
         raise ValueError(
             f"The following string values were provided: '"
             f"{misc_table_ids}'. "

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import collections
+from collections.abc import Callable
+from collections.abc import Iterator
+from collections.abc import MutableMapping
+from collections.abc import Sequence
 import errno
 import hashlib
 import os
 import platform
 import re
 import sys
-import typing as typing
 
 import iso639
 from iso639.exceptions import InvalidLanguageValue
@@ -39,10 +42,10 @@ if platform.system() in ["Windows"]:  # pragma: no cover
 
 
 def concat(
-    objs: typing.Sequence[pd.Series | pd.DataFrame],
+    objs: Sequence[pd.Series | pd.DataFrame],
     *,
     overwrite: bool = False,
-    aggregate_function: typing.Callable[[pd.Series], typing.Any] = None,
+    aggregate_function: Callable[[pd.Series], object] = None,
     aggregate_strategy: str = "mismatch",
 ) -> pd.Series | pd.DataFrame:
     r"""Concatenate objects.
@@ -425,7 +428,7 @@ def concat(
 
 
 def difference(
-    objs: typing.Sequence[pd.Index],
+    objs: Sequence[pd.Index],
 ) -> pd.Index:
     r"""Difference of index objects.
 
@@ -805,7 +808,7 @@ def index_has_overlap(
 
 
 def intersect(
-    objs: typing.Sequence[pd.Index],
+    objs: Sequence[pd.Index],
 ) -> pd.Index:
     r"""Intersect index objects.
 
@@ -941,7 +944,7 @@ def intersect(
 
 
 def is_index_alike(
-    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
+    objs: Sequence[pd.Index | pd.Series | pd.DataFrame],
 ) -> bool:
     r"""Check if index objects are alike.
 
@@ -998,7 +1001,7 @@ def is_index_alike(
 
 def iter_by_file(
     obj: (pd.Index | pd.Series | pd.DataFrame),
-) -> typing.Iterator[
+) -> Iterator[
     tuple[
         str,
         pd.Index | pd.Series | pd.DataFrame,
@@ -1051,7 +1054,7 @@ def iter_by_file(
 
 
 def join_labels(
-    labels: typing.Sequence[list | dict],
+    labels: Sequence[list | dict],
 ) -> list | dict:
     r"""Combine scheme labels.
 
@@ -1124,7 +1127,7 @@ def join_labels(
 
 
 def join_schemes(
-    dbs: typing.Sequence[Database],
+    dbs: Sequence[Database],
     scheme_id: str,
 ):
     r"""Join and update scheme of databases.
@@ -1205,7 +1208,7 @@ def map_country(country: str) -> str:
 
 def map_file_path(
     index: pd.Index,
-    func: typing.Callable[[str], str],
+    func: Callable[[str], str],
 ) -> pd.Index:
     r"""Apply callable to file path in index.
 
@@ -1697,7 +1700,7 @@ def to_segmented_index(
     obj: pd.Index | pd.Series | pd.DataFrame,
     *,
     allow_nat: bool = True,
-    files_duration: typing.MutableMapping[str, pd.Timedelta] = None,
+    files_duration: MutableMapping[str, pd.Timedelta] = None,
     root: str = None,
     num_workers: int | None = 1,
     verbose: bool = False,
@@ -1846,7 +1849,7 @@ UNION_MAX_INDEX_LEN_THRES = 500
 
 
 def union(
-    objs: typing.Sequence[pd.Index],
+    objs: Sequence[pd.Index],
 ) -> pd.Index:
     r"""Create union of index objects.
 
@@ -2004,7 +2007,7 @@ def union(
 
 def _alike_index(
     index: pd.Index,
-    data: typing.Sequence = [],
+    data: Sequence = [],
 ) -> pd.Index:
     if isinstance(index, pd.MultiIndex):
         return set_index_dtypes(
@@ -2020,7 +2023,7 @@ def _alike_index(
 
 
 def _assert_index_alike(
-    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
+    objs: Sequence[pd.Index | pd.Series | pd.DataFrame],
 ):
     r"""Raise if index objects are not alike.
 
@@ -2112,8 +2115,8 @@ def _levels(index) -> list[str]:
 
 
 def _maybe_convert_filewise_index(
-    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
-) -> typing.Sequence[pd.Index | pd.Series | pd.DataFrame]:
+    objs: Sequence[pd.Index | pd.Series | pd.DataFrame],
+) -> Sequence[pd.Index | pd.Series | pd.DataFrame]:
     r"""Convert filewise to segmented index.
 
     Checks if all index objects are either filewise or segmented,
@@ -2175,8 +2178,8 @@ def _maybe_convert_pandas_dtype(
 
 
 def _maybe_convert_single_level_multi_index(
-    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
-) -> typing.Sequence[pd.Index | pd.Series | pd.DataFrame]:
+    objs: Sequence[pd.Index | pd.Series | pd.DataFrame],
+) -> Sequence[pd.Index | pd.Series | pd.DataFrame]:
     r"""Convert single-level pd.MultiIndex to pd.Index.
 
     If input is a mixture of single-level
@@ -2206,7 +2209,7 @@ def _maybe_convert_single_level_multi_index(
     return objs
 
 
-def _pandas_dtypes(index) -> list[typing.Any]:
+def _pandas_dtypes(index) -> list[object]:
     r"""List of pandas dtypes of index.
 
     Args:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import errno
 import hashlib
@@ -37,12 +39,12 @@ if platform.system() in ["Windows"]:  # pragma: no cover
 
 
 def concat(
-    objs: typing.Sequence[typing.Union[pd.Series, pd.DataFrame]],
+    objs: typing.Sequence[pd.Series | pd.DataFrame],
     *,
     overwrite: bool = False,
     aggregate_function: typing.Callable[[pd.Series], typing.Any] = None,
     aggregate_strategy: str = "mismatch",
-) -> typing.Union[pd.Series, pd.DataFrame]:
+) -> pd.Series | pd.DataFrame:
     r"""Concatenate objects.
 
     If all objects are conform to
@@ -423,7 +425,7 @@ def concat(
 
 
 def difference(
-    objs: typing.Sequence[typing.Union[pd.Index]],
+    objs: typing.Sequence[pd.Index],
 ) -> pd.Index:
     r"""Difference of index objects.
 
@@ -556,7 +558,7 @@ def difference(
 
 
 def duration(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
     *,
     root: str = None,
     num_workers: int = 1,
@@ -666,7 +668,7 @@ def expand_file_path(
 
 
 def hash(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
     strict: bool = False,
 ) -> str:
     r"""Create hash from object.
@@ -753,7 +755,7 @@ def hash(
 
 
 def index_has_overlap(
-    obj: typing.Union[pd.Index, pd.DataFrame, pd.Series],
+    obj: pd.Index | pd.DataFrame | pd.Series,
 ) -> bool:
     r"""Check if one or more segments in the index overlap.
 
@@ -803,7 +805,7 @@ def index_has_overlap(
 
 
 def intersect(
-    objs: typing.Sequence[typing.Union[pd.Index]],
+    objs: typing.Sequence[pd.Index],
 ) -> pd.Index:
     r"""Intersect index objects.
 
@@ -939,7 +941,7 @@ def intersect(
 
 
 def is_index_alike(
-    objs: typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]],
+    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
 ) -> bool:
     r"""Check if index objects are alike.
 
@@ -995,15 +997,11 @@ def is_index_alike(
 
 
 def iter_by_file(
-    obj: typing.Union[
-        pd.Index,
-        pd.Series,
-        pd.DataFrame,
-    ],
+    obj: (pd.Index | pd.Series | pd.DataFrame),
 ) -> typing.Iterator[
     tuple[
         str,
-        typing.Union[pd.Index, pd.Series, pd.DataFrame],
+        pd.Index | pd.Series | pd.DataFrame,
     ],
 ]:
     r"""Iterate over object by file.
@@ -1053,8 +1051,8 @@ def iter_by_file(
 
 
 def join_labels(
-    labels: typing.Sequence[typing.Union[list, dict]],
-) -> typing.Union[list, dict]:
+    labels: typing.Sequence[list | dict],
+) -> list | dict:
     r"""Combine scheme labels.
 
     Args:
@@ -1081,8 +1079,7 @@ def join_labels(
     if not isinstance(labels, list):
         labels = list(labels)
 
-    misc_table_ids = [x for x in labels if isinstance(x, str)]
-    if len(misc_table_ids) > 0:
+    if misc_table_ids := [x for x in labels if isinstance(x, str)]:
         raise ValueError(
             f"The following string values were provided: '"
             f"{misc_table_ids}'. "
@@ -1092,8 +1089,8 @@ def join_labels(
         )
 
     if not (
-        all([isinstance(x, list) for x in labels])
-        or all([isinstance(x, dict) for x in labels])
+        all(isinstance(x, list) for x in labels)
+        or all(isinstance(x, dict) for x in labels)
     ):
         raise ValueError("All labels must be either of type 'list' or 'dict'.")
 
@@ -1101,8 +1098,7 @@ def join_labels(
         return labels[0]
 
     items = audeer.flatten_list([list(x) for x in labels])
-    dtypes = sorted(list({str(type(x)) for x in items}))
-    if len(dtypes) > 1:
+    if dtypes := sorted(list({str(type(x)) for x in items})):
         raise ValueError(
             f"Elements or keys must "
             f"have the same dtype, "
@@ -1307,7 +1303,7 @@ def read_csv(
     *args,
     as_dataframe: bool = False,
     **kwargs,
-) -> typing.Union[pd.Index, pd.Series, pd.DataFrame]:
+) -> pd.Index | pd.Series | pd.DataFrame:
     r"""Read object from CSV file.
 
     Automatically detects the index type and returns an object that is
@@ -1461,10 +1457,7 @@ def replace_file_extension(
 
 def set_index_dtypes(
     index: pd.Index,
-    dtypes: typing.Union[
-        str,
-        dict[str, str],
-    ],
+    dtypes: (str | dict[str, str]),
 ) -> pd.Index:
     r"""Set the dtypes of an index for the given level names.
 
@@ -1569,13 +1562,13 @@ def set_index_dtypes(
 
 
 def to_filewise_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
     root: str,
     output_folder: str,
     *,
     num_workers: int = 1,
     progress_bar: bool = False,
-) -> typing.Union[pd.Index, pd.Series, pd.DataFrame]:
+) -> pd.Index | pd.Series | pd.DataFrame:
     r"""Convert to filewise index.
 
     If input is segmented, each segment is saved to a separate file
@@ -1700,14 +1693,14 @@ def to_filewise_index(
 
 
 def to_segmented_index(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
     *,
     allow_nat: bool = True,
     files_duration: typing.MutableMapping[str, pd.Timedelta] = None,
     root: str = None,
-    num_workers: typing.Optional[int] = 1,
+    num_workers: int | None = 1,
     verbose: bool = False,
-) -> typing.Union[pd.Index, pd.Series, pd.DataFrame]:
+) -> pd.Index | pd.Series | pd.DataFrame:
     r"""Convert to segmented index.
 
     If the input a filewise table,
@@ -2026,7 +2019,7 @@ def _alike_index(
 
 
 def _assert_index_alike(
-    objs: typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]],
+    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
 ):
     r"""Raise if index objects are not alike.
 
@@ -2118,8 +2111,8 @@ def _levels(index) -> list[str]:
 
 
 def _maybe_convert_filewise_index(
-    objs: typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]],
-) -> typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]]:
+    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
+) -> typing.Sequence[pd.Index | pd.Series | pd.DataFrame]:
     r"""Convert filewise to segmented index.
 
     Checks if all index objects are either filewise or segmented,
@@ -2181,8 +2174,8 @@ def _maybe_convert_pandas_dtype(
 
 
 def _maybe_convert_single_level_multi_index(
-    objs: typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]],
-) -> typing.Sequence[typing.Union[pd.Index, pd.Series, pd.DataFrame]]:
+    objs: typing.Sequence[pd.Index | pd.Series | pd.DataFrame],
+) -> typing.Sequence[pd.Index | pd.Series | pd.DataFrame]:
     r"""Convert single-level pd.MultiIndex to pd.Index.
 
     If input is a mixture of single-level

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -980,7 +980,7 @@ def is_index_alike(
     objs = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
 
     # check names
-    levels = set([obj.names for obj in objs])
+    levels = {obj.names for obj in objs}
     if len(levels) > 1:
         return False
 
@@ -1001,7 +1001,7 @@ def iter_by_file(
         pd.DataFrame,
     ],
 ) -> typing.Iterator[
-    typing.Tuple[
+    tuple[
         str,
         typing.Union[pd.Index, pd.Series, pd.DataFrame],
     ],
@@ -1053,8 +1053,8 @@ def iter_by_file(
 
 
 def join_labels(
-    labels: typing.Sequence[typing.Union[typing.List, typing.Dict]],
-) -> typing.Union[typing.List, typing.Dict]:
+    labels: typing.Sequence[typing.Union[list, dict]],
+) -> typing.Union[list, dict]:
     r"""Combine scheme labels.
 
     Args:
@@ -1095,13 +1095,13 @@ def join_labels(
         all([isinstance(x, list) for x in labels])
         or all([isinstance(x, dict) for x in labels])
     ):
-        raise ValueError(("All labels must be either " "of type 'list' or 'dict'."))
+        raise ValueError("All labels must be either of type 'list' or 'dict'.")
 
     if len(labels) == 1:
         return labels[0]
 
     items = audeer.flatten_list([list(x) for x in labels])
-    dtypes = sorted(list(set([str(type(x)) for x in items])))
+    dtypes = sorted(list({str(type(x)) for x in items}))
     if len(dtypes) > 1:
         raise ValueError(
             f"Elements or keys must "
@@ -1463,7 +1463,7 @@ def set_index_dtypes(
     index: pd.Index,
     dtypes: typing.Union[
         str,
-        typing.Dict[str, str],
+        dict[str, str],
     ],
 ) -> pd.Index:
     r"""Set the dtypes of an index for the given level names.
@@ -1662,7 +1662,7 @@ def to_filewise_index(
             [
                 os.path.join(
                     output_folder,
-                    "_{}.".format(str(count).zfill(width)).join(f.rsplit(".", 1)),
+                    f"_{str(count).zfill(width)}.".join(f.rsplit(".", 1)),
                 )
                 for count in range(len(group))
             ]
@@ -2070,7 +2070,7 @@ def _assert_index_alike(
     raise ValueError(msg)
 
 
-def _audformat_dtypes(index) -> typing.List[str]:
+def _audformat_dtypes(index) -> list[str]:
     r"""List of audformat data types of index.
 
     Args:
@@ -2101,7 +2101,7 @@ def _is_same_dtype(d1, d2) -> bool:
     return d1.name == d2.name
 
 
-def _levels(index) -> typing.List[str]:
+def _levels(index) -> list[str]:
     r"""List of levels of index.
 
     Args:
@@ -2199,7 +2199,7 @@ def _maybe_convert_single_level_multi_index(
     """
     indices = [obj if isinstance(obj, pd.Index) else obj.index for obj in objs]
     is_single_level = indices[0].nlevels == 1
-    is_mix = len(set(isinstance(index, pd.MultiIndex) for index in indices)) == 2
+    is_mix = len({isinstance(index, pd.MultiIndex) for index in indices}) == 2
 
     if is_single_level and is_mix:
         objs = list(objs)
@@ -2212,7 +2212,7 @@ def _maybe_convert_single_level_multi_index(
     return objs
 
 
-def _pandas_dtypes(index) -> typing.List[typing.Any]:
+def _pandas_dtypes(index) -> list[typing.Any]:
     r"""List of pandas dtypes of index.
 
     Args:

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -1079,7 +1079,7 @@ def join_labels(
     if not isinstance(labels, list):
         labels = list(labels)
 
-    if misc_table_ids := [x for x in labels if isinstance(x, str)]:
+    if len(misc_table_ids := [x for x in labels if isinstance(x, str)]) > 1:
         raise ValueError(
             f"The following string values were provided: '"
             f"{misc_table_ids}'. "
@@ -1098,7 +1098,8 @@ def join_labels(
         return labels[0]
 
     items = audeer.flatten_list([list(x) for x in labels])
-    if dtypes := sorted(list({str(type(x)) for x in items})):
+    dtypes = sorted(list({str(type(x)) for x in items}))
+    if len(dtypes) > 1:
         raise ValueError(
             f"Elements or keys must "
             f"have the same dtype, "

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -879,7 +879,7 @@ def test_update(tmpdir):
         for file in db.attachments[attachment_id].files:
             assert os.path.exists(os.path.join(db.root, file))
             if file in expected_content:
-                with open(audeer.path(db.root, file), "r") as fp:
+                with open(audeer.path(db.root, file)) as fp:
                     assert fp.read() == expected_content[file]
 
     # test media files

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -1,4 +1,4 @@
-import typing
+from __future__ import annotations
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,7 @@ import audformat.testing
 
 
 def create_db_misc_table(
-    obj: typing.Union[pd.Series, pd.DataFrame] = None,
+    obj: pd.Series | pd.DataFrame = None,
     *,
     rater: audformat.Rater = None,
     media: audformat.Media = None,
@@ -44,7 +44,7 @@ def create_db_misc_table(
 
 
 def create_misc_table(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ) -> audformat.MiscTable:
     r"""Helper function to create Table."""
     index = obj if isinstance(obj, pd.Index) else obj.index

--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -280,7 +280,7 @@ def test_scheme_errors():
     # labels not list or dictionary
     error_msg = "Labels must be passed " "as a dictionary, list or ID of a misc table."
     with pytest.raises(ValueError, match=error_msg):
-        audformat.Scheme(labels=set([1, 2, 3]))
+        audformat.Scheme(labels={1, 2, 3})
 
     # labels do not have the same type
     error_msg = "All labels must be of the same data type."

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 import random
 import re
 import time
-import typing
 
 import numpy as np
 import pandas as pd
@@ -16,7 +17,7 @@ import audformat.testing
 
 
 def create_db_table(
-    obj: typing.Union[pd.Series, pd.DataFrame] = None,
+    obj: pd.Series | pd.DataFrame = None,
     *,
     rater: audformat.Rater = None,
     media: audformat.Media = None,
@@ -50,7 +51,7 @@ def create_db_table(
 
 
 def create_table(
-    obj: typing.Union[pd.Index, pd.Series, pd.DataFrame],
+    obj: pd.Index | pd.Series | pd.DataFrame,
 ) -> audformat.Table:
     r"""Helper function to create Table."""
     index = obj if isinstance(obj, pd.Index) else obj.index


### PR DESCRIPTION
Updates syntax to Python >=3.9 by removing the use of `typing` (with the exception of `typing.Self` in `audformat/core/table.py` type alias definitions in `audformat/core/typing.py`, and `typing.TYPE_CHECKING` in `audformat/core/column.py`).

## Summary by Sourcery

Enhancements:
- Use native Python 3.9 type hinting syntax instead of the `typing` library.