### PR TITLE
Avoid scheme mismatch warning in Table.load()

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1124,9 +1124,7 @@ class Base(HeaderBase):
             dtype = to_categorical_dtype(labels)
             # Set values not in scheme labels to NaN
             # https://github.com/audeering/audformat/issues/525
-            mask = df[column].notna() & ~df[column].isin(labels)
-            if mask.any():
-                df[column] = df[column].where(~mask)
+            df[column] = df[column].where(df[column].isin(labels))
             df[column] = df[column].astype(dtype)
         return df
 

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -461,7 +461,7 @@ class Base(HeaderBase):
         otherwise it will raise an error
         and ask to delete one of the files.
 
-        If a table column is assigned to a scheme containing labels,
+        If a scheme with labels is assigned to a table column,
         values not matching those labels are set to ``None``.
 
         Args:

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -461,6 +461,9 @@ class Base(HeaderBase):
         otherwise it will raise an error
         and ask to delete one of the files.
 
+        If a table column is assigned to a scheme containing labels,
+        values not matching those labels are set to ``None``.
+
         Args:
             path: file path without extension
 
@@ -1053,7 +1056,10 @@ class Base(HeaderBase):
                 ``"bool"``, and ``"int"`` audformat dtypes
 
         Returns:
-            dataframe with converted dtypes
+            dataframe with converted dtypes.
+                For columns with scheme labels,
+                values not in the scheme's labels
+                are set to NaN
 
         """
         # Collect columns with dtypes,
@@ -1116,6 +1122,11 @@ class Base(HeaderBase):
             scheme = self.db.schemes[self.columns[column].scheme_id]
             labels = scheme._labels_to_list()
             dtype = to_categorical_dtype(labels)
+            # Set values not in scheme labels to NaN
+            # https://github.com/audeering/audformat/issues/525
+            mask = df[column].notna() & ~df[column].isin(labels)
+            if mask.any():
+                df[column] = df[column].where(~mask)
             df[column] = df[column].astype(dtype)
         return df
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1831,7 +1831,8 @@ def test_save_and_load_labels_removed(tmpdir, storage_format):
     When a table is saved with labels ``["a", "b", "c"]``
     but the scheme is later changed to ``["a", "b"]``,
     loading should not raise a warning
-    about values not in the categorical dtype's categories.
+    about values not in the categorical dtype's categories,
+    but values should be replaced with ``None``.
 
     """
     db = audformat.Database("test")
