### PR TITLE
CI: switch to use ubuntu-latest in all tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-latest, macOS-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
         python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
       with:
         path: emodb-src
         key: emodb-ubuntu
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -49,7 +49,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
 
     - name: Install dependencies
       run: |
@@ -80,4 +80,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'


### PR DESCRIPTION
Rerplace deprecated `ubuntu-20.04` by `ubuntu-latest` in the tests.

## Summary by Sourcery

CI:
- Replace all references to `ubuntu-20.04` with `ubuntu-latest` in the GitHub Actions test workflow, including matrix definitions and conditional steps