### PR TITLE
TST: check total seconds of segmented index

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -310,7 +310,10 @@ def test_create_segmented_index(files, starts, ends):
     ],
 )
 def test_segmented_index_dtype(files, starts, ends):
-    """Check for correct dtypes in segmented_index."""
+    """Check for correct dtypes in segmented_index.
+
+    See https://github.com/audeering/audformat/issues/529
+    """
     index = audformat.segmented_index(files, starts=starts, ends=ends)
     assert index.get_level_values("file").dtype == pd.StringDtype(na_value=pd.NA)
     assert index.get_level_values("start").dtype == "timedelta64[ns]"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -314,6 +315,28 @@ def test_segmented_index_dtype(files, starts, ends):
     assert index.get_level_values("file").dtype == pd.StringDtype(na_value=pd.NA)
     assert index.get_level_values("start").dtype == "timedelta64[ns]"
     assert index.get_level_values("end").dtype == "timedelta64[ns]"
+
+
+@pytest.mark.parametrize(
+    "files, starts, ends",
+    [
+        (["f1.wav"] * 2, [1.0, 2.0], [2.0, 3.0]),
+        (["f1.wav"] * 2, [1.01, 2.0], [1.02, 3.0]),
+        (["f1.wav"] * 2, [1.0, 2.01], [2.0, 3.01]),
+        (["f1.wav"] * 2, [1, 2.01], [2, 3.01]),
+    ],
+)
+def test_segmented_index_seconds(files, starts, ends):
+    """Check that the total seconds of the segmented index are correct."""
+    index = audformat.segmented_index(files, starts=starts, ends=ends)
+    np.testing.assert_almost_equal(
+        index.get_level_values("start").to_series().dt.total_seconds().to_numpy(),
+        np.array(starts),
+    )
+    np.testing.assert_almost_equal(
+        index.get_level_values("end").to_series().dt.total_seconds().to_numpy(),
+        np.array(ends),
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -334,11 +334,11 @@ def test_segmented_index_seconds(files, starts, ends):
     index = audformat.segmented_index(files, starts=starts, ends=ends)
     np.testing.assert_almost_equal(
         index.get_level_values("start").to_series().dt.total_seconds().to_numpy(),
-        np.array(starts),
+        np.array(starts, dtype=float),
     )
     np.testing.assert_almost_equal(
         index.get_level_values("end").to_series().dt.total_seconds().to_numpy(),
-        np.array(ends),
+        np.array(ends, dtype=float),
     )
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -310,10 +310,7 @@ def test_create_segmented_index(files, starts, ends):
     ],
 )
 def test_segmented_index_dtype(files, starts, ends):
-    """Check for correct dtypes in segmented_index.
-
-    See https://github.com/audeering/audformat/issues/529
-    """
+    """Check for correct dtypes in segmented_index."""
     index = audformat.segmented_index(files, starts=starts, ends=ends)
     assert index.get_level_values("file").dtype == pd.StringDtype(na_value=pd.NA)
     assert index.get_level_values("start").dtype == "timedelta64[ns]"
@@ -330,7 +327,10 @@ def test_segmented_index_dtype(files, starts, ends):
     ],
 )
 def test_segmented_index_seconds(files, starts, ends):
-    """Check that the total seconds of the segmented index are correct."""
+    """Check that the total seconds of the segmented index are correct.
+
+    See https://github.com/audeering/audformat/issues/529
+    """
     index = audformat.segmented_index(files, starts=starts, ends=ends)
     np.testing.assert_almost_equal(
         index.get_level_values("start").to_series().dt.total_seconds().to_numpy(),


### PR DESCRIPTION
This adds a test that checks whether the total seconds of the start and end levels of an index created with `audformat.segmented_index()` are as expected. (See https://github.com/audeering/audformat/issues/529)

## Summary by Sourcery

Tests:
- Add parametrized tests ensuring segmented_index start and end levels match expected total seconds for various floating-point inputs.