### PR TITLE
Release 1.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.4.2 (2026-05-12)
+--------------------------
+
+* Changed: exclude ``tests/`` and ``docs/`` folders from the Python package
+* Fixed: ensure it works with ``pandas>=3.0.3``
+
+
 Version 1.4.1 (2026-04-13)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Version 1.4.2 (2026-05-12)
 --------------------------
 
 * Changed: exclude ``tests/`` and ``docs/`` folders from the Python package
-* Fixed: ensure it works with ``pandas>=3.0.3``
+* Fixed: ensure ``pandas>=3.0.3`` works with ``audformat``
 
 
 Version 1.4.1 (2026-04-13)


### PR DESCRIPTION
`pandas` 3.0.3 was released yesterday and included a fix for https://github.com/pandas-dev/pandas/issues/65150, so it should work with `audformat` now (and it is, see the passing tests, e.g. [ubuntu-latest, 3.14](https://github.com/audeering/audformat/actions/runs/25735963602/job/75572948595?pr=538) and the specific test for the failed behavior we added in https://github.com/audeering/audformat/pull/530).

<img width="544" height="116" alt="image" src="https://github.com/user-attachments/assets/ccd327d6-40e8-433b-8398-ad71c76878bc" />
