### PR TITLE
TST: additional dtype tests for schemes

### DIFF
--- a/tests/test_scheme.py
+++ b/tests/test_scheme.py
@@ -291,12 +291,12 @@ def test_scheme_contains():
         (
             audformat.define.DataType.FLOAT,
             [1.0, 2.0, 3.0],
-            "float64",
+            "float",
         ),
         (
             audformat.define.DataType.STRING,
             ["a", "b", "c"],
-            "string",
+            pd.StringDtype(na_value=pd.NA),
         ),
         (
             audformat.define.DataType.TIME,
@@ -315,7 +315,7 @@ def test_scheme_dtypes(dtype, values, expected_dtype):
 
     column = db["table"]["labels"].get()
     assert set(column) == set(values)
-    assert str(column.dtype) == expected_dtype
+    assert column.dtype == expected_dtype
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Extends the tests for schemes with labels by specifying the expected categorical dtype, and adds another test for corect dtype when using schemes without labels.

## Summary by Sourcery

Extend scheme dtype tests to verify both raw and labeled scheme columns use the correct pandas dtypes.

Tests:
- Add parameterized tests that check the exact pandas dtype used for scheme columns without labels across all supported audformat data types.
- Enhance existing labeled scheme tests to validate the expected categorical dtype for each audformat data type, including version-specific handling of string dtypes.