### PR TITLE
Fix Database.update() for misc tables

### DIFF
--- a/audformat/core/database.py
+++ b/audformat/core/database.py
@@ -1245,7 +1245,7 @@ class Database(HeaderBase):
         for other in others:
             for table_id in list(other.misc_tables) + list(other.tables):
                 table = other[table_id]
-                if table_id in self.tables:
+                if table_id in list(self):
                     self[table_id].update(table, overwrite=overwrite)
                 else:
                     self[table_id] = table.copy()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -970,7 +970,8 @@ def test_update_misc_table():
 
     This addresses the particular case
     of adding a new column
-    to the table,
+    to a misc table
+    in a database having only a single table,
     which was failing as described in
     https://github.com/audeering/audformat/issues/466
 
@@ -992,10 +993,8 @@ def test_update_misc_table():
     db2["sessions"]["prompt_2"].set(["response2"])
     df2 = db2["sessions"].df.copy()
 
-    df_expected = pd.concat([df2, df1])
+    df_expected = pd.concat([df1, df2])
 
     db1.update(db2)
-    print(f'{db1["sessions"].df=}')
-    print(f'{db2["sessions"].df=}')
-    print(f"{df_expected=}")
     pd.testing.assert_frame_equal(db1["sessions"].df, df_expected)
+    pd.testing.assert_frame_equal(db2["sessions"].df, df2)


### PR DESCRIPTION
Closes #466 

Fixes `audformat.Database.update()` for the case of misc tables. The error was not covered by our previous test. I'm still not completely sure why, but to save time I added a new test for the particular problem.

The error was due to us looking only at `self.tables` for existing tables in the database that should be updated. I changed it to `list(self)` to include misc tables as well.

## Summary by Sourcery

Fix misc table handling in Database.update by including them in the update loop and add a corresponding test.

Bug Fixes:
- Support merging miscellaneous tables with new columns in Database.update.

Tests:
- Add test_update_misc_table to verify merging of misc tables when new columns are introduced.