### PR TITLE
TST: use sybil for doctests

### DIFF
--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -1,8 +1,12 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
 import os
 import tempfile
 
 import numpy as np
 import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
 
 import audiofile
 
@@ -22,3 +26,13 @@ def prepare_docstring_tests(doctest_namespace):
         yield
 
         os.chdir(current_dir)
+
+
+parsers = [
+    DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+]
+pytest_collect_file = sybil.Sybil(
+    parsers=parsers,
+    pattern="*.py",
+    fixtures=["prepare_docstring_tests"],
+).pytest()

--- a/audformat/core/conftest.py
+++ b/audformat/core/conftest.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import sybil
 from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import SkipParser
 
 import audiofile
 
@@ -30,6 +31,7 @@ def prepare_docstring_tests(doctest_namespace):
 
 parsers = [
     DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+    SkipParser(),
 ]
 pytest_collect_file = sybil.Sybil(
     parsers=parsers,

--- a/audformat/core/utils.py
+++ b/audformat/core/utils.py
@@ -646,10 +646,15 @@ def expand_file_path(
             :ref:`table specifications <data-tables:Tables>`
 
     Examples:
+
+        .. skip: start if(sys.platform.startswith("win"))
+
         >>> expand_file_path(filewise_index(["f1", "f2"]), "/a")
         Index(['/a/f1', '/a/f2'], dtype='string', name='file')
         >>> expand_file_path(filewise_index(["f1", "f2"]), "./a")
         Index(['a/f1', 'a/f2'], dtype='string', name='file')
+
+        .. skip: end
 
     """  # noqa: E501
     if len(index) == 0:
@@ -1603,6 +1608,9 @@ def to_filewise_index(
             original data
 
     Examples:
+
+        .. skip: start if(sys.platform.startswith("win"))
+
         >>> index = segmented_index(
         ...     files=["f.wav", "f.wav"],
         ...     starts=[0, 0.5],
@@ -1610,6 +1618,8 @@ def to_filewise_index(
         ... )
         >>> to_filewise_index(index, ".", "split")
         Index(['split/f_0.wav', 'split/f_1.wav'], dtype='string', name='file')
+
+        .. skip: end
 
     """
     if is_filewise_index(obj):

--- a/docs/accessing-data.rst
+++ b/docs/accessing-data.rst
@@ -11,6 +11,10 @@ by the :meth:`audformat.Table.get` method:
 .. code-block:: python
 
     import audformat.testing
+    import random
+
+
+    random.seed(1)
 
 
     db = audformat.testing.create_db()
@@ -23,8 +27,8 @@ Which returns the following :class:`pandas.DataFrame`:
 >>> table.iloc[0:2, 0:2]
                bool                    date
 file
-audio/001.wav  True 1970-01-01 00:00:00.350
-audio/002.wav  True                     NaT
+audio/001.wav  <NA>                     NaT
+audio/002.wav  True 1970-01-01 00:00:00.170
 
 
 Or you can directly access a column with :meth:`audformat.Column.get()`:
@@ -39,8 +43,8 @@ Which results in the following :class:`pandas.Series`:
 
 >>> column[0:2]
 file
-audio/001.wav    19gBvYMkzf
-audio/002.wav    SamkVRP8E9
+audio/001.wav    vv7xWJcOxL
+audio/002.wav    eF5Of2ICvG
 Name: string, dtype: string
 
 

--- a/docs/accessing-data.rst
+++ b/docs/accessing-data.rst
@@ -2,24 +2,13 @@ Working with a database
 =======================
 
 
-.. Enforce HTML output for pd.Series
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audformat
-
-
-    audformat.core.common.format_series_as_html()
-
-
 Accessing data
 --------------
 
 Annotation labels can be accessed
 by the :meth:`audformat.Table.get` method:
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat.testing
 
@@ -31,13 +20,16 @@ by the :meth:`audformat.Table.get` method:
 
 Which returns the following :class:`pandas.DataFrame`:
 
-.. jupyter-execute::
+>>> table.iloc[0:2, 0:2]
+               bool                    date
+file
+audio/001.wav  True 1970-01-01 00:00:00.350
+audio/002.wav  True                     NaT
 
-    table.iloc[0:2, 0:2]
 
 Or you can directly access a column with :meth:`audformat.Column.get()`:
 
-.. jupyter-execute::
+.. code-block:: python
 
     column = db["files"]["string"].get()
     # Short for:
@@ -45,9 +37,12 @@ Or you can directly access a column with :meth:`audformat.Column.get()`:
 
 Which results in the following :class:`pandas.Series`:
 
-.. jupyter-execute::
+>>> column[0:2]
+file
+audio/001.wav    19gBvYMkzf
+audio/002.wav    SamkVRP8E9
+Name: string, dtype: string
 
-    column[0:2]
 
 For more information on how to access or add data
 have a look at the code examples in the
@@ -59,7 +54,7 @@ Changing referenced files
 
 To convert to absolute file paths in all tables, do:
 
-.. jupyter-execute::
+.. code-block:: python
 
     import os
 

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -8,11 +8,9 @@ in tables of different type as some labels belong to the whole file,
 others don't. The following examples highlights this with the labels
 for age and likability:
 
-.. jupyter-execute::
-    :hide-output:
+.. code-block:: python
 
     import audformat.testing
-
 
     db = audformat.testing.create_db(minimal=True)
     db.schemes["age"] = audformat.Scheme(
@@ -40,52 +38,112 @@ for age and likability:
 
 Which results in the following two :class:`pandas.DataFrame`:
 
-.. jupyter-execute::
+>>> db["age"].get()
+               age
+file
+audio/001.wav   40
+audio/002.wav   33
+audio/003.wav   38
 
-    display(
-        db["age"].get(),
-        db["likability"].get(),
-    )
+>>> db["likability"].get()
+                                                                   likability
+file          start                     end
+audio/001.wav 0 days 00:00:00.063022023 0 days 00:00:00.670806417    0.310583
+              0 days 00:00:02.176912810 0 days 00:00:02.570855787    0.047821
+              0 days 00:00:03.254253920 0 days 00:00:03.748281529    0.288177
+              0 days 00:00:03.959315192 0 days 00:00:04.110064420    0.848677
+              0 days 00:00:04.541308146 0 days 00:00:04.962982764    0.787870
+audio/002.wav 0 days 00:00:00.003443562 0 days 00:00:00.037705840    0.122311
+              0 days 00:00:00.796582868 0 days 00:00:01.075538128    0.646814
+              0 days 00:00:01.110602019 0 days 00:00:01.439743769    0.837227
+              0 days 00:00:02.194859538 0 days 00:00:03.675142916    0.430492
+              0 days 00:00:04.187563347 0 days 00:00:04.738401164    0.944455
+audio/003.wav 0 days 00:00:00.574500931 0 days 00:00:00.929483764    0.422895
+              0 days 00:00:01.450303730 0 days 00:00:01.953211769    0.559592
+              0 days 00:00:02.808842477 0 days 00:00:03.099035455    0.586085
+              0 days 00:00:03.225926686 0 days 00:00:04.007331084    0.701001
+              0 days 00:00:04.015322811 0 days 00:00:04.430922264    0.492587
+audio/004.wav 0 days 00:00:00.276361409 0 days 00:00:00.625730112    0.717525
+              0 days 00:00:01.335888842 0 days 00:00:01.920178620    0.705011
+              0 days 00:00:02.320023510 0 days 00:00:02.419307606    0.607638
+              0 days 00:00:02.798096347 0 days 00:00:02.892323558    0.918130
+              0 days 00:00:03.617486299 0 days 00:00:03.943024074    0.414640
+
 
 You can simply combine both tables with:
 
-.. jupyter-execute::
-
-    combined_table = db["likability"] + db["age"]
-
-Which results in the following :class:`pandas.DataFrame`:
-
-.. jupyter-execute::
-
-    combined_table.get()
+>>> combined_table = db["likability"] + db["age"]
+>>> combined_table.get()
+                                                                   likability   age
+file          start                     end
+audio/001.wav 0 days 00:00:00.063022023 0 days 00:00:00.670806417    0.310583  <NA>
+              0 days 00:00:02.176912810 0 days 00:00:02.570855787    0.047821  <NA>
+              0 days 00:00:03.254253920 0 days 00:00:03.748281529    0.288177  <NA>
+              0 days 00:00:03.959315192 0 days 00:00:04.110064420    0.848677  <NA>
+              0 days 00:00:04.541308146 0 days 00:00:04.962982764    0.787870  <NA>
+audio/002.wav 0 days 00:00:00.003443562 0 days 00:00:00.037705840    0.122311  <NA>
+              0 days 00:00:00.796582868 0 days 00:00:01.075538128    0.646814  <NA>
+              0 days 00:00:01.110602019 0 days 00:00:01.439743769    0.837227  <NA>
+              0 days 00:00:02.194859538 0 days 00:00:03.675142916    0.430492  <NA>
+              0 days 00:00:04.187563347 0 days 00:00:04.738401164    0.944455  <NA>
+audio/003.wav 0 days 00:00:00.574500931 0 days 00:00:00.929483764    0.422895  <NA>
+              0 days 00:00:01.450303730 0 days 00:00:01.953211769    0.559592  <NA>
+              0 days 00:00:02.808842477 0 days 00:00:03.099035455    0.586085  <NA>
+              0 days 00:00:03.225926686 0 days 00:00:04.007331084    0.701001  <NA>
+              0 days 00:00:04.015322811 0 days 00:00:04.430922264    0.492587  <NA>
+audio/004.wav 0 days 00:00:00.276361409 0 days 00:00:00.625730112    0.717525  <NA>
+              0 days 00:00:01.335888842 0 days 00:00:01.920178620    0.705011  <NA>
+              0 days 00:00:02.320023510 0 days 00:00:02.419307606    0.607638  <NA>
+              0 days 00:00:02.798096347 0 days 00:00:02.892323558    0.918130  <NA>
+              0 days 00:00:03.617486299 0 days 00:00:03.943024074    0.414640  <NA>
+audio/001.wav 0 days 00:00:00           NaT                               NaN    40
+audio/002.wav 0 days 00:00:00           NaT                               NaN    33
+audio/003.wav 0 days 00:00:00           NaT                               NaN    38
 
 Or, if you just want to have the likability information for all segments,
 for which age information is available:
 
-.. jupyter-execute::
-
-    df_likability = db["likability"].get(
-        db["age"].files,
-    )
-
-Which results in the following :class:`pandas.DataFrame`:
-
-.. jupyter-execute::
-
-    df_likability
+>>> df_likability = db["likability"].get(db["age"].files)
+>>> df_likability
+                                                                   likability
+file          start                     end
+audio/001.wav 0 days 00:00:00.063022023 0 days 00:00:00.670806417    0.310583
+              0 days 00:00:02.176912810 0 days 00:00:02.570855787    0.047821
+              0 days 00:00:03.254253920 0 days 00:00:03.748281529    0.288177
+              0 days 00:00:03.959315192 0 days 00:00:04.110064420    0.848677
+              0 days 00:00:04.541308146 0 days 00:00:04.962982764    0.787870
+audio/002.wav 0 days 00:00:00.003443562 0 days 00:00:00.037705840    0.122311
+              0 days 00:00:00.796582868 0 days 00:00:01.075538128    0.646814
+              0 days 00:00:01.110602019 0 days 00:00:01.439743769    0.837227
+              0 days 00:00:02.194859538 0 days 00:00:03.675142916    0.430492
+              0 days 00:00:04.187563347 0 days 00:00:04.738401164    0.944455
+audio/003.wav 0 days 00:00:00.574500931 0 days 00:00:00.929483764    0.422895
+              0 days 00:00:01.450303730 0 days 00:00:01.953211769    0.559592
+              0 days 00:00:02.808842477 0 days 00:00:03.099035455    0.586085
+              0 days 00:00:03.225926686 0 days 00:00:04.007331084    0.701001
+              0 days 00:00:04.015322811 0 days 00:00:04.430922264    0.492587
 
 Or, if you want to have the age information for segments
 in the likeability table:
 
-.. jupyter-execute::
-
-    df_age = db["age"].get(df_likability.index)
-
-Which results in the following :class:`pandas.DataFrame`:
-
-.. jupyter-execute::
-
-    df_age
+>>> db["age"].get(df_likability.index)
+                                                                   age
+file          start                     end
+audio/001.wav 0 days 00:00:00.063022023 0 days 00:00:00.670806417   40
+              0 days 00:00:02.176912810 0 days 00:00:02.570855787   40
+              0 days 00:00:03.254253920 0 days 00:00:03.748281529   40
+              0 days 00:00:03.959315192 0 days 00:00:04.110064420   40
+              0 days 00:00:04.541308146 0 days 00:00:04.962982764   40
+audio/002.wav 0 days 00:00:00.003443562 0 days 00:00:00.037705840   33
+              0 days 00:00:00.796582868 0 days 00:00:01.075538128   33
+              0 days 00:00:01.110602019 0 days 00:00:01.439743769   33
+              0 days 00:00:02.194859538 0 days 00:00:03.675142916   33
+              0 days 00:00:04.187563347 0 days 00:00:04.738401164   33
+audio/003.wav 0 days 00:00:00.574500931 0 days 00:00:00.929483764   38
+              0 days 00:00:01.450303730 0 days 00:00:01.953211769   38
+              0 days 00:00:02.808842477 0 days 00:00:03.099035455   38
+              0 days 00:00:03.225926686 0 days 00:00:04.007331084   38
+              0 days 00:00:04.015322811 0 days 00:00:04.430922264   38
 
 So far we have combined tables using the ``+`` operator.
 The result is a table that is no longer attached to a database.
@@ -99,17 +157,16 @@ as we will demonstrate with the following example.
 First we create a second database
 and add a gender scheme:
 
-.. jupyter-execute::
-
-    db2 = audformat.testing.create_db(minimal=True)
-    db2.schemes["gender"] = audformat.Scheme(
-        labels=["female", "male"],
-    )
-    db2.schemes
+>>> db2 = audformat.testing.create_db(minimal=True)
+>>> db2.schemes["gender"] = audformat.Scheme(labels=["female", "male"])
+>>> db2.schemes
+gender:
+  dtype: str
+  labels: [female, male]
 
 Next, we add a table and fill in some gender information:
 
-.. jupyter-execute::
+.. code-block:: python
 
     audformat.testing.add_table(
         db2,
@@ -121,12 +178,19 @@ Next, we add a table and fill in some gender information:
 
 Now, we update the table with age values from the other database.
 
-.. jupyter-execute::
-
-    db2["gender_and_age"].update(db["age"]).get()
+>>> db2["gender_and_age"].update(db["age"]).get()
+              gender   age
+file
+audio/002.wav   male    33
+audio/003.wav   male    38
+audio/004.wav   male  <NA>
+audio/001.wav    NaN    40
 
 And also copies the according scheme to the database:
 
-.. jupyter-execute::
-
-    db2.schemes
+>>> db2.schemes
+age:
+  {dtype: int, minimum: 20, maximum: 50}
+gender:
+  dtype: str
+  labels: [female, male]

--- a/docs/combine-tables.rst
+++ b/docs/combine-tables.rst
@@ -166,15 +166,18 @@ gender:
 
 Next, we add a table and fill in some gender information:
 
-.. code-block:: python
-
-    audformat.testing.add_table(
-        db2,
-        table_id="gender_and_age",
-        index_type=audformat.define.IndexType.FILEWISE,
-        columns="gender",
-        num_files=[2, 3, 4],
-    ).get()
+>>> audformat.testing.add_table(
+...     db2,
+...     table_id="gender_and_age",
+...     index_type=audformat.define.IndexType.FILEWISE,
+...     columns="gender",
+...     num_files=[2, 3, 4],
+... ).get()
+              gender
+file
+audio/002.wav   male
+audio/003.wav   male
+audio/004.wav   male
 
 Now, we update the table with age values from the other database.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinxcontrib.katex",  # has to be before jupyter_sphinx
-    "jupyter_sphinx",
     "sphinx_apipages",
 ]
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,12 +7,6 @@ from sybil.parsers.rest import PythonCodeBlockParser
 from sybil.parsers.rest import SkipParser
 
 
-# @pytest.fixture(scope="module")
-# def tmpdir(tmpdir_factory):
-#     """Provide tmpdir."""
-#     yield tmpdir_factory.mktemp("tmp")
-
-
 # Collect doctests
 #
 # We use several `sybil.Sybil` instances
@@ -28,36 +22,3 @@ pytest_collect_file = sybil.Sybil(
     pattern="*.rst",
     fixtures=["tmpdir"],
 ).pytest()
-# pytest_collect_file = sybil.sybil.SybilCollection(
-#     (
-#         sybil.Sybil(
-#             parsers=parsers,
-#             filenames=[
-#                 "authentication.rst",
-#                 "overview.rst",
-#                 "quickstart.rst",
-#                 "dependencies.rst",
-#                 "load.rst",
-#                 "audb.info.rst",
-#             ],
-#             fixtures=[
-#                 "cache",
-#                 "run_in_tmpdir",
-#                 "public_repository",
-#             ],
-#             setup=imports,
-#         ),
-#         sybil.Sybil(
-#             parsers=parsers,
-#             filenames=["publish.rst"],
-#             fixtures=["cache", "run_in_tmpdir"],
-#             setup=imports,
-#         ),
-#         sybil.Sybil(
-#             parsers=parsers,
-#             filenames=["configuration.rst", "caching.rst"],
-#             fixtures=["default_configuration"],
-#             setup=imports,
-#         ),
-#     )
-# ).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,6 +7,12 @@ from sybil.parsers.rest import PythonCodeBlockParser
 from sybil.parsers.rest import SkipParser
 
 
+# @pytest.fixture(scope="module")
+# def tmpdir(tmpdir_factory):
+#     """Provide tmpdir."""
+#     yield tmpdir_factory.mktemp("tmp")
+
+
 # Collect doctests
 #
 # We use several `sybil.Sybil` instances
@@ -17,7 +23,11 @@ parsers = [
     PythonCodeBlockParser(),
     SkipParser(),
 ]
-pytest_collect_file = sybil.Sybil(parsers=parsers, pattern="*.rst").pytest()
+pytest_collect_file = sybil.Sybil(
+    parsers=parsers,
+    pattern="*.rst",
+    fixtures=["tmpdir"],
+).pytest()
 # pytest_collect_file = sybil.sybil.SybilCollection(
 #     (
 #         sybil.Sybil(

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,53 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+
+import sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
+
+
+# Collect doctests
+#
+# We use several `sybil.Sybil` instances
+# to pass different fixtures for different files
+#
+parsers = [
+    DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+    PythonCodeBlockParser(),
+    SkipParser(),
+]
+pytest_collect_file = sybil.Sybil(parsers=parsers, pattern="*.rst").pytest()
+# pytest_collect_file = sybil.sybil.SybilCollection(
+#     (
+#         sybil.Sybil(
+#             parsers=parsers,
+#             filenames=[
+#                 "authentication.rst",
+#                 "overview.rst",
+#                 "quickstart.rst",
+#                 "dependencies.rst",
+#                 "load.rst",
+#                 "audb.info.rst",
+#             ],
+#             fixtures=[
+#                 "cache",
+#                 "run_in_tmpdir",
+#                 "public_repository",
+#             ],
+#             setup=imports,
+#         ),
+#         sybil.Sybil(
+#             parsers=parsers,
+#             filenames=["publish.rst"],
+#             fixtures=["cache", "run_in_tmpdir"],
+#             setup=imports,
+#         ),
+#         sybil.Sybil(
+#             parsers=parsers,
+#             filenames=["configuration.rst", "caching.rst"],
+#             fixtures=["default_configuration"],
+#             setup=imports,
+#         ),
+#     )
+# ).pytest()

--- a/docs/create-database.rst
+++ b/docs/create-database.rst
@@ -22,7 +22,7 @@ Let's assume in addition you have
 three raters annotated the files
 for the emotion anger in the range 0 to 5.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import io
 
@@ -47,7 +47,7 @@ Each column has the scheme ID ``anger``
 for the defined scheme covering the emotion anger.
 
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat
 
@@ -89,9 +89,30 @@ for the defined scheme covering the emotion anger.
 
 The resulting :class:`audformat.Database` will then contain:
 
-.. jupyter-execute::
-
-    db
+>>> db
+name: foo
+source: https://github.com/audeering/audformat/
+usage: unrestricted
+languages: []
+media:
+  microphone: {type: audio, format: wav}
+raters:
+  R1: {type: human}
+  R2: {type: human}
+  R3: {type: human}
+schemes:
+  anger: {dtype: int, minimum: 0, maximum: 5}
+splits:
+  train: {type: train}
+tables:
+  anger:
+    type: filewise
+    split_id: train
+    media_id: microphone
+    columns:
+      R1: {scheme_id: anger, rater_id: R1}
+      R2: {scheme_id: anger, rater_id: R2}
+      R3: {scheme_id: anger, rater_id: R3}
 
 For more information on how to define a database,
 have a look at the code examples in the
@@ -107,7 +128,7 @@ without creating one, you can use :mod:`audformat.testing`.
 It provides you with a command to create a database,
 containing all possible :ref:`tables types <data-tables:Tables>`:
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat.testing
 
@@ -116,20 +137,46 @@ containing all possible :ref:`tables types <data-tables:Tables>`:
 
 Which results in the following :class:`audformat.Table` objects:
 
-.. jupyter-execute::
-
-    db.tables
+>>> db.tables
+files:
+  type: filewise
+  split_id: train
+  media_id: microphone
+  columns:
+    bool: {scheme_id: bool, rater_id: gold}
+    date: {scheme_id: date, rater_id: gold}
+    float: {scheme_id: float, rater_id: gold}
+    int: {scheme_id: int, rater_id: gold}
+    label: {scheme_id: label, rater_id: gold}
+    label_map_int: {scheme_id: label_map_int, rater_id: gold}
+    label_map_misc: {scheme_id: label_map_misc, rater_id: gold}
+    label_map_str: {scheme_id: label_map_str, rater_id: gold}
+    string: {scheme_id: string, rater_id: gold}
+    time: {scheme_id: time, rater_id: gold}
+    no_scheme: {}
+segments:
+  type: segmented
+  split_id: dev
+  media_id: microphone
+  columns:
+    bool: {scheme_id: bool, rater_id: gold}
+    date: {scheme_id: date, rater_id: gold}
+    float: {scheme_id: float, rater_id: gold}
+    int: {scheme_id: int, rater_id: gold}
+    label: {scheme_id: label, rater_id: gold}
+    label_map_int: {scheme_id: label_map_int, rater_id: gold}
+    label_map_misc: {scheme_id: label_map_misc, rater_id: gold}
+    label_map_str: {scheme_id: label_map_str, rater_id: gold}
+    string: {scheme_id: string, rater_id: gold}
+    time: {scheme_id: time, rater_id: gold}
+    no_scheme: {}
 
 Or you can create a database,
 containing only the minimum entries,
 required by the :ref:`database specification <data-header:Database>`:
 
-.. jupyter-execute::
-
-    db_minimal = audformat.testing.create_db(minimal=True)
-
-Which results in the following :class:`audformat.Database`:
-
-.. jupyter-execute::
-
-    db_minimal
+>>> audformat.testing.create_db(minimal=True)
+name: unittest
+source: internal
+usage: unrestricted
+languages: [deu, eng]

--- a/docs/data-conventions.rst
+++ b/docs/data-conventions.rst
@@ -1,13 +1,6 @@
 Conventions
 ===========
 
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audformat
-
-
 Database name
 -------------
 
@@ -18,7 +11,9 @@ If you have different versions,
 or very long names you can use ``-``
 to increase readability.
 
-.. jupyter-execute::
+.. code-block:: python
+
+    import audformat
 
     audformat.Database(name="librispeech-mfa-cseg-pho")
 
@@ -60,7 +55,7 @@ Use lower case for table and scheme names.
 If you have multiple raters,
 name each column after the name of the rater.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audformat.Database("mydata")
 
@@ -78,7 +73,28 @@ name each column after the name of the rater.
                 rater_id=rater_id,
             )
 
-    db
+>>> db
+name: mydata
+source: ''
+usage: unrestricted
+languages: []
+raters:
+  rater1: {type: human}
+  rater2: {type: human}
+schemes:
+  arousal: {dtype: float}
+  valence: {dtype: float}
+tables:
+  arousal:
+    type: filewise
+    columns:
+      rater1: {scheme_id: arousal, rater_id: rater1}
+      rater2: {scheme_id: arousal, rater_id: rater2}
+  valence:
+    type: filewise
+    columns:
+      rater1: {scheme_id: valence, rater_id: rater1}
+      rater2: {scheme_id: valence, rater_id: rater2}
 
 
 Database splits
@@ -91,7 +107,7 @@ consists,
 consider one table per split,
 named ``scheme_id.split``.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audformat.Database("mydata")
 
@@ -109,8 +125,22 @@ named ``scheme_id.split``.
                 split_id=split_id,
             )
 
-    db
-        
+>>> db
+name: mydata
+source: ''
+usage: unrestricted
+languages: []
+schemes:
+  arousal: {dtype: float}
+splits:
+  dev: {type: dev}
+  test: {type: test}
+  train: {type: train}
+tables:
+  arousal.dev: {type: filewise, split_id: dev}
+  arousal.test: {type: filewise, split_id: test}
+  arousal.train: {type: filewise, split_id: train}
+
 
 Gold standard annotation
 ------------------------
@@ -130,7 +160,7 @@ should be created
 and associated with the column
 holding the gold standard values.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audformat.Database("mydata")
 
@@ -154,7 +184,27 @@ holding the gold standard values.
             rater_id="gold_standard",
         )
 
