### PR TITLE
CI: cache emodb under Windows and Mac as well

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: emodb-src
-        key: emodb-ubuntu
+        key: emodb-src
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: emodb-src
-        key: emodb-ubuntu
+        key: emodb-src
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: emodb-src
-        key: emodb-ubuntu
-      if: matrix.os == 'ubuntu-latest'
+        key: emodb-${{ matrix.os }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: emodb-src
-        key: emodb-${{ matrix.os }}
+        key: emodb-src
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
In https://github.com/audeering/audformat/pull/465 we also enabled building and testing the documentation under Windows and MacOS, but we only cache the `emodb` source download under Ubuntu. As this is needed for building the documentation, we cache it now also under Windows and MacOS.

## Summary by Sourcery

CI:
- Adjust CI cache key to be OS-specific so emodb is cached on Windows and macOS in addition to Ubuntu.