### PR TITLE
Remove deprecated copy from astype()

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -981,7 +981,7 @@ class Base(HeaderBase):
                 and (self.db.schemes[column.scheme_id].dtype == define.DataType.STRING)
                 and df[column_id].dtype == "object"
             ):
-                df[column_id] = df[column_id].astype("string", copy=False)
+                df[column_id] = df[column_id].astype("string")
         # Fix index entries as well
         df.index = _maybe_convert_dtype_to_string(df.index)
 


### PR DESCRIPTION
pandas 3.0.0 is showing a deprecation warning when using `.astype(..., copy=False)` as `copy` will be removed. With `copy=False` it will not change the type if it matches already the requested one. But we have anyway an `if`-statement before that runs the code only if the types do not match, so it should be safe to remove it.

## Summary by Sourcery

Enhancements:
- Simplify dtype conversion for string columns during pickle loading by relying on `astype("string")` without the deprecated `copy` parameter.