-    db
+>>> db
+name: mydata
+source: ''
+usage: unrestricted
+languages: []
+raters:
+  gold_standard: {type: vote}
+  rater1: {type: human}
+  rater2: {type: human}
+schemes:
+  arousal: {dtype: float}
+tables:
+  arousal:
+    type: filewise
+    columns:
+      rater1: {scheme_id: arousal, rater_id: rater1}
+      rater2: {scheme_id: arousal, rater_id: rater2}
+  arousal.gold_standard:
+    type: filewise
+    columns:
+      arousal: {scheme_id: arousal, rater_id: gold_standard}
 
 
 Confidence values
@@ -174,7 +224,7 @@ The confidence values should be stored in a separate table.
 Or it can be stored within the same table as a different column,
 which might be worth considering when storing the gold standard.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audformat.Database("mydata")
 
@@ -194,7 +244,22 @@ which might be worth considering when storing the gold standard.
             rater_id="gold_standard",
         )
 
-    db
+>>> db
+name: mydata
+source: ''
+usage: unrestricted
+languages: []
+raters:
+  gold_standard: {type: vote}
+schemes:
+  arousal: {dtype: float}
+  arousal.confidence: {dtype: float, minimum: 0, maximum: 1}
+tables:
+  arousal:
+    type: filewise
+    columns:
+      arousal: {scheme_id: arousal, rater_id: gold_standard}
+      arousal.confidence: {scheme_id: arousal.confidence, rater_id: gold_standard}
 
 
 File and speaker information
