### PR TITLE
DOC: depend on sphinx-audeering-theme>=1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
     'pytest-cov',
     'sphinx',
     'sphinx-apipages >=0.1.2',
-    'sphinx-audeering-theme >=1.2.1',
+    'sphinx-audeering-theme >=1.4.1',
     'sphinx-autodoc-typehints',
     'sphinx-copybutton',
     'sphinxcontrib-katex',


### PR DESCRIPTION
Update the doc dependencies to the newest version of `sphinx-audeering-theme`