### PR TITLE
Simplify converting arrow to pandas

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1148,13 +1148,7 @@ class Base(HeaderBase):
             dataframe
 
         """
-        df = table.to_pandas(
-            deduplicate_objects=False,
-            types_mapper={
-                pa.string(): pd.StringDtype(),
-            }.get,  # we have to provide a callable, not a dict
-        )
-        # Adjust dtypes and set index
+        df = table.to_pandas(deduplicate_objects=False)
         df = self._pyarrow_convert_dtypes(df, convert_all=from_csv)
         index_columns = list(self._levels_and_dtypes.keys())
         df = self._set_index(df, index_columns)


### PR DESCRIPTION
Similar to https://github.com/audeering/audb/pull/542 this removes the `types_mapper` argument for `table.to_pandas()` as the conversion is handled in `_pyarrow_convert_dtypes()`.

TODO:
* Benchmark if there is a different in speed

## Summary by Sourcery

Enhancements:
- Remove custom types_mapper usage in PyArrow-to-pandas conversion and rely on _pyarrow_convert_dtypes for dtype handling.