@@ -213,7 +278,7 @@ like age of speaker,
 should be collected in the header
 as it can be later automatically mapped.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audformat.Database("mydata")
 
@@ -231,21 +296,38 @@ as it can be later automatically mapped.
     db["files"]["speaker"] = audformat.Column(scheme_id="speaker")
     db["files"]["speaker"].set(["speaker1", "speaker2"])
 
-    db
-
-
-.. jupyter-execute::
-
-    db["files"].get()
+>>> db
+name: mydata
+source: ''
+usage: unrestricted
+languages: []
+schemes:
+  speaker:
+    dtype: str
+    labels:
+      speaker1: {gender: female, age: 31}
+      speaker2: {gender: male, age: 85}
+tables:
+  files:
+    type: filewise
+    columns:
+      speaker: {scheme_id: speaker}
+>>> db["files"].get()
+        speaker
+file
+a.wav  speaker1
+b.wav  speaker2
 
 You can access the additional information with the ``map`` argument
 of :meth:`audformat.Table.get`,
 see :ref:`map-scheme-labels`
 for an extended documentation.
 
-.. jupyter-execute::
-
-    db["files"].get(map={"speaker": "gender"})
+>>> db["files"].get(map={"speaker": "gender"})
+       gender
+file
+a.wav  female
+b.wav    male
 
 
 Temporal data
