### PR TITLE
Include table id in error msg if available

### DIFF
--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -319,7 +319,7 @@ class Base(HeaderBase):
         table = self if inplace else self.copy()
 
         index = _maybe_convert_dtype_to_string(index)
-        _assert_table_index(table, index, "drop rows from")
+        _assert_table_index(self, index, "drop rows from")
 
         index = utils.intersect([table.index, index])
         new_index = utils.difference([table.index, index])
@@ -356,7 +356,7 @@ class Base(HeaderBase):
         table = self if inplace else self.copy()
 
         index = _maybe_convert_dtype_to_string(index)
-        _assert_table_index(table, index, "extend")
+        _assert_table_index(self, index, "extend")
 
         new_index = utils.union([table.index, index])
         table._df = table.df.reindex(new_index)
@@ -578,7 +578,7 @@ class Base(HeaderBase):
         table = self if inplace else self.copy()
 
         index = _maybe_convert_dtype_to_string(index)
-        _assert_table_index(table, index, "pick rows from")
+        _assert_table_index(self, index, "pick rows from")
 
         new_index = utils.intersect([table.index, index])
         table._df = table.df.reindex(new_index)
@@ -1931,11 +1931,13 @@ def _assert_table_index(
     operation: str,
 ):
     r"""Raise error if index does not match table."""
+    table_ref = f" '{table._id}'" if table._id is not None else ""
     if isinstance(table, Table):
         input_type = index_type(index)
         if table.type != input_type:
             raise ValueError(
-                f"Cannot {operation} a {table.type} table with a {input_type} index."
+                f"Cannot {operation} a {table.type} "
+                f"table{table_ref} with a {input_type} index."
             )
     elif not utils.is_index_alike([table.index, index]):
         want = (
@@ -1955,7 +1957,7 @@ def _assert_table_index(
         raise ValueError(
             f"Cannot "
             f"{operation} "
-            f"table if input index and table index are not alike.\n"
+            f"table{table_ref} if input index and table index are not alike.\n"
             f"Expected index:\n"
             f"\t{want}"
             f"\nbut yours is:\n"

--- a/audformat/core/table.py
+++ b/audformat/core/table.py
@@ -1931,7 +1931,8 @@ def _assert_table_index(
     operation: str,
 ):
     r"""Raise error if index does not match table."""
-    table_ref = f" '{table._id}'" if table._id is not None else ""
+    table_id = getattr(table, "_id", None)
+    table_ref = f" '{table_id}'" if table_id is not None else ""
     if isinstance(table, Table):
         input_type = index_type(index)
         if table.type != input_type:

--- a/tests/test_misc_table.py
+++ b/tests/test_misc_table.py
@@ -1098,6 +1098,51 @@ def test_drop_and_pick_index():
         pytest.DB[table_id].pick_index(index).get()
 
 
+def test_index_mismatch_error_includes_table_id():
+    # See https://github.com/audeering/audformat/issues/524
+    # When the misc table is assigned to a database,
+    # the error message should reference the table id
+    # so the user can identify which table is affected.
+    db = audformat.testing.create_db(minimal=True)
+    db["misc"] = audformat.MiscTable(pd.Index([0, 1], name="id", dtype="Int64"))
+    bad_index = pd.Index(["a"], name="file", dtype="string")
+
+    # Table assigned to db: id appears in the error message
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot extend table 'misc' "
+        r"if input index and table index are not alike\.",
+    ):
+        db["misc"].extend_index(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot drop rows from table 'misc' "
+        r"if input index and table index are not alike\.",
+    ):
+        db["misc"].drop_index(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot pick rows from table 'misc' "
+        r"if input index and table index are not alike\.",
+    ):
+        db["misc"].pick_index(bad_index)
+    db["other"] = audformat.MiscTable(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot update table 'misc' "
+        r"if input index and table index are not alike\.",
+    ):
+        db["misc"].update(db["other"])
+
+    # Standalone table: no id reference, no spurious quotes
+    standalone = audformat.MiscTable(pd.Index([0, 1], name="id", dtype="Int64"))
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot extend table if input index and table index are not alike\.",
+    ):
+        standalone.extend_index(bad_index)
+
+
 def test_drop_extend_and_pick_index_order():
     # Ensure order of index is preserved.
     index = pd.Index([4, 3, 2, 1], name="idx")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -555,6 +555,49 @@ def test_drop_and_pick_index():
         pytest.DB["files"].pick_index(index).get()
 
 
+def test_index_mismatch_error_includes_table_id():
+    # See https://github.com/audeering/audformat/issues/524
+    # When the table is assigned to a database,
+    # the error message should reference the table id
+    # so the user can identify which table is affected.
+    db = audformat.testing.create_db(minimal=True)
+    db["files"] = audformat.Table(audformat.filewise_index(["f1.wav"]))
+    bad_index = audformat.segmented_index(files=["f1.wav"], starts=["0s"], ends=["1s"])
+
+    # Table assigned to db: id appears in the error message
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot extend a filewise table 'files' with a segmented index\.",
+    ):
+        db["files"].extend_index(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot drop rows from a filewise table 'files' "
+        r"with a segmented index\.",
+    ):
+        db["files"].drop_index(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot pick rows from a filewise table 'files' "
+        r"with a segmented index\.",
+    ):
+        db["files"].pick_index(bad_index)
+    db["segments"] = audformat.Table(bad_index)
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot update a filewise table 'files' with a segmented index\.",
+    ):
+        db["files"].update(db["segments"])
+
+    # Standalone table: no id reference, no spurious quotes
+    standalone = audformat.Table(audformat.filewise_index(["f1.wav"]))
+    with pytest.raises(
+        ValueError,
+        match=r"Cannot extend a filewise table with a segmented index\.",
+    ):
+        standalone.extend_index(bad_index)
+
+
 def test_drop_extend_and_pick_index_order():
     # Ensure order of index is preserved.
     index = audformat.filewise_index(["f4", "f3", "f2", "f1"])


### PR DESCRIPTION
Closes https://github.com/audeering/audformat/issues/524

Includes the table ID of the receiving table for failing table operations (`update`, `pick_index`, `drop_index`, `pick_index`).

For example:

```python
import audformat
import pandas as pd

db = audformat.Database("test")
db["misc"] = audformat.MiscTable(pd.Index([0, 1], name="id", dtype="Int64"))
bad_index = pd.Index(["a"], name="file", dtype="string")
db["misc"].drop_index(bad_index)
```

results in

```
ValueError: Cannot drop rows from table 'misc' if input index and table index are not alike.
Expected index:
        file    string[python]
but yours is:
        id    Int64
```

## Summary by Sourcery

Include table identifiers in index mismatch error messages and adjust index validation to reference the original table instead of its copies.

Bug Fixes:
- Ensure index mismatch errors for update, extend_index, drop_index, and pick_index reference the correct table when the table is attached to a database.

Enhancements:
- Improve index mismatch error messages to mention the table id when available while keeping messages clean for standalone tables.

Tests:
- Add regression tests verifying that index mismatch error messages include the table id for database-attached tables and omit it for standalone tables.