### PR TITLE
Ensure pickled table pandas compatibility

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -500,7 +500,7 @@ class Base(HeaderBase):
         if pickled:
             try:
                 self._load_pickled(pkl_file)
-            except (AttributeError, ValueError, EOFError) as ex:
+            except Exception as ex:
                 # If exception is raised
                 # (e.g. unsupported pickle protocol)
                 # try to load from PARQUET or CSV


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/483

Ensure we except all possible errors when loading a table from pickle as storing/loading with different `pandas` versions might result in a variety of different errors.

## Summary by Sourcery

Bug Fixes:
- Handle all exceptions raised during pickled table loading so that fallback loading from PARQUET or CSV works reliably with differing pandas versions.