@@ -258,7 +340,7 @@ Temporal dates
 like time of rating
 should be stored as :class:`datetime.datetime`.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import pandas as pd
 
@@ -279,4 +361,8 @@ should be stored as :class:`datetime.datetime`.
     )
     db["files"]["time"].set(pd.to_timedelta(times, unit="s"))
 
-    db["files"].get()
+>>> db["files"].get()
+                        time
+file
+a.wav 0 days 00:00:02.100000
+b.wav 0 days 00:00:00.100000

--- a/docs/data-example.rst
+++ b/docs/data-example.rst
@@ -3,48 +3,141 @@ Example
 
 Header (YAML):
 
-.. jupyter-execute::
-
-    import audformat.testing
-
-    db = audformat.testing.create_db()
-    db
+>>> import audformat.testing
+>>> db = audformat.testing.create_db()
+>>> db
+name: unittest
+description: A database for unit testing.
+source: internal
+usage: unrestricted
+languages: [deu, eng]
+author: J. Wagner, H. Wierstorf
+organization: audEERING GmbH
+license: CC0-1.0
+attachments:
+  file: {path: extra/file.txt}
+  folder: {path: extra/folder}
+media:
+  microphone: {type: other, format: wav, channels: 1, bit_depth: 16, sampling_rate: 16000}
+  webcam:
+    type: other
+    format: avi
+    video_fps: 25
+    video_resolution: [800, 600]
+    video_channels: 3
+    video_depth: 8
+raters:
+  gold: {description: Gold standard by taking the average ratings., type: human}
+  machine: {description: Predictions made by the machine., type: machine, classifier: LibSVM,
+    features: ComParE_2016}
+schemes:
+  bool: {dtype: bool}
+  date: {dtype: date}
+  float: {dtype: float, minimum: -1.0, maximum: 1.0}
+  int: {dtype: int, minimum: 0, maximum: 100}
+  label:
+    dtype: str
+    labels: [label1, label2, label3]
+  label_map_int:
+    dtype: int
+    labels: {1: a, 2: b, 3: c}
+  label_map_misc: {dtype: str, labels: misc}
+  label_map_str:
+    dtype: str
+    labels:
+      label1: {prop1: 1, prop2: a}
+      label2: {prop1: 2, prop2: b}
+      label3: {prop1: 3, prop2: c}
+  string: {dtype: str}
+  time: {dtype: time}
+splits:
+  dev: {type: dev}
+  test: {type: test}
+  train: {type: train}
+tables:
+  files:
+    type: filewise
+    split_id: train
+    media_id: microphone
+    columns:
+      bool: {scheme_id: bool, rater_id: gold}
+      date: {scheme_id: date, rater_id: gold}
+      float: {scheme_id: float, rater_id: gold}
+      int: {scheme_id: int, rater_id: gold}
+      label: {scheme_id: label, rater_id: gold}
+      label_map_int: {scheme_id: label_map_int, rater_id: gold}
+      label_map_misc: {scheme_id: label_map_misc, rater_id: gold}
+      label_map_str: {scheme_id: label_map_str, rater_id: gold}
+      string: {scheme_id: string, rater_id: gold}
+      time: {scheme_id: time, rater_id: gold}
+      no_scheme: {}
+  segments:
+    type: segmented
+    split_id: dev
+    media_id: microphone
+    columns:
+      bool: {scheme_id: bool, rater_id: gold}
+      date: {scheme_id: date, rater_id: gold}
+      float: {scheme_id: float, rater_id: gold}
+      int: {scheme_id: int, rater_id: gold}
+      label: {scheme_id: label, rater_id: gold}
+      label_map_int: {scheme_id: label_map_int, rater_id: gold}
+      label_map_misc: {scheme_id: label_map_misc, rater_id: gold}
+      label_map_str: {scheme_id: label_map_str, rater_id: gold}
+      string: {scheme_id: string, rater_id: gold}
+      time: {scheme_id: time, rater_id: gold}
+      no_scheme: {}
+misc_tables:
+  misc:
+    levels: {labels: str}
+    columns:
+      int: {scheme_id: int}
+      label: {scheme_id: label}
+audformat: https://github.com/audeering/audformat
 
 Filewise table as :class:`pd.DataFrame`:
 
-.. jupyter-execute::
-
-    db["files"].get()
-
-and as CSV:
-
-.. jupyter-execute::
-    :hide-code:
-
-    print(db["files"].get().to_csv())
+>>> db["files"].get()
+                bool                    date  ...                   time   no_scheme
+file                                          ...
+audio/001.wav  False                     NaT  ... 0 days 00:00:00.280000  nOqgBuJRkn
+audio/002.wav   <NA>                     NaT  ... 0 days 00:00:00.960000  iMKa6qC99q
+audio/003.wav  False 1970-01-01 00:00:00.640  ... 0 days 00:00:00.520000  MgqdWkARaq
+audio/004.wav  False 1970-01-01 00:00:00.090  ... 0 days 00:00:00.060000        None
+audio/005.wav  False                     NaT  ... 0 days 00:00:00.540000  l8x3NmGtNB
+...              ...                     ...  ...                    ...         ...
+audio/096.wav   True 1970-01-01 00:00:00.160  ... 0 days 00:00:00.180000  Vgv37YqafU
+audio/097.wav   <NA> 1970-01-01 00:00:00.780  ... 0 days 00:00:00.210000  Nr3hn17JSB
+audio/098.wav   True 1970-01-01 00:00:00.750  ... 0 days 00:00:00.620000  FFSFTcMjMu
+audio/099.wav  False 1970-01-01 00:00:00.470  ... 0 days 00:00:00.920000  V49rd5YUQW
+audio/100.wav   <NA> 1970-01-01 00:00:00.610  ... 0 days 00:00:00.280000  zeTXeIT7wb
+<BLANKLINE>
+[100 rows x 11 columns]
 
 Segmented table as :class:`pd.DataFrame`:
 
-.. jupyter-execute::
-
-    db["segments"].get()
-
-and as CSV:
-
-.. jupyter-execute::
-    :hide-code:
-
-    print(db["segments"].get().to_csv())
+>>> db["segments"].get()
+                                                                    bool  ...   no_scheme
+file          start                     end                               ...
+audio/001.wav 0 days 00:00:00.082561829 0 days 00:00:04.832983387   True  ...        None
+              0 days 00:00:09.907641513 0 days 00:00:13.087561565   <NA>  ...        None
+              0 days 00:00:13.422086186 0 days 00:00:16.376171043   True  ...  ZYixPedAyB
+              0 days 00:00:19.276700122 0 days 00:00:25.737048646   True  ...        None
+              0 days 00:00:30.918073408 0 days 00:00:35.168424756   <NA>  ...  s5pS1eh4k7
+...                                                                  ...  ...         ...
+audio/010.wav 0 days 00:00:18.786962756 0 days 00:00:29.510792049  False  ...        None
+              0 days 00:00:30.691782517 0 days 00:00:33.635262781  False  ...  jWjGWGeIYX
+              0 days 00:00:34.058263452 0 days 00:00:34.149017810  False  ...        None
+              0 days 00:00:45.930182929 0 days 00:00:49.444541600  False  ...  Zz7W7ZlYXJ
+              0 days 00:00:51.577189767 0 days 00:00:56.646463227   True  ...        None
+<BLANKLINE>
+[100 rows x 11 columns]
 
 Misc table as :class:`pd.DataFrame`:
 