@@ -1850,6 +1851,14 @@ def test_save_and_load_labels_removed(tmpdir, storage_format):
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         db["table"].load(path)
+
+    # "c" was removed from labels and should now be NaN
+    categories = pd.Index(["a", "b"], dtype="object")
+    expected = pd.DataFrame(
+        {"col": pd.Categorical(["a", "b", None], categories=categories)},
+        index=audformat.filewise_index(["f1", "f2", "f3"]),
+    )
+    pd.testing.assert_frame_equal(db["table"].df, expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2,6 +2,7 @@ import os
 import random
 import re
 import time
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -1821,6 +1822,34 @@ def test_save_and_load(tmpdir, storage_format):
         assert os.path.exists(path)
         db[table_id].load(path_wo_ext)
         pd.testing.assert_frame_equal(db[table_id].df, expected_df)
+
+
+@pytest.mark.parametrize("storage_format", ["csv", "parquet"])
+def test_save_and_load_labels_removed(tmpdir, storage_format):
+    r"""Test loading table after labels were removed from scheme.
+
+    When a table is saved with labels ``["a", "b", "c"]``
+    but the scheme is later changed to ``["a", "b"]``,
+    loading should not raise a warning
+    about values not in the categorical dtype's categories.
+
+    """
+    db = audformat.Database("test")
+    db.schemes["label"] = audformat.Scheme(labels=["a", "b", "c"])
+    index = audformat.filewise_index(["f1", "f2", "f3"])
+    db["table"] = audformat.Table(index)
+    db["table"]["col"] = audformat.Column(scheme_id="label")
+    db["table"]["col"].set(["a", "b", "c"])
+
+    path = os.path.join(tmpdir, "table")
+    db["table"].save(path, storage_format=storage_format)
+
+    # Remove label "c" from scheme
+    db.schemes["label"] = audformat.Scheme(labels=["a", "b"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        db["table"].load(path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #525 

This updates `audformat.Table.load()` (via `_pyarrow_convert_dtypes()`) when loading a table from a csv or parquet file to explicitly set column values to `None` if they are not part of the scheme labels, if the column has a scheme with labels. Before this was silently done by `pandas` when applying `.astype()`, but with `pandas` 3.0 this started to raise a warning that this will result in an error in future `pandas` versions and the user should handle this.

As we check now for non-matching labels, this adds a little bit of overhead. So I benchmarked the added execution time for a row with 10% non-matching labels:

  | Rows | Current /s | Proposed / s | Overhead |                         
  |---:|---:|---:|---:|                                                                                                                                                       
  | 1,000 | 0.0017 | 0.0022 | +0.5ms |                                
  | 10,000 | 0.0027 | 0.0039 | +1.2ms |                                                                                                                                       
  | 100,000 | 0.0117 | 0.0178 | +6.1ms |      
  | 1,000,000 | 0.1010 | 0.1550 | +54ms |

So we can ignore this. The difference is most likely not too large as `pandas` also was dealing with it internally before.

<details><summary>Benchmark code</summary>

```python
"""Benchmark: cost of filtering data not matching scheme labels on load.

Compares table.load() performance between main branch (no filtering)
and handle-data-with-additional-labels branch (line 1127 in table.py:
  df[column] = df[column].where(df[column].isin(labels))
).

Run on both branches and compare the output.
"""

import tempfile
import time

import numpy as np
import pandas as pd

import audformat


ROWS = [1_000, 10_000, 100_000, 1_000_000]
NUM_LABELS = 50  # number of labels in the scheme
REPETITIONS = 5


def create_db(n_rows, n_labels, tmpdir, fraction_extra=0.0):
    """Create a database with a labeled column and save it.

    For fraction_extra > 0, we manipulate the parquet file directly
    since the API won't allow setting values outside the scheme.

    Args:
        n_rows: number of rows
        n_labels: number of labels in scheme
        tmpdir: directory to save the database
        fraction_extra: fraction of values that are NOT in the scheme labels
                        (simulates the "extra labels" scenario)

    """
    import pyarrow as pa
    import pyarrow.parquet as pq

    labels = [f"label_{i}" for i in range(n_labels)]
    extra_labels = [f"extra_{i}" for i in range(10)]

    db = audformat.Database("benchmark")
    db.schemes["emotion"] = audformat.Scheme(labels=labels)
    db.splits["train"] = audformat.Split(type=audformat.define.SplitType.TRAIN)

    files = [f"file_{i}.wav" for i in range(n_rows)]
    index = audformat.filewise_index(files)
    db["table"] = audformat.Table(index, split_id="train")
    db["table"]["emotion"] = audformat.Column(scheme_id="emotion")

    # Generate valid values and save
    rng = np.random.default_rng(42)
    values = rng.choice(labels, size=n_rows)
    db["table"]["emotion"].set(values, index=index)
    db.save(tmpdir, storage_format="parquet")

    # If extra labels requested, overwrite parquet with mixed values
    if fraction_extra > 0:
        n_extra = int(n_rows * fraction_extra)
        n_valid = n_rows - n_extra
        mixed_values = np.concatenate([
            rng.choice(labels, size=n_valid),
            rng.choice(extra_labels, size=n_extra),
        ])
        rng.shuffle(mixed_values)
        # Write directly to parquet, bypassing validation
        table = pa.table(
            {"file": files, "emotion": mixed_values.tolist()},
        )
        pq.write_table(table, f"{tmpdir}/db.table.parquet")

    return db


def benchmark_load(tmpdir, repetitions=REPETITIONS):
    """Time table.load() calls from an already-saved database."""
    times = []
    for _ in range(repetitions):
        # Reload header from disk each time (no data)
        db2 = audformat.Database.load(tmpdir, load_data=False)
        t0 = time.perf_counter()
        db2["table"].load(f"{tmpdir}/db.table")
        t1 = time.perf_counter()
        times.append(t1 - t0)

    return times


def main():
    print(f"audformat version: {audformat.__version__}")
    print(f"Repetitions per measurement: {REPETITIONS}")
    print(f"Number of scheme labels: {NUM_LABELS}")
    print()

    # Scenario 1: all values match labels (typical case)
    print("=" * 70)
    print("SCENARIO 1: All values match scheme labels (0% extra)")
    print("=" * 70)
    print(f"{'Rows':>12s}  {'Mean (s)':>10s}  {'Std (s)':>10s}  {'Min (s)':>10s}")
    print("-" * 50)
    for n_rows in ROWS:
        with tempfile.TemporaryDirectory() as tmpdir:
            create_db(n_rows, NUM_LABELS, tmpdir, fraction_extra=0.0)
            times = benchmark_load(tmpdir)
        mean = np.mean(times)
        std = np.std(times)
        mn = np.min(times)
        print(f"{n_rows:>12,d}  {mean:>10.4f}  {std:>10.4f}  {mn:>10.4f}")

    print()

    # Scenario 2: 10% of values don't match labels
    print("=" * 70)
    print("SCENARIO 2: 10% of values don't match scheme labels")
    print("=" * 70)
    print(f"{'Rows':>12s}  {'Mean (s)':>10s}  {'Std (s)':>10s}  {'Min (s)':>10s}")
    print("-" * 50)
    for n_rows in ROWS:
        with tempfile.TemporaryDirectory() as tmpdir:
            create_db(n_rows, NUM_LABELS, tmpdir, fraction_extra=0.1)
            times = benchmark_load(tmpdir)
        mean = np.mean(times)
        std = np.std(times)
        mn = np.min(times)
        print(f"{n_rows:>12,d}  {mean:>10.4f}  {std:>10.4f}  {mn:>10.4f}")


if __name__ == "__main__":
    main()
```

</details>


I also updated the docstring of `audformat.Table.load()` to make it more transparent that non-matching values are set to `None`:

<img width="721" height="450" alt="image" src="https://github.com/user-attachments/assets/3b9457bb-4fff-4d1f-94db-b4a48c12ee16" />