### PR TITLE
Exclude pandas 3.0.0-3.0.2 from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,10 @@ dependencies = [
     'iso639-lang',
     'iso3166',
     'oyaml',
-    'pandas >=2.1.0',  # for pyarrow -> timedelta conversion
+    # >=2.1.0 for pyarrow -> timedelta conversion
+    # !=3.0.0, !=3.0.1, !=3.0.2 for pandas timedelta issue
+    # (https://github.com/audeering/audformat/issues/529)
+    'pandas >=2.1.0, !=3.0.0, !=3.0.1, !=3.0.2',
     'pyarrow >=10.0.1',  # for pyarrow strings in pandas
     'pyyaml >=5.4.1',
 ]


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/529

Exclude `pandas` 3.0.0, 3.0.1, and 3.0.2 from dependencies due to https://github.com/pandas-dev/pandas/issues/65150.