-.. jupyter-execute::
-    
-    db["misc"].get()
-
-and as CSV:
-
-.. jupyter-execute::
-    :hide-code:
-
-    print(db["misc"].get().to_csv())
+>>> db["misc"].get()
+        int   label
+labels
+label1   26  label2
+label2    0  label3
+label3   56  label3

--- a/docs/data-header.rst
+++ b/docs/data-header.rst
@@ -62,18 +62,13 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: python
-
-    import audformat
-
-
-    # Create Database
-    db = audformat.Database(
-        name="databasename",
-        source="https://gitlab.audeering.com/data/databasename",
-        usage="commercial",
-    )
-
+>>> import audformat
+>>> # Create Database
+>>> db = audformat.Database(
+...     name="databasename",
+...     source="https://gitlab.audeering.com/data/databasename",
+...     usage="commercial",
+... )
 >>> db
 name: databasename
 source: https://gitlab.audeering.com/data/databasename

--- a/docs/data-header.rst
+++ b/docs/data-header.rst
@@ -62,7 +62,7 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat
 
@@ -73,7 +73,12 @@ audformat implementation
         source="https://gitlab.audeering.com/data/databasename",
         usage="commercial",
     )
-    db
+
+>>> db
+name: databasename
+source: https://gitlab.audeering.com/data/databasename
+usage: commercial
+languages: []
 
 
 Attachment
@@ -103,16 +108,17 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Attachment
-    attachment = audformat.Attachment("docs/setup.pdf")
-    # Add Attachment to Database
-    db.attachments["attachmentid"] = attachment
-    # Access path of Attachment
-    db.attachments["attachmentid"].path
-    # Access attachments
-    db.attachments
+>>> # Create minimal Attachment
+>>> attachment = audformat.Attachment("docs/setup.pdf")
+>>> # Add Attachment to Database
+>>> db.attachments["attachmentid"] = attachment
+>>> # Access path of Attachment
+>>> db.attachments["attachmentid"].path
+'docs/setup.pdf'
+>>> # Access attachments
+>>> db.attachments
+attachmentid:
+  {path: docs/setup.pdf}
 
 
 Rater
@@ -144,16 +150,17 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Rater
-    rater = audformat.Rater("human")
-    # Add Rater to Database
-    db.raters["raterid"] = rater
-    # Access type of Rater
-    db.raters["raterid"].type
-    # Access raters
-    db.raters
+>>> # Create minimal Rater
+>>> rater = audformat.Rater("human")
+>>> # Add Rater to Database
+>>> db.raters["raterid"] = rater
+>>> # Access type of Rater
+>>> db.raters["raterid"].type
+'human'
+>>> # Access raters
+>>> db.raters
+raterid:
+  {type: human}
 
 
 Scheme
@@ -192,16 +199,17 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Scheme
-    scheme = audformat.Scheme("float")
-    # Add Scheme to Database
-    db.schemes["schemeid"] = scheme
-    # Access dtype of Scheme
-    db.schemes["schemeid"].dtype
-    # Access schemes
-    db.schemes
+>>> # Create minimal Scheme
+>>> scheme = audformat.Scheme("float")
+>>> # Add Scheme to Database
+>>> db.schemes["schemeid"] = scheme
+>>> # Access dtype of Scheme
+>>> db.schemes["schemeid"].dtype
+'float'
+>>> # Access schemes
+>>> db.schemes
+schemeid:
+  {dtype: float}
 
 
 Split
@@ -233,16 +241,17 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Split
-    split = audformat.Split("test")
-    # Add Split to Database
-    db.splits["splitid"] = split
-    # Access type of Split
-    db.splits["splitid"].type
-    # Access splits
-    db.splits
+>>> # Create minimal Split
+>>> split = audformat.Split("test")
+>>> # Add Split to Database
+>>> db.splits["splitid"] = split
+>>> # Access type of Split
+>>> db.splits["splitid"].type
+'test'
+>>> # Access splits
+>>> db.splits
+splitid:
+  {type: test}
 
 
 Media
@@ -284,16 +293,17 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal media information
-    media = audformat.Media("audio")
-    # Add media to Database
-    db.media["mediaid"] = media
-    # Access type of Media
-    db.media["mediaid"].type
-    # Access media
-    db.media
+>>> # Create minimal media information
+>>> media = audformat.Media("audio")
+>>> # Add media to Database
+>>> db.media["mediaid"] = media
+>>> # Access type of Media
+>>> db.media["mediaid"].type
+'audio'
+>>> # Access media
+>>> db.media
+mediaid:
+  {type: audio}
 
 
 Table
@@ -327,20 +337,22 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Table
-    table = audformat.Table(audformat.filewise_index())
-    # Add Table to Database
-    db.tables["tableid"] = table
-    # Access type of Table
-    db.tables["tableid"].type
-    # Add Table to Database (short notation)
-    db["tableid"] = table
-    # Access type of Table (short notation)
-    db["tableid"].type
-    # Access tables
-    db.tables
+>>> # Create minimal Table
+>>> table = audformat.Table(audformat.filewise_index())
+>>> # Add Table to Database
+>>> db.tables["tableid"] = table
+>>> # Access type of Table
+>>> db.tables["tableid"].type
+'filewise'
+>>> # Add Table to Database (short notation)
+>>> db["tableid"] = table
+>>> # Access type of Table (short notation)
+>>> db["tableid"].type
+'filewise'
+>>> # Access tables
+>>> db.tables
+tableid:
+  {type: filewise}
 
 
 Misc Table
@@ -373,21 +385,27 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Misc Table
-    import pandas as pd
-    misc_table = audformat.MiscTable(pd.Index([], name="idx"))
-    # Add Misc Table to Database
-    db.misc_tables["misctableid"] = misc_table
-    # Access dataframe of Misc Table
-    db.misc_tables["misctableid"].df
-    # Add Misc Table to Database (short notation)
-    db["misctableid"] = misc_table
-    # Access dataframe of Misc Table (short notation)
-    db["misctableid"].df
-    # Access misc tables
-    db.misc_tables
+>>> # Create minimal Misc Table
+>>> import pandas as pd
+>>> misc_table = audformat.MiscTable(pd.Index([], name="idx"))
+>>> # Add Misc Table to Database
+>>> db.misc_tables["misctableid"] = misc_table
+>>> # Access dataframe of Misc Table
+>>> db.misc_tables["misctableid"].df
+Empty DataFrame
+Columns: []
+Index: []
+>>> # Add Misc Table to Database (short notation)
+>>> db["misctableid"] = misc_table
+>>> # Access dataframe of Misc Table (short notation)
+>>> db["misctableid"].df
+Empty DataFrame
+Columns: []
+Index: []
+>>> # Access misc tables
+>>> db.misc_tables
+misctableid:
+  levels: {idx: object}
 
 
 Column
@@ -421,13 +439,13 @@ Minimal example
 audformat implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. jupyter-execute::
-
-    # Create minimal Column
-    column = audformat.Column()
-    # Add Column to Table
-    db.tables["tableid"].columns["columnid"] = column
-    # Add Column to Table (short notation)
-    db["tableid"]["columnid"] = column
-    # Access columns
-    db["tableid"].columns
+>>> # Create minimal Column
+>>> column = audformat.Column()
+>>> # Add Column to Table
+>>> db.tables["tableid"].columns["columnid"] = column
+>>> # Add Column to Table (short notation)
+>>> db["tableid"]["columnid"] = column
+>>> # Access columns
+>>> db["tableid"].columns
+columnid:
+  {}

--- a/docs/data-misc-tables.rst
+++ b/docs/data-misc-tables.rst
@@ -32,10 +32,10 @@ Create an index with the levels ``"file"`` and ``"other"``:
     )
 
 >>> index
-    MultiIndex([('f1', 'f2'),
-                ('f1', 'f3'),
-                ('f2', 'f3')],
-               names=['file', 'other'])
+MultiIndex([('f1', 'f2'),
+            ('f1', 'f3'),
+            ('f2', 'f3')],
+           names=['file', 'other'])
 
 Create database and add misc table with the index:
 

--- a/docs/data-misc-tables.rst
+++ b/docs/data-misc-tables.rst
@@ -1,17 +1,6 @@
 Misc Tables
 ===========
 
-.. Enforce HTML output for pd.Series
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audformat
-
-
-    audformat.core.common.format_series_as_html()
-
-
 A miscellaneous (misc) table links labels to an index.
 The index has no restrictions
 and can contain an arbitrary number of columns (called levels),
