### PR TITLE
Release 1.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,8 +21,8 @@ Version 1.3.2 (2025-05-27)
 * Fixed: if ``audformat.Column.set()`` assigns values
   to a column with scheme labels
   given by a misc table,
-  the misc table is only converted ones to a dictionary
-  instead of ones for each value
+  the misc table is only converted once to a dictionary
+  instead of once for each value
 
 
 Version 1.3.1 (2024-09-16)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,22 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.3.2 (2025-05-27)
+--------------------------
+
+* Added: support for Python 3.13
+* Added: support for Python 3.12
+* Fixed: ``audformat.Database.update()`` for misc tables
+* Fixed: ``audformat.Database.get()``
+  if ``scheme`` is stored in a segmented table,
+  and ``additional_schemes`` are stored in filewise tables
+* Fixed: if ``audformat.Column.set()`` assigns values
+  to a column with scheme labels
+  given by a misc table,
+  the misc table is only converted ones to a dictionary
+  instead of ones for each value
+
+
 Version 1.3.1 (2024-09-16)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,9 @@ Version 1.3.2 (2025-05-27)
 * Fixed: ``audformat.Database.update()`` for misc tables
 * Fixed: ``audformat.Database.get()``
   if ``scheme`` is stored in a segmented table,
-  and ``additional_schemes`` are stored in filewise tables
+  and ``additional_schemes`` are stored in filewise tables.
+  Before,
+  values of the additional schemes were set to ``<NA>``
 * Fixed: if ``audformat.Column.set()`` assigns values
   to a column with scheme labels
   given by a misc table,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/30dcf6b9-b171-497e-a5a1-aefb3ab7a407)

## Summary by Sourcery

Documentation:
- Update CHANGELOG.rst with entries for version 1.3.2 release