### PR TITLE
Avoid warning in testing.add_table()

### DIFF
--- a/audformat/core/testing.py
+++ b/audformat/core/testing.py
@@ -143,7 +143,7 @@ def add_table(
 
         for file in files:
             times = [
-                pd.to_timedelta(random.random() * file_duration, unit="s")
+                random.random() * file_duration
                 for _ in range(num_segments_per_file * 2)
             ]
             times.sort()


### PR DESCRIPTION
This avoids a user warning by skipping unneeded conversion to timedelta values.

## Summary by Sourcery

Enhancements:
- Simplify generation of random segment times in test table creation by using raw float seconds instead of converting to pandas timedelta objects.