@@ -26,7 +15,7 @@ audformat implementation
 
 Create an index with the levels ``"file"`` and ``"other"``:
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat
     import audformat.testing
@@ -41,45 +30,49 @@ Create an index with the levels ``"file"`` and ``"other"``:
         ],
         names=["file", "other"],
     )
-    index
+
+>>> index
+    MultiIndex([('f1', 'f2'),
+                ('f1', 'f3'),
+                ('f2', 'f3')],
+               names=['file', 'other'])
 
 Create database and add misc table with the index:
 
-.. jupyter-execute::
-
-    db = audformat.testing.create_db(minimal=True)
-    db["misc"] = audformat.MiscTable(index)
-    db["misc"]["values"] = audformat.Column()
-    db.misc_tables["misc"]
+>>> db = audformat.testing.create_db(minimal=True)
+>>> db["misc"] = audformat.MiscTable(index)
+>>> db["misc"]["values"] = audformat.Column()
+>>> db.misc_tables["misc"]
+levels: {file: object, other: object}
+columns:
+  values: {}
 
 Assign labels to a table:
 
-.. jupyter-execute::
-
-    values_list = [0, 1, 0]
-    values_dict = {"values": values_list}
-    db["misc"].set(values_dict)
-
-Access labels as :class:`pandas.DataFrame`:
-
-.. jupyter-execute::
-
-    db["misc"].get()
+>>> values_list = [0, 1, 0]
+>>> values_dict = {"values": values_list}
+>>> db["misc"].set(values_dict)
+>>> db["misc"].get()
+           values
+file other
+f1   f2         0
+     f3         1
+f2   f3         0
 
 Assign labels to a column:
 
-.. jupyter-execute::
-
-    db["misc"]["values"].set(values_list)
-
-Access labels as :class:`pandas.Series`
-
-.. jupyter-execute::
-
-    db["misc"]["values"].get()
+>>> db["misc"]["values"].set(values_list)
+>>> db["misc"]["values"].get()
+file  other
+f1    f2       0
+      f3       1
+f2    f3       0
+Name: values, dtype: object
 
 Access labels from a misc table with an index:
 
-.. jupyter-execute::
-
-    db["misc"].get(index[:2])
+>>> db["misc"].get(index[:2])
+           values
+file other
+f1   f2         0
+     f3         1

--- a/docs/data-tables.rst
+++ b/docs/data-tables.rst
@@ -1,17 +1,6 @@
 Tables
 ======
 
-.. Enforce HTML output for pd.Series
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audformat
-
-
-    audformat.core.common.format_series_as_html()
-
-
 A table links labels to media files.
 It consists of one or three index columns
 followed by an arbitrary number of label columns.
@@ -40,75 +29,82 @@ audformat implementation
 
 Create a filewise index:
 
-.. jupyter-execute::
-
-    import audformat
-    import audformat.testing
-
-
-    filewise_index = audformat.filewise_index(
-        ["f1", "f2", "f3"],
-    )
-    filewise_index
+>>> import audformat
+>>> filewise_index = audformat.filewise_index(["f1", "f2", "f3"])
+>>> filewise_index
+Index(['f1', 'f2', 'f3'], dtype='string', name='file')
 
 Create database and add table with a filewise index:
 
-.. jupyter-execute::
-
-    db = audformat.testing.create_db(minimal=True)
-    db["filewise"] = audformat.Table(filewise_index)
-    db["filewise"]["values"] = audformat.Column()
-    db.tables["filewise"]
+>>> db = audformat.Database("mydb")
+>>> db["filewise"] = audformat.Table(filewise_index)
+>>> db["filewise"]["values"] = audformat.Column()
+>>> db.tables["filewise"]
+type: filewise
+columns:
+  values: {}
 
 Assign labels to a table:
 
-.. jupyter-execute::
-
-    values_list = [1, 2, 3]
-    values_dict = {"values": values_list}
-    db["filewise"].set(values_dict)
+>>> values_list = [1, 2, 3]
+>>> values_dict = {"values": values_list}
+>>> db["filewise"].set(values_dict)
 
 Access labels as :class:`pandas.DataFrame`:
 
-.. jupyter-execute::
-
-    db["filewise"].get()
+>>> db["filewise"].get()
+     values
+file
+f1        1
+f2        2
+f3        3
 
 Assign labels to a column:
 
-.. jupyter-execute::
-
-    db["filewise"]["values"].set(values_list)
+>>> db["filewise"]["values"].set(values_list)
 
 Access labels as :class:`pandas.Series`
 
-.. jupyter-execute::
-
-    db["filewise"]["values"].get()
+>>> db["filewise"]["values"].get()
+file
+f1    1
+f2    2
+f3    3
+Name: values, dtype: object
 
 Access labels and convert index to a segmented index:
 
-.. jupyter-execute::
-
-    db["filewise"]["values"].get(as_segmented=True)
+>>> db["filewise"]["values"].get(as_segmented=True)
+file  start   end
+f1    0 days  NaT    1
+f2    0 days  NaT    2
+f3    0 days  NaT    3
+Name: values, dtype: object
 
 Access labels from a filewise table with a segmented index:
 
-.. jupyter-execute::
-
-    segmented_index = audformat.segmented_index(
-        files=["f1", "f1", "f1", "f2"],
-        starts=["0s", "1s", "2s", "0s"],
-        ends=["1s", "2s", "3s", None],
-    )
-    db["filewise"].get(segmented_index)
+>>> segmented_index = audformat.segmented_index(
+...     files=["f1", "f1", "f1", "f2"],
+...     starts=["0s", "1s", "2s", "0s"],
+...     ends=["1s", "2s", "3s", None],
+... )
+>>> db["filewise"].get(segmented_index)
+                                     values
+file start           end
+f1   0 days 00:00:00 0 days 00:00:01      1
+     0 days 00:00:01 0 days 00:00:02      1
+     0 days 00:00:02 0 days 00:00:03      1
+f2   0 days 00:00:00 NaT                  2
 
 Access labels from a filewise column with a segmented index:
 
-.. jupyter-execute::
-
-    db["filewise"]["values"].get(segmented_index)
-    
+>>> db["filewise"]["values"].get(segmented_index)
+file  start            end
+f1   0 days 00:00:00 0 days 00:00:01      1
+     0 days 00:00:01 0 days 00:00:02      1
+     0 days 00:00:02 0 days 00:00:03      1
+f2   0 days 00:00:00 NaT                  2
+Name: values, dtype: object
 
 Segmented
 ---------
@@ -128,60 +124,77 @@ audformat implementation
 
 Create a segmented index:
 
-.. jupyter-execute::
-
-    segmented_index = audformat.segmented_index(
-        files=["f1", "f1", "f1", "f2", "f3"],
-        starts=["0s", "1s", "2s", "0s", "1m"],
-        ends=["1s", "2s", "3s", None, "1h"],
-    )
-    segmented_index
+>>> segmented_index = audformat.segmented_index(
+...     files=["f1", "f1", "f1", "f2", "f3"],
+...     starts=["0s", "1s", "2s", "0s", "1m"],
+...     ends=["1s", "2s", "3s", None, "1h"],
+... )
+>>> segmented_index
+MultiIndex([('f1', '0 days 00:00:00', '0 days 00:00:01'),
+            ('f1', '0 days 00:00:01', '0 days 00:00:02'),
+            ('f1', '0 days 00:00:02', '0 days 00:00:03'),
+            ('f2', '0 days 00:00:00',               NaT),
+            ('f3', '0 days 00:01:00', '0 days 01:00:00')],
+           names=['file', 'start', 'end'])
 
 Add table with a segmented index:
 
-.. jupyter-execute::
-
-    db["segmented"] = audformat.Table(segmented_index)
-    db["segmented"]["values"] = audformat.Column()
-    db.tables["segmented"]
+>>> db["segmented"] = audformat.Table(segmented_index)
+>>> db["segmented"]["values"] = audformat.Column()
+>>> db.tables["segmented"]
+type: segmented
+columns:
+  values: {}
 
 Assign labels to the whole table:
 
-.. jupyter-execute::
-
-    values_list = [1, 2, 3, 4, 5]
-    values_dict = {"values": values_list}
-    db["segmented"].set(values_dict)
+>>> values_list = [1, 2, 3, 4, 5]
+>>> values_dict = {"values": values_list}
+>>> db["segmented"].set(values_dict)
 
 Access all labels as :class:`pandas.DataFrame`:
 
-.. jupyter-execute::
-
-    db["segmented"].get()
+>>> db["segmented"].get()
+                                     values
+file start           end
+f1   0 days 00:00:00 0 days 00:00:01      1
+     0 days 00:00:01 0 days 00:00:02      2
+     0 days 00:00:02 0 days 00:00:03      3
+f2   0 days 00:00:00 NaT                  4
+f3   0 days 00:01:00 0 days 01:00:00      5
 
 Assign labels to a column:
 
