### PR TITLE
TST: use Python 3.12 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.10'
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.13'
           - os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Use Python 3.12 as default in tests.

## Summary by Sourcery

Update default Python version to 3.12 across CI workflows and pre-commit configuration

CI:
- Set Python 3.12 as the default for GitHub Actions jobs in test, doc, linter, and publish workflows

Tests:
- Update test matrix to use Python 3.12 by default and shift earlier versions accordingly

Chores:
- Bump pre-commit default_language_version to python3.12