### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.12'
           - os: ubuntu-latest
+            python-version: '3.13'
+          - os: ubuntu-latest
             python-version: '3.9'
             requirements: 'minimum'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'  # pandas >=2.1.0


### PR DESCRIPTION
Add tests and official support for Python 3.13.

## Summary by Sourcery

CI:
- Add Python 3.13 to the test matrix.