-.. jupyter-execute::
-
-    db["segmented"]["values"].set(values_list)
+>>> db["segmented"]["values"].set(values_list)
 
 Access labels from a column as :class:`pandas.Series`:
 
-.. jupyter-execute::
-
-    db["segmented"]["values"].get()
+>>> db["segmented"]["values"].get()
+file  start            end
+f1    0 days 00:00:00  0 days 00:00:01    1
+      0 days 00:00:01  0 days 00:00:02    2
+      0 days 00:00:02  0 days 00:00:03    3
+f2    0 days 00:00:00  NaT                4
+f3    0 days 00:01:00  0 days 01:00:00    5
+Name: values, dtype: object
 
 Access labels from a segmented table with a filewise index:
 
-.. jupyter-execute::
-
-    filewise_index = audformat.filewise_index(
-        ["f1", "f2"],
-    )
-    db["segmented"].get(filewise_index)
+>>> filewise_index = audformat.filewise_index(["f1", "f2"])
+>>> db["segmented"].get(filewise_index)
+                                     values
+file start           end
+f1   0 days 00:00:00 0 days 00:00:01      1
+     0 days 00:00:01 0 days 00:00:02      2
+     0 days 00:00:02 0 days 00:00:03      3
+f2   0 days 00:00:00 NaT                  4
 
 Access labels from a segmented column with a filewise index:
 
-.. jupyter-execute::
-
-    db["segmented"]["values"].get(filewise_index)
+>>> db["segmented"]["values"].get(filewise_index)
+file  start            end
+f1    0 days 00:00:00  0 days 00:00:01    1
+      0 days 00:00:01  0 days 00:00:02    2
+      0 days 00:00:02  0 days 00:00:03    3
+f2    0 days 00:00:00  NaT                4
+Name: values, dtype: object

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -45,8 +45,8 @@ of the database.
 
 First, have a look at the file names.
 
->>> sorted(os.listdir(os.path.join(src_dir, "wav"))[:3])
-['08b01Fd.wav', '08b03Fe.wav', '16a01Ec.wav']
+>>> sorted(os.listdir(os.path.join(src_dir, "wav")))[:3]
+['03a01Fa.wav', '03a01Nc.wav', '03a01Wa.wav']
 
 As described in the `emodb documentation`_
 the encoding is the following.

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -27,6 +27,7 @@ to the folder :file:`emodb-src`.
     # Get database source
     source = "http://emodb.bilderbar.info/download/download.zip"
     src_dir = "emodb-src"
+    audeer.rmdir(src_dir)
     if not os.path.exists(src_dir):
         urllib.request.urlretrieve(source, "emodb.zip")
         audeer.extract_archive("emodb.zip", src_dir)

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -173,7 +173,7 @@ to the emotion table.
         decimal=",",
         engine="python",
     ).squeeze("columns")
-    y.index = audformat.utils.expand_file_path(y.index, "wav/")
+    y.index = "wav/" + y.index
     y = y.loc[files]
     y = y.replace(to_replace=u"\xa0", value="", regex=True)
     y = y.replace(to_replace=",", value=".", regex=True)

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -168,7 +168,7 @@ to the emotion table.
         os.path.join(src_dir, "erkennung.txt"),
         usecols=["Satz", "erkannt"],
         index_col="Satz",
-        sep=r"\s+",
+        sep="\s+",
         encoding="Latin-1",
         decimal=",",
         converters={"Satz": lambda x: os.path.join("wav", x)},

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -149,7 +149,7 @@ to the emotion table.
     )
 
     files = sorted(
-        [os.path.join("wav", f) for f in os.listdir(os.path.join(src_dir, "wav"))]
+        [f"wav/{f}" for f in os.listdir(os.path.join(src_dir, "wav"))]
     )
     names = [audeer.basename_wo_ext(f) for f in files]
 

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -168,7 +168,7 @@ to the emotion table.
         os.path.join(src_dir, "erkennung.txt"),
         usecols=["Satz", "erkannt"],
         index_col="Satz",
-        sep="\s+",
+        sep=r"\s+",
         encoding="Latin-1",
         decimal=",",
         converters={"Satz": lambda x: os.path.join("wav", x)},

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -31,8 +31,8 @@ to the folder :file:`emodb-src`.
         urllib.request.urlretrieve(source, "emodb.zip")
         audeer.extract_archive("emodb.zip", src_dir)
 
->>> os.listdir(src_dir)
-['lablaut', 'silb', 'wav', 'erklaerung.txt', 'labsilb', 'erkennung.txt']
+>>> sorted(os.listdir(src_dir))
+['erkennung.txt', 'erklaerung.txt', 'lablaut', 'labsilb', 'silb', 'wav']
 
 
 Gather metadata and annotations
@@ -45,8 +45,8 @@ of the database.
 
 First, have a look at the file names.
 
->>> os.listdir(os.path.join(src_dir, "wav"))[:3]
-['16a01Ec.wav', '08b01Fd.wav', '08b03Fe.wav']
+>>> sorted(os.listdir(os.path.join(src_dir, "wav"))[:3])
+['08b01Fd.wav', '08b03Fe.wav', '16a01Ec.wav']
 
 As described in the `emodb documentation`_
 the encoding is the following.
@@ -481,8 +481,8 @@ that the media files are located at the correct position ourselves.
     )
     db.save(db_dir)
 
->>> os.listdir(db_dir)
-['wav', 'db.speaker.parquet', 'db.emotion.parquet', 'db.yaml', 'db.files.parquet']
+>>> sorted(os.listdir(db_dir))
+['db.emotion.parquet', 'db.files.parquet', 'db.speaker.parquet', 'db.yaml', 'wav']
 
 You can read the database from disk as well.
 

--- a/docs/emodb-example.rst
+++ b/docs/emodb-example.rst
@@ -27,7 +27,6 @@ to the folder :file:`emodb-src`.
     # Get database source
     source = "http://emodb.bilderbar.info/download/download.zip"
     src_dir = "emodb-src"
-    audeer.rmdir(src_dir)
     if not os.path.exists(src_dir):
         urllib.request.urlretrieve(source, "emodb.zip")
         audeer.extract_archive("emodb.zip", src_dir)
@@ -169,11 +168,12 @@ to the emotion table.
         os.path.join(src_dir, "erkennung.txt"),
         usecols=["Satz", "erkannt"],
         index_col="Satz",
-        sep=r"\s+",
+        sep=r"\t",
         encoding="Latin-1",
         decimal=",",
-        converters={"Satz": lambda x: os.path.join("wav", x)},
+        engine="python",
     ).squeeze("columns")
+    y.index = audformat.utils.expand_file_path(y.index, "wav/")
     y = y.loc[files]
     y = y.replace(to_replace=u"\xa0", value="", regex=True)
     y = y.replace(to_replace=",", value=".", regex=True)

--- a/docs/map-scheme.rst
+++ b/docs/map-scheme.rst
@@ -3,17 +3,6 @@
 Map scheme labels
 =================
 
-.. Enforce HTML output for pd.Series
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audformat
-
-
-    audformat.core.common.format_series_as_html()
-
-
 The ``labels`` attribute of schemes can be used to
 encode additional information about the table data.
 In the following example we have a scheme
@@ -21,8 +10,7 @@ In the following example we have a scheme
 And a scheme ``"speaker"`` that holds gender and age
 information about the speakers in the database.
 
-.. jupyter-execute::
-    :hide-output:
+.. code-block:: python
 
     import audformat.testing
 
@@ -58,67 +46,103 @@ information about the speakers in the database.
 If we request the ``transcription`` column,
 we get a :class:`pandas.Series` with the word IDs:
 
-.. jupyter-execute::
-
-    db["files"]["transcription"].get()
+>>> db["files"]["transcription"].get()
+file
+audio/001.wav    0
+audio/002.wav    1
+audio/003.wav    1                                                                                                                                                        audio/004.wav    0
+audio/005.wav    0
+Name: transcription, dtype: category
+Categories (2, int64): [0, 1]
 
 But if we are interested in the actual transcribed words,
 we can use the ``map`` argument to request them.
 
-.. jupyter-execute::
-
-    db["files"]["transcription"].get(map="transcription")
+>>> db["files"]["transcription"].get(map="transcription")
+file
+audio/001.wav      hello
+audio/002.wav    goodbye
+audio/003.wav    goodbye
+audio/004.wav      hello
+audio/005.wav      hello
+Name: transcription, dtype: string
 
 Note that we can pass any string to ``map``.
 It will be used as the name of
 the returned :class:`pandas.Series`.
 
-.. jupyter-execute::
-
-    db["files"]["transcription"].get(map="word")
+>>> db["files"]["transcription"].get(map="word")
+file
+audio/001.wav      hello
+audio/002.wav    goodbye
+audio/003.wav    goodbye
+audio/004.wav      hello
+audio/005.wav      hello
+Name: word, dtype: string
 
 Likewise, if we request the speaker column,
 a list of names is returned:
 
