### PR TITLE
TST: depend on pandas<3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     'audb',
     'audiofile >=1.1.0',
     'graphviz',
-    'pandas >=2.0.0',
+    'pandas >=2.0.0, <3.0',  # https://github.com/audeering/audformat/issues/487
     'pyarrow',
     'pytest',
     'pytest-console-scripts',


### PR DESCRIPTION
In order to work on https://github.com/audeering/audformat/issues/487 in several pull requests, we limit `pandas` to <3.0.0 for development.

Locally, we can then run individual tests for `pandas==3.0.0` by using e.g.

```bash
$ uv run --with "pandas==3.0.0" python -m pytest --no-cov tests/test_index.py::test_segmented_index_timedelta_dtype
```