### PR TITLE
TST: fix remaining tests

### DIFF
--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -105,12 +105,12 @@ def create_misc_table(
                 create_misc_table(
                     pd.Series(
                         [1.0],
-                        index=pd.Index(["a"], name="idx"),
+                        index=pd.Index(["a"], name="idx", dtype="object"),
                     ),
                 ),
                 create_misc_table(
                     pd.Series(
-                        index=pd.Index([], name="idx"),
+                        index=pd.Index([], name="idx", dtype="object"),
                         dtype="float",
                     ),
                 ),
@@ -118,7 +118,7 @@ def create_misc_table(
             create_misc_table(
                 pd.Series(
                     [1.0],
-                    index=pd.Index(["a"], name="idx"),
+                    index=pd.Index(["a"], name="idx", dtype="object"),
                 ),
             ),
         ),
@@ -127,21 +127,21 @@ def create_misc_table(
             [
                 create_misc_table(
                     pd.Series(
-                        index=pd.Index([], name="idx"),
+                        index=pd.Index([], name="idx", dtype="string"),
                         dtype="float",
                     )
                 ),
                 create_misc_table(
                     pd.Series(
                         [1.0],
-                        index=pd.Index(["a"], name="idx"),
+                        index=pd.Index(["a"], name="idx", dtype="string"),
                     ),
                 ),
             ],
             create_misc_table(
                 pd.Series(
                     [1.0],
-                    index=pd.Index(["a"], name="idx"),
+                    index=pd.Index(["a"], name="idx", dtype="string"),
                 ),
             ),
         ),
@@ -512,14 +512,14 @@ def test_dtype_column(
         (
             pd.Index,
             ["0"],
-            None,
+            "object",
             "object",
             audformat.define.DataType.OBJECT,
         ),
         (
             pd.Index,
             [],
-            None,
+            "object",
             "object",
             audformat.define.DataType.OBJECT,
         ),
@@ -571,13 +571,6 @@ def test_dtype_column(
             "Int64",
             "Int64",
             audformat.define.DataType.INTEGER,
-        ),
-        (
-            pd.Index,
-            [],
-            str,
-            "object",
-            audformat.define.DataType.OBJECT,
         ),
         (
             pd.Index,
@@ -638,7 +631,7 @@ def test_dtype_column(
         (
             pd.Index,
             ["0"],
-            None,
+            "object",
             "object",
             audformat.define.DataType.OBJECT,
         ),
@@ -782,12 +775,6 @@ def test_dtype_index(
         ),
         (
             [],
-            str,
-            "object",
-            audformat.define.DataType.OBJECT,
-        ),
-        (
-            [],
             "string",
             "string",
             audformat.define.DataType.STRING,
@@ -836,7 +823,7 @@ def test_dtype_index(
         ),
         (
             ["0"],
-            None,
+            "object",
             "object",
             audformat.define.DataType.OBJECT,
         ),
@@ -966,12 +953,6 @@ def test_dtype_multiindex(
         ),
         (
             [],
-            str,
-            "object",
-            audformat.define.DataType.OBJECT,
-        ),
-        (
-            [],
             "string",
             "string",
             audformat.define.DataType.STRING,
@@ -1020,7 +1001,7 @@ def test_dtype_multiindex(
         ),
         (
             ["0"],
-            None,
+            "object",
             "object",
             audformat.define.DataType.OBJECT,
         ),
@@ -1157,20 +1138,20 @@ def test_drop_extend_and_pick_index_order():
         # table empty
         (
             create_misc_table(pd.Index([], name="idx")),
-            pd.Index(["a", "b"], name="idx"),
+            pd.Index(["a", "b"], name="idx", dtype="object"),
             pd.Index([], name="idx"),
         ),
         # index empty
         (
-            create_misc_table(pd.Index(["a", "b"], name="idx")),
-            pd.Index([], name="idx"),
-            pd.Index(["a", "b"], name="idx"),
+            create_misc_table(pd.Index(["a", "b"], name="idx", dtype="string")),
+            pd.Index([], name="idx", dtype="string"),
+            pd.Index(["a", "b"], name="idx", dtype="string"),
         ),
         # index and table identical
         (
-            create_misc_table(pd.Index(["a", "b"], name="idx")),
-            pd.Index(["b", "a"], name="idx"),
-            pd.Index([], name="idx"),
+            create_misc_table(pd.Index(["a", "b"], name="idx", dtype="string")),
+            pd.Index(["b", "a"], name="idx", dtype="string"),
+            pd.Index([], name="idx", dtype="string"),
         ),
         # index within table
         (
@@ -1180,9 +1161,9 @@ def test_drop_extend_and_pick_index_order():
         ),
         # table within index
         (
-            create_misc_table(pd.Index(["b"], name="idx")),
-            pd.Index(["a", "b"], name="idx"),
-            pd.Index([], name="idx"),
+            create_misc_table(pd.Index(["b"], name="idx", dtype="string")),
+            pd.Index(["a", "b"], name="idx", dtype="string"),
+            pd.Index([], name="idx", dtype="string"),
         ),
         # index and table overlap
         (
@@ -1221,22 +1202,22 @@ def test_extend_index():
     # empty and invalid
 
     db["misc"] = audformat.MiscTable(pd.Index([], name="idx"))
-    db["misc"].extend_index(pd.Index([], name="idx"))
+    db["misc"].extend_index(pd.Index([], name="idx", dtype="object"))
     assert db["misc"].get().empty
     with pytest.raises(
         ValueError,
         match="Cannot extend",
     ):
-        db["misc"].extend_index(pd.Index([], name="other"))
+        db["misc"].extend_index(pd.Index([], name="other", dtype="object"))
 
     db.drop_tables("misc")
 
     # extend with pd.Index
 
-    db["misc"] = audformat.MiscTable(pd.Index([], name="idx"))
+    db["misc"] = audformat.MiscTable(pd.Index([], name="idx", dtype="object"))
     db["misc"]["columns"] = audformat.Column(scheme_id="scheme")
     db["misc"].extend_index(
-        pd.Index(["1", "2"], name="idx"),
+        pd.Index(["1", "2"], name="idx", dtype="object"),
         fill_values="a",
         inplace=True,
     )
@@ -1244,7 +1225,7 @@ def test_extend_index():
         db["misc"]["columns"].get().values,
         np.array(["a", "a"]),
     )
-    index = pd.Index(["1", "3"], name="idx")
+    index = pd.Index(["1", "3"], name="idx", dtype="object")
     db["misc"].extend_index(
         index,
         fill_values="b",
@@ -1258,6 +1239,7 @@ def test_extend_index():
     # extend with pd.MultiIndex
 
     index = pd.MultiIndex.from_arrays([["1", "4"]], names=["idx"])
+    index = audformat.utils.set_index_dtypes(index, "object")
     db["misc"].extend_index(
         index,
         fill_values="b",
@@ -1391,15 +1373,15 @@ def test_load_old_pickle(tmpdir):
         ),
         # table empty
         (
-            create_misc_table(pd.Index([], name="idx")),
-            pd.Index(["a", "b"], name="idx"),
-            pd.Index([], name="idx"),
+            create_misc_table(pd.Index([], name="idx", dtype="object")),
+            pd.Index(["a", "b"], name="idx", dtype="object"),
+            pd.Index([], name="idx", dtype="object"),
         ),
         # index empty
         (
-            create_misc_table(pd.Index(["a", "b"], name="idx")),
-            pd.Index([], name="idx"),
-            pd.Index([], name="idx"),
+            create_misc_table(pd.Index(["a", "b"], name="idx", dtype="object")),
+            pd.Index([], name="idx", dtype="object"),
+            pd.Index([], name="idx", dtype="object"),
         ),
         # index and table identical
         (


### PR DESCRIPTION
Fixes errors in `tests/test_misc_table.py` related to the switch from `object` to `string` as default new dtype for empty indices in pandas 3.0.

## Summary by Sourcery

Adjust miscellaneous table tests for pandas 3.0 index dtype behavior changes.

Tests:
- Update misc table tests to explicitly set index dtypes (object/string) for Series, Index, and MultiIndex fixtures.
- Adapt dtype-related parametrized tests to expect explicit index dtypes instead of relying on default/None values and remove obsolete str-based cases.
- Ensure index extension and pickle-loading tests use consistent object/string index dtypes, including via audformat.utils.set_index_dtypes for MultiIndex.