-.. jupyter-execute::
-
-    db["files"]["speaker"].get()
+>>> db["files"]["speaker"].get()
+file
+audio/001.wav    spk2
+audio/002.wav    spk1
+audio/003.wav    spk1
+audio/004.wav    spk1
+audio/005.wav    spk3
+Name: speaker, dtype: category
+Categories (3, object): ['spk1', 'spk2', 'spk3']
 
 If we are interested in the age of the speakers, we can do:
 
-.. jupyter-execute::
-
-    db["files"]["speaker"].get(map="age")
+>>> db["files"]["speaker"].get(map="age")
+file
+audio/001.wav    30
+audio/002.wav    33
+audio/003.wav    33
+audio/004.wav    33
+audio/005.wav    37
+Name: age, dtype: Int64
 
 This also works for tables.
 Here we pass a dictionary with column names
 as keys and scheme fields as values.
 
-.. jupyter-execute::
-
-    map = {
-        "speaker": "age",
-    }
-    db["files"].get(map=map)
+>>> map = {"speaker": "age"}
+>>> db["files"].get(map=map)
+              transcription  age
+file
+audio/001.wav             0   30
+audio/002.wav             1   33
+audio/003.wav             1   33
+audio/004.wav             0   33
+audio/005.wav             0   37
 
 It is possible to map several columns at once
 and to map the same column to multiple fields.
 
 .. jupyter-execute::
 
-    map = {
-        "transcription": "words",
-        "speaker": ["age", "gender"],
-    }
-    db["files"].get(map=map)
+>>> map = {"transcription": "words", "speaker": ["age", "gender"]}
+>>> db["files"].get(map=map)
+                 words  age  gender                                                                                                                                           file                                                                                                                                                                          audio/001.wav    hello   30  female
+audio/002.wav  goodbye   33    male
+audio/003.wav  goodbye   33    male
+audio/004.wav    hello   33    male
+audio/005.wav    hello   37    male
 
 To keep the original columns values,
 we can include the column name in the list.
 
-.. jupyter-execute::
-
-    map = {
-        "transcription": ["transcription", "words"],
-        "speaker": ["speaker", "age", "gender"],
-    }
-    db["files"].get(map=map)
+>>> map = {
+...     "transcription": ["transcription", "words"],
+...     "speaker": ["speaker", "age", "gender"],
+... }
+>>> db["files"].get(map=map)
+              speaker transcription    words  age  gender
+file
+audio/001.wav    spk2             0    hello   30  female
+audio/002.wav    spk1             1  goodbye   33    male
+audio/003.wav    spk1             1  goodbye   33    male
+audio/004.wav    spk1             0    hello   33    male
+audio/005.wav    spk3             0    hello   37    male

--- a/docs/map-scheme.rst
+++ b/docs/map-scheme.rst
@@ -121,8 +121,6 @@ audio/005.wav             0   37
 It is possible to map several columns at once
 and to map the same column to multiple fields.
 
-.. jupyter-execute::
-
 >>> map = {"transcription": "words", "speaker": ["age", "gender"]}
 >>> db["files"].get(map=map)
                  words  age  gender                                                                                                                                           file                                                                                                                                                                          audio/001.wav    hello   30  female

--- a/docs/map-scheme.rst
+++ b/docs/map-scheme.rst
@@ -123,7 +123,9 @@ and to map the same column to multiple fields.
 
 >>> map = {"transcription": "words", "speaker": ["age", "gender"]}
 >>> db["files"].get(map=map)
-                 words  age  gender                                                                                                                                           file                                                                                                                                                                          audio/001.wav    hello   30  female
+                 words  age  gender
+file
+audio/001.wav    hello   30  female
 audio/002.wav  goodbye   33    male
 audio/003.wav  goodbye   33    male
 audio/004.wav    hello   33    male

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
 graphviz
-ipykernel
-jupyter-sphinx
 pyarrow  # https://github.com/pandas-dev/pandas/issues/54466
 sphinx
 sphinx-apipages >=0.1.2

--- a/docs/update-database.rst
+++ b/docs/update-database.rst
@@ -8,7 +8,7 @@ is the possibility to update a :class:`audformat.Database`.
 For instance, consider the following database that contains
 age labels for a hundred files.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audformat
     import audformat.testing
@@ -27,17 +27,41 @@ age labels for a hundred files.
         columns="age",
         num_files=100,
     )
-    db
 
-.. jupyter-execute::
-
-    db["table"].df
+>>> db
+name: unittest
+source: internal
+usage: unrestricted
+languages: [deu, eng]
+schemes:
+  age: {dtype: int, minimum: 20, maximum: 50}
+tables:
+  table:
+    type: filewise
+    columns:
+      age: {scheme_id: age}
+>>> db["table"].df
+               age
+file
+audio/001.wav   44
+audio/002.wav   36
+audio/003.wav   24
+audio/004.wav   44
+audio/005.wav   37
+...            ...
+audio/096.wav   23
+audio/097.wav   42
+audio/098.wav   35
+audio/099.wav   27
+audio/100.wav   39
+<BLANKLINE>
+[100 rows x 1 columns]
 
 Now assume we record more files to add to our original database.
 The new files are stored together with annotations in a second database,
 that is then added to the original database.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db_update = audformat.testing.create_db(minimal=True)
     db_update.schemes["age"] = db.schemes["age"]
@@ -49,13 +73,29 @@ that is then added to the original database.
         num_files=range(101, 105),
     )
     db.update(db_update)  # update original database with new data
-    db["table"].df
+
+>>> db["table"].df
+               age
+file
+audio/001.wav   44
+audio/002.wav   36
+audio/003.wav   24
+audio/004.wav   44
+audio/005.wav   37
+...            ...
+audio/100.wav   39
+audio/101.wav   46
+audio/102.wav   43
+audio/103.wav   21
+audio/104.wav   45
+<BLANKLINE>
+[104 rows x 1 columns]
 
 Or we find out that some files in the original database have wrong labels.
 To update those, we again start from a fresh database containing only
 the critical files, relabel them and then update the original database.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db_update = audformat.testing.create_db(minimal=True)
     db_update.schemes["age"] = db.schemes["age"]
@@ -67,13 +107,29 @@ the critical files, relabel them and then update the original database.
         num_files=10,
     )
     db.update(db_update, overwrite=True)  # overwrite existing labels
-    db["table"].df
+
+>>> db["table"].df
+               age
+file
+audio/001.wav   48
+audio/002.wav   45
+audio/003.wav   28
+audio/004.wav   35
+audio/005.wav   37
+...            ...
+audio/100.wav   39
+audio/101.wav   46
+audio/102.wav   43
+audio/103.wav   21
+audio/104.wav   45
+<BLANKLINE>
+[104 rows x 1 columns]
 
 Finally, we want to add gender information to the database.
 Again, it might be easier to start with a fresh database to
 collect the new labels and only later merge it into our original database.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db_update = audformat.Database(
         name="update",
@@ -90,11 +146,30 @@ collect the new labels and only later merge it into our original database.
         num_files=len(db.files),
     )
     db.update(db_update)
-    db["table"].df
+
+>>> db["table"].df
+               age  gender
+file
+audio/001.wav   48    male
+audio/002.wav   45    male
+audio/003.wav   28    male
+audio/004.wav   35    male
+audio/005.wav   37  female
+...            ...     ...
+audio/100.wav   39    male
+audio/101.wav   46  female
+audio/102.wav   43    male
+audio/103.wav   21    male
+audio/104.wav   45    male
+<BLANKLINE>
+[104 rows x 2 columns]
 
 Note that this not only updates the table data,
 but also adds the new gender scheme:
 
-.. jupyter-execute::
-
-    db.schemes
+>>> db.schemes
+age:
+  {dtype: int, minimum: 20, maximum: 50}
+gender:
+  dtype: str
+  labels: [female, male]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,11 @@ ignore-words-list = 'Sie,sie,unter,ist,ba'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
+    -p no:doctest
     --cov=audformat
     --cov-fail-under=100
     --cov-report term-missing
     --cov-report xml
-    --ignore=docs/
     --ignore=benchmarks/
 '''
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-doctestplus
 pytest-console-scripts
 pytest-cov
+sybil

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,6 @@ audb
 audiofile >=1.1.0
 pandas >=2.0.0
 pytest
-pytest-doctestplus
 pytest-console-scripts
 pytest-cov
 sybil


### PR DESCRIPTION
Remove `jupyter-execute` extension from the documentation build process and start using `sybil` instead to test docstrings and the documentation.

## Summary by Sourcery

Tests:
- Use sybil for running doctests.

## Summary by Sourcery

Refactor documentation testing to use sybil instead of jupyter-execute. This change simplifies the documentation build process and improves the reliability of doctests.

Tests:
- Use sybil for running doctests in .py files.
- Use sybil for running doctests in .rst files.
- Remove pytest-doctestplus dependency.
- Skip doctests that depend on the OS platform.